### PR TITLE
Fix desktop data path and mount tool schema routes

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -26,6 +26,7 @@ import GoalRoutes from './src/routes/GoalRoutes.js';
 import LayoutRoutes from './src/routes/LayoutRoutes.js';
 import OrchestratorRoutes from './src/routes/OrchestratorRoutes.js';
 import ToolsRoutes from './src/routes/ToolsRoutes.js';
+import ToolSchemaRoutes from './src/routes/ToolSchemaRoutes.js';
 import ModelRoutes from './src/routes/ModelRoutes.js';
 import CustomProviderRoutes from './src/routes/CustomProviderRoutes.js';
 import MCPRoutes from './src/routes/MCPRoutes.js';
@@ -165,6 +166,7 @@ app.use('/api/goals', GoalRoutes);
 app.use('/api/layouts', LayoutRoutes);
 app.use('/api/orchestrator', OrchestratorRoutes);
 app.use('/api/tools', ToolsRoutes);
+app.use('/api/tool-schemas', ToolSchemaRoutes);
 app.use('/api/models', ModelRoutes); // Generic models endpoint for all providers
 app.use('/api/openrouter', ModelRoutes); // Legacy support for OpenRouter
 app.use('/api/custom-providers', CustomProviderRoutes);

--- a/backend/src/models/database/index.js
+++ b/backend/src/models/database/index.js
@@ -5,17 +5,19 @@ import WebhookModel from '../WebhookModel.js';
 
 // Get user data path - prioritize USER_DATA_PATH env var (set by Electron)
 const getUserDataPath = () => {
-  // 1. Docker: Use /app/data if it exists (mounted volume)
-  if (process.env.NODE_ENV === 'production' && fs.existsSync('/app/data')) {
-    console.log('Using Docker volume for database: /app/data');
-    return '/app/data';
-  }
-
-  // 2. Electron: Use USER_DATA_PATH env var (ASAR-compatible)
+  // 1. Electron: Use USER_DATA_PATH env var (ASAR-compatible)
   if (process.env.USER_DATA_PATH) {
     const userPath = path.join(process.env.USER_DATA_PATH, 'Data');
     console.log('Using USER_DATA_PATH for database:', userPath);
     return userPath;
+  }
+
+  // 2. Docker: Use /app/data if it exists (mounted volume)
+  // On Windows, /app/data can resolve to C:\app\data, so only take this branch
+  // when USER_DATA_PATH is absent.
+  if (process.env.NODE_ENV === 'production' && fs.existsSync('/app/data')) {
+    console.log('Using Docker volume for database: /app/data');
+    return '/app/data';
   }
 
   // 3. Development: Use ./data in project root


### PR DESCRIPTION
## Summary

This fixes two desktop/runtime issues found while testing the Windows desktop build on AGNT 0.5.14:

- Prefer Electron `USER_DATA_PATH` before Docker `/app/data` when selecting the SQLite data directory.
- Mount the existing `ToolSchemaRoutes` router at `/api/tool-schemas` so documented tool-schema endpoints work.

## Why

In the packaged Windows desktop build, `/app/data` can resolve to `C:\app\data`. Because the current code checks that path before Electron `USER_DATA_PATH`, a desktop install can accidentally use a stale Docker-style data directory instead of `%APPDATA%\AGNT\Data`. This can make an update appear to wipe chat history by opening the wrong database.

The repo already contains `ToolSchemaRoutes.js` and docs for `/api/tool-schemas/*`, but the server does not mount the route. As a result `/api/tool-schemas/stats` returns 404.

## Changes

- Move the `USER_DATA_PATH` branch before Docker `/app/data`.
- Keep `/app/data` as a Docker/self-hosted fallback when `USER_DATA_PATH` is absent.
- Import and mount `ToolSchemaRoutes` in `backend/server.js`.

## Verification

Ran syntax checks locally:

```bash
node --check backend/server.js
node --check backend/src/models/database/index.js
```

Also verified the equivalent patched desktop build locally:

- `/api/health` returned `OK`
- `/api/version` returned `0.5.14`
- `/api/tool-schemas/stats` returned schema stats instead of 404
- live DB stayed under `%APPDATA%\AGNT\Data\agnt.db`
- `C:\app\data` was not recreated