### PR TITLE
[codex] Improve terminal screen loading performance

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,9 +1,9 @@
 import { createRouter, createWebHistory } from 'vue-router';
 // import Marketplace from '@/views/Marketplace/Marketplace.vue';
 // import ExecutionDetails from '@/views/ExecutionDetails/ExecutionDetails.vue';
-import Terminal from '@/views/Terminal/Terminal.vue';
+const Terminal = () => import('@/views/Terminal/Terminal.vue');
 const DocsView = () => import('@/views/Docs/Docs.vue');
-import OAuthCallback from '@/views/_components/utility/OAuthCallback.vue';
+const OAuthCallback = () => import('@/views/_components/utility/OAuthCallback.vue');
 import store from '@/store/state';
 
 const router = createRouter({

--- a/frontend/src/views/Terminal/Terminal.vue
+++ b/frontend/src/views/Terminal/Terminal.vue
@@ -11,7 +11,7 @@
       @screen-change="changeScreen"
     >
       <!-- KeepAlive caches visited screens so charts/data don't reload on every navigation -->
-      <KeepAlive>
+      <KeepAlive :max="4">
         <component
           v-if="isScreenReady"
           :is="activeScreenComponent"
@@ -37,7 +37,7 @@
 </template>
 
 <script>
-import { ref, computed, onMounted, watch, defineAsyncComponent, shallowReactive, markRaw, nextTick } from 'vue';
+import { ref, computed, onMounted, watch, shallowReactive, markRaw } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useStore } from 'vuex';
 
@@ -49,20 +49,14 @@ import OnboardingModal from '@/components/OnboardingModal.vue';
 // Canvas system (provides navigation sidebar + toolbar)
 import CanvasScreen from '@/canvas/CanvasScreen.vue';
 
-// Chat + Settings loaded eagerly (default screen + auth fallback)
-import ChatScreen from './CenterPanel/screens/Chat/Chat.vue';
-import SettingsScreen from './CenterPanel/screens/Settings/Settings.vue';
-
 // Shallow-reactive screen registry — screens register as they load
 // Must be shallowReactive so Vue doesn't deep-proxy component objects
 // (deep proxying breaks Vue internals like emitsOptions/HMR in dev mode)
-const screenComponents = shallowReactive({
-  ChatScreen: markRaw(ChatScreen),
-  SettingsScreen: markRaw(SettingsScreen),
-});
+const screenComponents = shallowReactive({});
 
-// Screens to preload in background after Chat renders
 const screenLoaders = [
+  ['ChatScreen', () => import('./CenterPanel/screens/Chat/Chat.vue')],
+  ['SettingsScreen', () => import('./CenterPanel/screens/Settings/Settings.vue')],
   ['AgentsScreen', () => import('./CenterPanel/screens/Agents/Agents.vue')],
   ['ToolsScreen', () => import('./CenterPanel/screens/Tools/Tools.vue')],
   ['WorkflowsScreen', () => import('./CenterPanel/screens/Workflows/Workflows.vue')],
@@ -84,13 +78,83 @@ const screenLoaders = [
   ['AutonomyScreen', () => import('./CenterPanel/screens/Autonomy/Autonomy.vue')],
 ];
 
-// Preload all screen chunks in parallel, register into reactive map as each resolves
-const preloadScreens = () => {
-  for (const [name, loader] of screenLoaders) {
-    loader()
-      .then((mod) => { screenComponents[name] = markRaw(mod.default); })
-      .catch((err) => console.warn(`[preload] Failed to load ${name}:`, err));
+const screenLoadersByName = new Map(screenLoaders);
+const screenLoadPromises = new Map();
+const preloadedGroups = new Set();
+const DASHBOARD_PREFETCH_SCREENS = new Set(['DashboardScreen', 'GoalsScreen', 'TracesScreen']);
+
+const screenPreloadGroups = {
+  DashboardScreen: ['GoalsScreen', 'TracesScreen'],
+  GoalsScreen: ['DashboardScreen', 'TracesScreen'],
+  TracesScreen: ['DashboardScreen', 'GoalsScreen'],
+  AgentsScreen: ['AgentForgeScreen'],
+  AgentForgeScreen: ['AgentsScreen'],
+  WorkflowsScreen: ['WorkflowForgeScreen'],
+  WorkflowForgeScreen: ['WorkflowsScreen'],
+  ToolsScreen: ['ToolForgeScreen'],
+  ToolForgeScreen: ['ToolsScreen'],
+  WidgetManagerScreen: ['WidgetForgeScreen'],
+  WidgetForgeScreen: ['WidgetManagerScreen'],
+  SkillsScreen: ['MemoryScreen', 'ExperimentsScreen', 'AutonomyScreen'],
+  MemoryScreen: ['SkillsScreen', 'ExperimentsScreen', 'AutonomyScreen'],
+  ExperimentsScreen: ['SkillsScreen', 'MemoryScreen', 'AutonomyScreen'],
+  AutonomyScreen: ['SkillsScreen', 'MemoryScreen', 'ExperimentsScreen'],
+};
+
+const idle = (cb, timeout = 2000) => (
+  typeof requestIdleCallback === 'function'
+    ? requestIdleCallback(cb, { timeout })
+    : setTimeout(cb, 100)
+);
+
+const loadScreen = (screenName) => {
+  if (screenComponents[screenName]) {
+    return Promise.resolve(screenComponents[screenName]);
   }
+
+  if (screenLoadPromises.has(screenName)) {
+    return screenLoadPromises.get(screenName);
+  }
+
+  const loader = screenLoadersByName.get(screenName);
+  if (!loader) {
+    return Promise.reject(new Error(`Unknown screen: ${screenName}`));
+  }
+
+  const promise = loader()
+    .then((mod) => {
+      screenComponents[screenName] = markRaw(mod.default);
+      return screenComponents[screenName];
+    })
+    .catch((err) => {
+      screenLoadPromises.delete(screenName);
+      console.warn(`[screen] Failed to load ${screenName}:`, err);
+      throw err;
+    });
+
+  screenLoadPromises.set(screenName, promise);
+  return promise;
+};
+
+const preloadLikelyScreens = (screenName) => {
+  const candidates = screenPreloadGroups[screenName] || [];
+  const groupKey = [screenName, ...candidates].join('|');
+  if (!candidates.length || preloadedGroups.has(groupKey)) return;
+  preloadedGroups.add(groupKey);
+
+  let index = 0;
+  const loadNext = () => {
+    const nextScreen = candidates[index++];
+    if (!nextScreen) return;
+
+    loadScreen(nextScreen)
+      .catch(() => {})
+      .finally(() => {
+        if (index < candidates.length) idle(loadNext, 4000);
+      });
+  };
+
+  idle(loadNext);
 };
 
 export default {
@@ -117,9 +181,6 @@ export default {
       return getDefaultScreen();
     };
     const activeScreen = ref(getScreenFromRoute());
-
-    // Placeholder shown while a screen chunk is still loading
-    const ScreenPlaceholder = { template: '<div style="flex:1;width:100%;height:100%;background:var(--color-background)"></div>' };
 
     const isScreenReady = computed(() => !!screenComponents[activeScreen.value]);
 
@@ -153,6 +214,8 @@ export default {
       };
 
       if (screenName in screenRoutes) {
+        ensureScreen(screenName);
+        prefetchScreenData(screenName);
         activeScreen.value = screenName;
         const targetPath = screenRoutes[screenName];
 
@@ -205,42 +268,40 @@ export default {
       store.dispatch('executionHistory/fetchExecutions').catch(() => {});
     };
 
-    onMounted(() => {
-      // Eagerly load the active screen if it's not already available
-      // This ensures reloading on /workflows (etc.) shows content immediately
-      const currentScreen = activeScreen.value;
-      if (!screenComponents[currentScreen]) {
-        const entry = screenLoaders.find(([name]) => name === currentScreen);
-        if (entry) {
-          entry[1]()
-            .then((mod) => { screenComponents[currentScreen] = markRaw(mod.default); })
-            .catch((err) => console.warn(`[eager] Failed to load ${currentScreen}:`, err));
-        }
-      }
+    const ensureScreen = (screenName) => {
+      loadScreen(screenName)
+        .then(() => preloadLikelyScreens(screenName))
+        .catch((err) => console.warn(`[screen] Failed to prepare ${screenName}:`, err));
+    };
 
-      // Preload remaining screens AND prime dashboard data in the same idle
-      // window. Both run in background so the active screen paints first.
-      const startPreload = () => {
-        preloadScreens();
-        prefetchDashboardData();
-      };
-      if (typeof requestIdleCallback === 'function') {
-        requestIdleCallback(startPreload);
-      } else {
-        setTimeout(startPreload, 100);
+    const prefetchScreenData = (screenName) => {
+      if (DASHBOARD_PREFETCH_SCREENS.has(screenName)) {
+        idle(prefetchDashboardData, 3000);
       }
+    };
+
+    onMounted(() => {
+      ensureScreen(activeScreen.value);
+      prefetchScreenData(activeScreen.value);
     });
 
     watch(
       () => route.path,
       () => {
+        let nextScreen = activeScreen.value;
         if (route.meta?.terminalScreen) {
-          activeScreen.value = route.meta.terminalScreen;
+          nextScreen = route.meta.terminalScreen;
         } else if (route.query.id) {
-          activeScreen.value = 'WorkflowForgeScreen';
+          nextScreen = 'WorkflowForgeScreen';
         } else if (route.path === '/') {
-          activeScreen.value = getDefaultScreen();
+          nextScreen = getDefaultScreen();
         }
+
+        if (nextScreen !== activeScreen.value) {
+          activeScreen.value = nextScreen;
+        }
+        ensureScreen(nextScreen);
+        prefetchScreenData(nextScreen);
       },
     );
 

--- a/frontend/src/views/_components/layout/TerminalLayout.vue
+++ b/frontend/src/views/_components/layout/TerminalLayout.vue
@@ -73,7 +73,11 @@ export default {
     const glitchDuration = 1000;
     const terminalScreenRef = ref(null);
     const hasUserInteracted = ref(false); // To track user interaction
-    const currentAudio = ref(null); // Track currently playing audio
+    const activeHtmlAudio = new Set();
+    const activeAudioSources = new Set();
+    const audioBuffers = new Map();
+    const pendingAudioBuffers = new Map();
+    let audioContext = null;
 
     // --- Background Layer ---
     const useCustomBackground = computed(() => store.getters['theme/useCustomBackground']);
@@ -114,15 +118,79 @@ export default {
       // keyPress: '/sounds/key-press.mp3',
       // notification: '/sounds/notification.mp3',
     };
+    const eagerSoundNames = ['buttonClick'];
 
     const setInteracted = () => {
       if (!hasUserInteracted.value) {
         hasUserInteracted.value = true;
         // console.log("User interaction detected. Sounds are now operational.");
       }
+      if (audioContext?.state === 'suspended') {
+        audioContext.resume().catch(() => {});
+      }
     };
 
-    const playSound = (soundName, volume = null) => {
+    const getAudioContext = () => {
+      if (audioContext) return audioContext;
+      const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+      if (!AudioContextCtor) return null;
+
+      audioContext = new AudioContextCtor();
+      return audioContext;
+    };
+
+    const getAudioBuffer = async (soundPath) => {
+      if (audioBuffers.has(soundPath)) return audioBuffers.get(soundPath);
+      if (pendingAudioBuffers.has(soundPath)) return pendingAudioBuffers.get(soundPath);
+
+      const context = getAudioContext();
+      if (!context) return null;
+
+      const pendingBuffer = fetch(soundPath)
+        .then((response) => {
+          if (!response.ok) throw new Error(`Unable to load ${soundPath}: ${response.status}`);
+          return response.arrayBuffer();
+        })
+        .then((arrayBuffer) => context.decodeAudioData(arrayBuffer))
+        .then((buffer) => {
+          audioBuffers.set(soundPath, buffer);
+          pendingAudioBuffers.delete(soundPath);
+          return buffer;
+        })
+        .catch((error) => {
+          pendingAudioBuffers.delete(soundPath);
+          console.warn(`Could not decode sound "${soundPath}":`, error);
+          return null;
+        });
+
+      pendingAudioBuffers.set(soundPath, pendingBuffer);
+      return pendingBuffer;
+    };
+
+    const preloadSoundBuffers = () => {
+      getAudioContext();
+      eagerSoundNames.forEach((soundName) => {
+        const soundPath = sounds[soundName];
+        if (soundPath) getAudioBuffer(soundPath).catch(() => {});
+      });
+    };
+
+    const playHtmlAudioFallback = (soundName, soundPath, volume) => {
+      const audio = new Audio(soundPath);
+      audio.volume = volume;
+      activeHtmlAudio.add(audio);
+
+      const cleanup = () => activeHtmlAudio.delete(audio);
+      audio.addEventListener('ended', cleanup, { once: true });
+      audio.addEventListener('error', cleanup, { once: true });
+
+      audio.play().catch((error) => {
+        console.warn(`Could not play sound "${soundName}" (HTML audio fallback):`, error);
+        cleanup();
+      });
+    };
+
+    const playSound = async (soundName, volume = null) => {
       // Check localStorage for sound settings
       const savedEnabled = localStorage.getItem('soundsEnabled');
       const soundsEnabled = savedEnabled === null ? true : savedEnabled === 'true';
@@ -145,53 +213,50 @@ export default {
         return;
       }
 
+      // Get saved volume or use provided/default
+      const savedVolume = localStorage.getItem('soundVolume');
+      let finalVolume;
+
+      if (volume !== null && typeof volume === 'number' && volume >= 0 && volume <= 1) {
+        // Use provided volume
+        finalVolume = volume;
+      } else if (savedVolume !== null) {
+        // Use saved volume
+        finalVolume = parseFloat(savedVolume);
+      } else {
+        // Use default
+        finalVolume = 0.3;
+      }
+
       try {
-        // Stop any currently playing sound
-        if (currentAudio.value) {
-          currentAudio.value.pause();
-          currentAudio.value.currentTime = 0;
-          currentAudio.value = null;
+        const context = getAudioContext();
+        if (!context) {
+          playHtmlAudioFallback(soundName, soundPath, finalVolume);
+          return;
         }
 
-        const audio = new Audio(soundPath);
-
-        // Get saved volume or use provided/default
-        const savedVolume = localStorage.getItem('soundVolume');
-        let finalVolume;
-
-        if (volume !== null && typeof volume === 'number' && volume >= 0 && volume <= 1) {
-          // Use provided volume
-          finalVolume = volume;
-        } else if (savedVolume !== null) {
-          // Use saved volume
-          finalVolume = parseFloat(savedVolume);
-        } else {
-          // Use default
-          finalVolume = 0.3;
+        if (context.state === 'suspended') {
+          await context.resume();
         }
 
-        audio.volume = finalVolume;
+        const buffer = await getAudioBuffer(soundPath);
+        if (!buffer) {
+          playHtmlAudioFallback(soundName, soundPath, finalVolume);
+          return;
+        }
 
-        // Track this audio as the current one
-        currentAudio.value = audio;
+        const source = context.createBufferSource();
+        const gain = context.createGain();
+        source.buffer = buffer;
+        gain.gain.value = finalVolume;
+        source.connect(gain).connect(context.destination);
 
-        // Clear the reference when the sound finishes
-        audio.addEventListener('ended', () => {
-          if (currentAudio.value === audio) {
-            currentAudio.value = null;
-          }
-        });
-
-        audio.play().catch((error) => {
-          // This catch handles errors other than NotAllowedError post-interaction
-          console.warn(`Could not play sound "${soundName}" (post-interaction attempt):`, error);
-          // Clear the reference on error
-          if (currentAudio.value === audio) {
-            currentAudio.value = null;
-          }
-        });
+        activeAudioSources.add(source);
+        source.onended = () => activeAudioSources.delete(source);
+        source.start();
       } catch (error) {
-        console.error(`Error creating or playing sound "${soundName}":`, error);
+        console.error(`Error playing sound "${soundName}":`, error);
+        playHtmlAudioFallback(soundName, soundPath, finalVolume);
       }
     };
 
@@ -252,6 +317,12 @@ export default {
 
     onMounted(() => {
       checkMobile();
+      const preloadSounds = () => preloadSoundBuffers();
+      if (typeof requestIdleCallback === 'function') {
+        requestIdleCallback(preloadSounds, { timeout: 2500 });
+      } else {
+        setTimeout(preloadSounds, 250);
+      }
       window.addEventListener('resize', checkMobile);
       window.addEventListener('sounds-settings-changed', handleSoundSettingsChange);
 
@@ -279,6 +350,19 @@ export default {
       if (terminalScreenRef.value) {
         terminalScreenRef.value.removeEventListener('click', handleGlobalButtonClick, true);
       }
+      activeAudioSources.forEach((source) => {
+        try {
+          source.stop();
+        } catch (e) {
+          // Source may have already ended.
+        }
+      });
+      activeAudioSources.clear();
+      activeHtmlAudio.forEach((audio) => {
+        audio.pause();
+        audio.currentTime = 0;
+      });
+      activeHtmlAudio.clear();
     });
 
     // Watch for the terminal becoming visible


### PR DESCRIPTION
## Summary
- lazy-load the terminal route and OAuth callback route instead of importing them into the initial router bundle
- lazy-load Chat and Settings screens, then load only the active screen immediately
- replace preload-every-screen behavior with section-scoped idle preloading for likely next screens
- bound terminal screen `KeepAlive` cache to reduce long-session memory retention
- switch UI sound playback to decoded Web Audio buffers with HTML audio fallback

## Scope
This PR intentionally covers performance items 2-5 from the local review: screen preload policy, cache bounds, Chat/Settings laziness, and Web Audio playback. The global `index.html` library cleanup is left out so this PR stays focused.

## Validation
- `git diff --check`
- `npm ci` in `frontend`
- `npm run build` in `frontend`
- preview smoke on `http://127.0.0.1:5301/settings` with Playwright

## Smoke Result
The `/settings` preview loaded without page errors. The probe confirmed Settings no longer loaded the Chat chunk, vendor-3d, vendor-editor, or vendor-charts. Remaining preview console errors were expected because Vite preview does not serve the backend API/socket routes.