### PR TITLE
Fix MCP request ID collisions

### DIFF
--- a/backend/src/tools/library/mcp/transports/HTTPTransport.js
+++ b/backend/src/tools/library/mcp/transports/HTTPTransport.js
@@ -15,6 +15,7 @@ class HTTPTransport {
     this.messageHandlers = new Map();
     this.notificationHandlers = [];
     this.connected = false;
+    this.requestCounter = 0;
   }
 
   async connect() {
@@ -180,7 +181,7 @@ class HTTPTransport {
       throw new Error('Transport not connected');
     }
 
-    const requestId = message.id || `req-${Date.now()}`;
+    const requestId = message.id || `req-${Date.now()}-${++this.requestCounter}`;
     message.id = requestId;
 
     const responsePromise = new Promise((resolve, reject) => {

--- a/backend/src/tools/library/mcp/transports/POSTTransport.js
+++ b/backend/src/tools/library/mcp/transports/POSTTransport.js
@@ -11,6 +11,7 @@ class POSTTransport {
     this.headers = options.headers || {};
     this.sessionId = null;
     this.connected = false;
+    this.requestCounter = 0;
   }
 
   async connect() {
@@ -32,7 +33,7 @@ class POSTTransport {
       throw new Error('Transport not connected');
     }
 
-    const requestId = message.id || `req-${Date.now()}`;
+    const requestId = message.id || `req-${Date.now()}-${++this.requestCounter}`;
     message.id = requestId;
 
     const headers = {


### PR DESCRIPTION
Fixes a bug where concurrent MCP requests could share the same request ID when issued within the same millisecond, causing tools/resources to hang or return empty. Adds a per-transport counter suffix to guarantee unique IDs.