### PR TITLE
[codex] Fix Codex context reduction for replay history

### DIFF
--- a/backend/src/services/orchestrator/llmAdapters.codex.test.js
+++ b/backend/src/services/orchestrator/llmAdapters.codex.test.js
@@ -122,6 +122,51 @@ describe('CodexResponsesAdapter', () => {
     expect(result.responseMessage.content).not.toContain('Please check your OAuth connection');
     expect(result.responseMessage.content).not.toContain('reconnect your OAuth account');
   });
+
+  it('compresses oversized Codex replay history before streaming requests', async () => {
+    let capturedParams;
+    const client = {
+      responses: {
+        create: async (params) => {
+          capturedParams = params;
+          return streamFrom([
+            { type: 'response.output_text.delta', delta: 'OK' },
+            { type: 'response.completed', response: { id: 'resp_context', output: [], usage: {} } },
+          ]);
+        },
+      },
+    };
+    const adapter = await createLlmAdapter('openai-codex', client, 'gpt-5.5');
+    const hugeReplay = 'x'.repeat(1_300_000);
+
+    await adapter.callStream(
+      [
+        { role: 'system', content: 'System prompt' },
+        { role: 'user', content: 'Earlier research step' },
+        {
+          role: 'assistant',
+          content: '',
+          _responsesOutputItems: [
+            {
+              id: 'rs_huge',
+              type: 'reasoning',
+              summary: [],
+              encrypted_content: hugeReplay,
+              status: 'completed',
+            },
+          ],
+        },
+        { role: 'user', content: 'Continue with a concise answer' },
+      ],
+      [],
+      () => {},
+    );
+
+    const serializedParams = JSON.stringify(capturedParams);
+    expect(serializedParams).not.toContain(hugeReplay);
+    expect(serializedParams.length).toBeLessThan(100_000);
+    expect(capturedParams.input.some((item) => item.type === 'message' && item.content?.[0]?.text?.includes('Previous conversation'))).toBe(true);
+  });
 });
 
 describe('OpenAIResponsesAdapter', () => {

--- a/backend/src/services/orchestrator/llmAdapters.js
+++ b/backend/src/services/orchestrator/llmAdapters.js
@@ -4054,6 +4054,7 @@ class CodexResponsesAdapter extends OpenAIResponsesAdapter {
   constructor(client, model, options = {}) {
     super(client, model, options);
     // Codex reasoning models — match by prefix so new models work automatically
+    this.provider = options.provider || 'openai-codex';
     this.reasoningModels = new Set();
     // The ChatGPT backend hiccups (transient 5xx with the generic
     // "An error occurred while processing your request" envelope) more often
@@ -4093,6 +4094,39 @@ class CodexResponsesAdapter extends OpenAIResponsesAdapter {
       return true;
     }
     return false;
+  }
+
+  isTokenLimitError(error) {
+    const message = [
+      error?.message,
+      error?.error?.message,
+      error?.response?.data?.error?.message,
+      error?.cause?.message,
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase();
+
+    return (
+      message.includes('context window') ||
+      message.includes('input exceeds') ||
+      message.includes('reduce the length') ||
+      message.includes('context length') ||
+      message.includes('token limit') ||
+      message.includes('too long')
+    );
+  }
+
+  _manageCodexContext(messages, tools, reason) {
+    const contextResult = manageContext(messages, this.model, tools, this.provider);
+    if (contextResult.wasManaged && contextResult.managedTokens < contextResult.originalTokens) {
+      console.log(
+        `[Codex Responses] Context ${reason}: ` +
+        `${contextResult.originalTokens} -> ${contextResult.managedTokens} tokens ` +
+        `(request ${contextResult.totalRequestTokens}/${contextResult.tokenLimit})`,
+      );
+    }
+    return contextResult;
   }
 
   /**
@@ -4213,10 +4247,11 @@ class CodexResponsesAdapter extends OpenAIResponsesAdapter {
    */
   async call(messages, tools) {
     let lastError;
+    let currentMessages = this._manageCodexContext(messages, tools, 'preflight').messages;
 
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
       try {
-        const params = this._buildCodexParams(messages, tools);
+        const params = this._buildCodexParams(currentMessages, tools);
 
         console.log(`[Codex Responses] Calling model '${this.model}' via ChatGPT backend (streaming internally)`);
         console.log(`[Codex Responses] Input items: ${params.input.length}, Tools: ${params.tools?.length || 0}`);
@@ -4249,7 +4284,17 @@ class CodexResponsesAdapter extends OpenAIResponsesAdapter {
       } catch (error) {
         lastError = error;
 
-        if (attempt === this.maxRetries || !this.isRetryableError(error)) {
+        if (this.isTokenLimitError(error)) {
+          console.warn(`[Codex Responses] Token/context limit error detected, reducing context (attempt ${attempt + 1})`);
+          const contextResult = this._manageCodexContext(currentMessages, tools, 'retry');
+          if (contextResult.wasManaged && contextResult.managedTokens < contextResult.originalTokens) {
+            currentMessages = contextResult.messages;
+            attempt--;
+            continue;
+          }
+        }
+
+        if (attempt === this.maxRetries || !this.isRetryableError(error) || this.isTokenLimitError(error)) {
           console.error(
             `Codex Responses call failed after ${attempt + 1} attempts, but NEVER STOPPING:`,
             describeCodexError(error),
@@ -4295,10 +4340,11 @@ class CodexResponsesAdapter extends OpenAIResponsesAdapter {
    */
   async callStream(messages, tools, onChunk, context = {}) {
     let lastError;
+    let currentMessages = this._manageCodexContext(messages, tools, 'stream preflight').messages;
 
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
       try {
-        const params = this._buildCodexParams(messages, tools);
+        const params = this._buildCodexParams(currentMessages, tools);
 
         console.log(`[Codex Responses] Streaming call to model '${this.model}' via ChatGPT backend`);
 
@@ -4330,7 +4376,17 @@ class CodexResponsesAdapter extends OpenAIResponsesAdapter {
       } catch (error) {
         lastError = error;
 
-        if (attempt === this.maxRetries || !this.isRetryableError(error)) {
+        if (this.isTokenLimitError(error)) {
+          console.warn(`[Codex Responses] Token/context limit error detected during stream, reducing context (attempt ${attempt + 1})`);
+          const contextResult = this._manageCodexContext(currentMessages, tools, 'stream retry');
+          if (contextResult.wasManaged && contextResult.managedTokens < contextResult.originalTokens) {
+            currentMessages = contextResult.messages;
+            attempt--;
+            continue;
+          }
+        }
+
+        if (attempt === this.maxRetries || !this.isRetryableError(error) || this.isTokenLimitError(error)) {
           console.error(
             `Codex Responses streaming call failed after ${attempt + 1} attempts, but NEVER STOPPING:`,
             describeCodexError(error),

--- a/backend/src/utils/contextManager.js
+++ b/backend/src/utils/contextManager.js
@@ -200,6 +200,7 @@ function estimateMessagesTokens(messages) {
     // to context management even though providers count them in the request.
     messageTokens += estimateSerializedTokens(message.tool_calls);
     messageTokens += estimateSerializedTokens(message.function_call);
+    messageTokens += estimateSerializedTokens(message._responsesOutputItems);
     messageTokens += estimateTokens(message.reasoning_content || '');
 
     // Add overhead for role, name, tool_call_id, and provider framing.

--- a/backend/src/utils/contextManager.test.js
+++ b/backend/src/utils/contextManager.test.js
@@ -29,6 +29,27 @@ describe('contextManager', () => {
     expect(estimateMessagesTokens(large)).toBeGreaterThan(estimateMessagesTokens(small) + 20_000);
   });
 
+  it('counts Codex Responses replay payloads when estimating message tokens', () => {
+    const small = [{ role: 'assistant', content: '', _responsesOutputItems: [] }];
+    const large = [
+      {
+        role: 'assistant',
+        content: '',
+        _responsesOutputItems: [
+          {
+            id: 'rs_large',
+            type: 'reasoning',
+            summary: [],
+            encrypted_content: 'x'.repeat(100_000),
+            status: 'completed',
+          },
+        ],
+      },
+    ];
+
+    expect(estimateMessagesTokens(large)).toBeGreaterThan(estimateMessagesTokens(small) + 20_000);
+  });
+
   it('compresses oversized histories and keeps the summary in conversation messages', () => {
     const hugePayload = 'x'.repeat(700_000);
     const messages = [


### PR DESCRIPTION
## Summary

This PR fixes a Codex Responses context-management gap that can surface as `Your input exceeds the context window of this model` during long research/tool-heavy conversations.

## Root Cause

`CodexResponsesAdapter` was building requests from the full message history without running the existing `manageContext` reducer. Codex Responses also replays `_responsesOutputItems` for encrypted reasoning/tool state, but those replay payloads were not included in the token estimate, so AGNT could undercount large histories before sending them upstream.

## Changes

- Count `_responsesOutputItems` in `estimateMessagesTokens` so Codex replay state contributes to context budgeting.
- Run Codex Responses calls through preflight context management before building request params.
- Detect Codex context-window/token-limit errors and retry once with reduced context when reduction is possible.
- Add regression coverage for oversized Codex replay history and replay-payload token estimation.

## Validation

- `npm exec vitest run backend/src/services/orchestrator/llmAdapters.codex.test.js backend/src/utils/contextManager.test.js`
- `git diff --check`