### PR TITLE
Prefer local API keys for desktop auth

### DIFF
--- a/backend/src/libs/agnt2.js
+++ b/backend/src/libs/agnt2.js
@@ -600,10 +600,19 @@ class AuthModule {
     const response = await this.client.get(`/auth/connected`);
     return response.data;
   }
+  _getUserIdFromToken() {
+    try {
+      const payload = JSON.parse(Buffer.from(this.apiKey.split('.')[1], 'base64url').toString('utf8'));
+      return payload.id || payload.userId || payload.sub || null;
+    } catch {
+      return null;
+    }
+  }
   async getValidToken(providerId) {
-    // Assuming backend's /auth/valid-token uses req.user.id from the bearer token
-    // and providerId from query param.
-    const response = await this.client.get(`/auth/valid-token?providerId=${providerId}`);
+    const params = new URLSearchParams({ providerId });
+    const userId = this._getUserIdFromToken();
+    if (userId) params.set('userId', userId);
+    const response = await this.client.get(`/auth/valid-token?${params.toString()}`);
     return response.data; // Expected: { access_token: "..." }
   }
 }

--- a/backend/src/services/auth/AuthManager.js
+++ b/backend/src/services/auth/AuthManager.js
@@ -30,8 +30,24 @@ class AuthManager {
     this._scheduleTokenRefresh(userId, providerId, tokens);
     return tokens;
   }
-  // LOCAL VERSION THAT USES REMOTE AUTH SERVICE
+  // LOCAL VERSION THAT USES LOCAL API-KEY STORAGE FIRST, THEN REMOTE AUTH SERVICE
   async getValidAccessToken(userId, providerId) {
+    try {
+      // API-key providers stored through /auth/apikeys/:providerId live in the
+      // local api_keys table. Prefer that local value so desktop-only providers
+      // such as Obsidian Local REST API do not have to exist in the remote OAuth
+      // provider registry.
+      const localApiKey = await this._getApiKey(userId, providerId);
+      if (localApiKey) {
+        console.log(`Using local API key for ${providerId}`);
+        return localApiKey;
+      }
+    } catch (localError) {
+      console.error(`Error retrieving local API key for ${providerId}:`, localError.message);
+      // Continue to the remote token proxy so OAuth providers are not blocked by
+      // a local api_keys lookup/decryption issue.
+    }
+
     try {
       const response = await axios.get(`${this.remoteUrl}/auth/valid-token`, {
         params: { userId, providerId },
@@ -610,7 +626,6 @@ async function checkGoogleHealth(token) {
 
 async function checkTwitterHealth(token) {
   try {
-    console.log('Checking Twitter health with token:', token);
     const response = await axios.get('https://api.twitter.com/2/users/me', {
       headers: { Authorization: `Bearer ${token}` },
     });
@@ -624,8 +639,16 @@ async function checkTwitterHealth(token) {
       },
     };
   } catch (error) {
-    console.error('Twitter token validation failed:', error);
-    throw new Error('Twitter token validation failed');
+    const status = error.response?.status;
+    const data = error.response?.data || {};
+    const type = data.type || null;
+    const title = data.title || null;
+    const detail = data.detail || data.errors?.[0]?.message || null;
+    console.error('Twitter token validation failed:', { status, type, title, detail });
+    if (status === 403 && (type?.includes('client-forbidden') || title === 'Client Forbidden')) {
+      throw new Error('Twitter token validation failed: X API client forbidden; the AGNT X app lacks required API access/enrollment.');
+    }
+    throw new Error(`Twitter token validation failed${status ? `: HTTP ${status}` : ''}${title ? ` ${title}` : ''}`);
   }
 }
 

--- a/backend/src/services/orchestrator/tools.js
+++ b/backend/src/services/orchestrator/tools.js
@@ -2577,6 +2577,43 @@ export const TOOLS = {
       const agnt = new AGNT(userApiKey); // Uses user's JWT token instead of hardcoded AGNT_API_KEY
 
       try {
+        const getAuthenticatedUserId = () => {
+          try {
+            const decoded = jwt.decode(userApiKey);
+            return decoded?.id || decoded?.userId || decoded?.user_id || decoded?.sub || null;
+          } catch {
+            return null;
+          }
+        };
+
+        const getProviderCandidates = (providerId) => {
+          const raw = String(providerId || '').trim();
+          const normalized = raw.toLowerCase();
+          const aliases = {
+            obsidian: ['obsidian', 'obsidian-local-rest-api'],
+            'obsidian-local-rest-api': ['obsidian-local-rest-api', 'obsidian'],
+          };
+          return [...new Set([raw, normalized, ...(aliases[normalized] || [])].filter(Boolean))];
+        };
+
+        const getLocalApiKey = async (providerId) => {
+          const userId = getAuthenticatedUserId();
+          if (!userId || !providerId) return null;
+
+          for (const candidate of getProviderCandidates(providerId)) {
+            try {
+              const apiKey = await AuthManager._getApiKey(userId, candidate);
+              if (apiKey) {
+                return { providerId: candidate, apiKey };
+              }
+            } catch (error) {
+              console.error(`Local API key lookup failed for ${candidate}:`, error.message);
+            }
+          }
+
+          return null;
+        };
+
         let result;
         switch (operation) {
           case 'list_providers':
@@ -2622,6 +2659,18 @@ export const TOOLS = {
             if (!provider_id) {
               return JSON.stringify({ success: false, error: "provider_id is required for 'retrieve_api_key'." });
             }
+            {
+              const localApiKey = await getLocalApiKey(provider_id);
+              if (localApiKey) {
+                result = {
+                  success: true,
+                  apiKey: localApiKey.apiKey,
+                  provider_id: localApiKey.providerId,
+                  source: 'local_api_keys',
+                };
+                break;
+              }
+            }
             result = await agnt.auth.retrieveApiKey(provider_id);
             break;
           case 'connect_provider':
@@ -2642,6 +2691,18 @@ export const TOOLS = {
           case 'get_valid_token':
             if (!provider_id) {
               return JSON.stringify({ success: false, error: "provider_id is required for 'get_valid_token'." });
+            }
+            {
+              const localApiKey = await getLocalApiKey(provider_id);
+              if (localApiKey) {
+                result = {
+                  access_token: localApiKey.apiKey,
+                  token_type: 'api_key',
+                  provider_id: localApiKey.providerId,
+                  source: 'local_api_keys',
+                };
+                break;
+              }
             }
             result = await agnt.auth.getValidToken(provider_id); // Returns { access_token: "..." }
             break;


### PR DESCRIPTION
## Summary

This improves desktop/local auth behavior and removes a token leak from Twitter/X health checks.

## Why

Some desktop integrations, especially local API-key integrations such as Obsidian Local REST API, store encrypted credentials in the local `api_keys` table. The current desktop auth flow often goes directly to AGNT hosted auth for `valid-token`/API-key retrieval, so local-only providers can appear disconnected even when the key is stored locally and valid.

The Twitter/X health check also logs the token value before calling `https://api.twitter.com/2/users/me`, which can leak credentials into app logs.

## Changes

- Make `AuthManager.getValidAccessToken` prefer local encrypted `api_keys` before falling back to hosted auth.
- Make the `agnt_auth` tool check local `api_keys` for `retrieve_api_key` and `get_valid_token`.
- Add Obsidian provider alias handling between `obsidian` and `obsidian-local-rest-api`.
- Include decoded user id when the AGNT SDK calls hosted `/auth/valid-token`.
- Stop logging Twitter/X tokens.
- Preserve useful Twitter/X health diagnostics and surface `client-forbidden` as an actionable API access/enrollment error.

## Verification

Ran syntax checks locally:

```bash
node --check backend/src/services/auth/AuthManager.js
node --check backend/src/libs/agnt2.js
node --check backend/src/services/orchestrator/tools.js
```

Also verified the equivalent patched desktop build locally with Obsidian Local REST API: the stored local API key was returned from `local_api_keys` and authenticated successfully against Obsidian's protected `/vault/` endpoint.