### PR TITLE
[codex] Lazy-load global frontend libraries

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,38 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AGNT.gg</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.css" />
-    <script id="Highlight-script" src="/js/libs/highlight.js"></script>
-    <script defer>
-      window.MathJax = {
-        tex: {
-          inlineMath: [['\\(', '\\)']],
-          displayMath: [
-            ['\\[', '\\]'],
-            ['$$', '$$'],
-            // ['$', '$'],
-          ],
-          processEscapes: true,
-          processEnvironments: true,
-          packages: { '[+]': ['mhchem'] },
-        },
-        svg: {
-          fontCache: 'global',
-        },
-        loader: {
-          load: ['[tex]/mhchem'],
-        },
-        startup: {
-          typeset: false,
-          pageReady: () => {
-            return MathJax.startup.defaultPageReady();
-          },
-        },
-      };
-      hljs.configure({
-        ignoreUnescapedHTML: true,
-      });
-    </script>
-    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" defer></script>
     <script defer>
       // Add this script at the end of the head section
       document.addEventListener('DOMContentLoaded', function () {
@@ -50,10 +18,6 @@
   <body class="dark">
     <!-- LIBRARIES -->
     <div id="app"></div>
-    <script id="Showdown-script" src="/js/libs/showdown.js"></script>
-    <script id="HTML2Canvas-script" src="/js/libs/html2canvas.js"></script>
-    <script id="JSPDF-script" src="/js/libs/jspdf.js"></script>
-    <script id="JSPDF-Autotable-script" src="/js/libs/jspdf-autotable.js"></script>
     <script id="Common-script" src="/js/common.js"></script>
     <script id="Main-Vue-script" src="/src/main.js" type="module"></script>
   </body>

--- a/frontend/src/composables/useContentLoader.js
+++ b/frontend/src/composables/useContentLoader.js
@@ -2,6 +2,7 @@ import { onMounted } from 'vue';
 import { useRoute } from 'vue-router';
 import axios from 'axios';
 import { API_CONFIG } from '@/tt.config.js';
+import { highlightCodeBlocks, typesetMath } from '@/utils/lazyGlobalLibraries.js';
 
 /**
  * Composable to load content from query parameters
@@ -36,26 +37,17 @@ export function useContentLoader() {
             contentActions.style.display = 'flex';
           }
 
-          // Highlight code blocks
-          responseArea.querySelectorAll('pre code:not([highlighted])').forEach((el) => {
-            if (typeof hljs !== 'undefined') {
-              hljs.highlightElement(el);
-              el.setAttribute('highlighted', 'true');
-            }
-          });
+          await highlightCodeBlocks(responseArea);
 
           // Set spellcheck to false for code elements
           responseArea.querySelectorAll('code').forEach((el) => {
             el.setAttribute('spellcheck', 'false');
           });
 
-          // Handle MathJax rendering
-          if (typeof MathJax !== 'undefined' && MathJax.typesetPromise) {
-            try {
-              await MathJax.typesetPromise([responseArea]);
-            } catch (error) {
-              console.error('Error in MathJax typesetting:', error);
-            }
+          try {
+            await typesetMath(responseArea);
+          } catch (error) {
+            console.error('Error in MathJax typesetting:', error);
           }
 
           // Add copy buttons to pre elements

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,9 +1,9 @@
 import { createRouter, createWebHistory } from 'vue-router';
 // import Marketplace from '@/views/Marketplace/Marketplace.vue';
 // import ExecutionDetails from '@/views/ExecutionDetails/ExecutionDetails.vue';
-import Terminal from '@/views/Terminal/Terminal.vue';
+const Terminal = () => import('@/views/Terminal/Terminal.vue');
 const DocsView = () => import('@/views/Docs/Docs.vue');
-import OAuthCallback from '@/views/_components/utility/OAuthCallback.vue';
+const OAuthCallback = () => import('@/views/_components/utility/OAuthCallback.vue');
 import store from '@/store/state';
 
 const router = createRouter({

--- a/frontend/src/utils/lazyGlobalLibraries.js
+++ b/frontend/src/utils/lazyGlobalLibraries.js
@@ -1,0 +1,124 @@
+const scriptPromises = new Map();
+
+const loadScript = (id, src, options = {}) => {
+  if (typeof window === 'undefined') return Promise.resolve(null);
+  if (scriptPromises.has(id)) return scriptPromises.get(id);
+
+  const existing = document.getElementById(id);
+  if (existing?.dataset.loaded === 'true') {
+    const promise = Promise.resolve(existing);
+    scriptPromises.set(id, promise);
+    return promise;
+  }
+
+  const promise = new Promise((resolve, reject) => {
+    const script = existing || document.createElement('script');
+    script.id = id;
+    script.src = src;
+    script.async = options.async ?? true;
+    script.defer = options.defer ?? true;
+    script.onload = () => {
+      script.dataset.loaded = 'true';
+      resolve(script);
+    };
+    script.onerror = () => {
+      scriptPromises.delete(id);
+      reject(new Error(`Failed to load script: ${src}`));
+    };
+    if (!existing) document.head.appendChild(script);
+  });
+
+  scriptPromises.set(id, promise);
+  return promise;
+};
+
+export const loadHljs = async () => {
+  if (!window.hljs) {
+    await loadScript('Highlight-script', '/js/libs/highlight.js');
+  }
+  if (window.hljs?.configure) {
+    window.hljs.configure({ ignoreUnescapedHTML: true });
+  }
+  return window.hljs;
+};
+
+export const highlightCodeBlocks = async (root) => {
+  const blocks = root?.querySelectorAll?.('pre code:not([highlighted]), pre code:not(.hljs)');
+  if (!blocks?.length) return;
+
+  const hljs = await loadHljs();
+  if (!hljs) return;
+
+  blocks.forEach((el) => {
+    hljs.highlightElement(el);
+    el.setAttribute('highlighted', 'true');
+  });
+};
+
+const configureMathJax = () => {
+  if (window.MathJax) return;
+  window.MathJax = {
+    tex: {
+      inlineMath: [['\\(', '\\)']],
+      displayMath: [
+        ['\\[', '\\]'],
+        ['$$', '$$'],
+      ],
+      processEscapes: true,
+      processEnvironments: true,
+      packages: { '[+]': ['mhchem'] },
+    },
+    svg: {
+      fontCache: 'global',
+    },
+    loader: {
+      load: ['[tex]/mhchem'],
+    },
+    startup: {
+      typeset: false,
+      pageReady: () => window.MathJax.startup.defaultPageReady(),
+    },
+  };
+};
+
+export const loadMathJax = async () => {
+  if (!window.MathJax?.typesetPromise) {
+    configureMathJax();
+    await loadScript('MathJax-script', 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js');
+    if (window.MathJax?.startup?.promise) {
+      await window.MathJax.startup.promise;
+    }
+  }
+  return window.MathJax;
+};
+
+export const typesetMath = async (elements) => {
+  const targets = Array.isArray(elements) ? elements.filter(Boolean) : [elements].filter(Boolean);
+  if (!targets.length) return;
+
+  const hasMath = targets.some((el) => /\\\(|\\\[|\$\$|<math[\s>]/.test(el.textContent || el.innerHTML || ''));
+  if (!hasMath) return;
+
+  const mathJax = await loadMathJax();
+  if (!mathJax?.typesetPromise) return;
+
+  targets.forEach((el) => {
+    try {
+      mathJax.typesetClear?.([el]);
+    } catch (error) {
+      // It is safe to typeset without clearing if MathJax has no previous state for this node.
+    }
+  });
+  await mathJax.typesetPromise(targets);
+};
+
+export const loadPdfExportLibraries = async () => {
+  await loadScript('HTML2Canvas-script', '/js/libs/html2canvas.js');
+  await loadScript('JSPDF-script', '/js/libs/jspdf.js');
+  await loadScript('JSPDF-Autotable-script', '/js/libs/jspdf-autotable.js');
+
+  return {
+    html2canvas: window.html2canvas,
+    jspdf: window.jspdf,
+  };
+};

--- a/frontend/src/views/Docs/Docs.vue
+++ b/frontend/src/views/Docs/Docs.vue
@@ -30,6 +30,7 @@ let _showdown = null;
 let _hljs = null;
 import { addCopyEventListenerToPreButtons } from '../_components/base/response.js';
 import LoadingOverlay from '@/views/_components/utility/LoadingOverlay.vue';
+import { typesetMath } from '@/utils/lazyGlobalLibraries.js';
 
 // Dynamically import all markdown files from the docs directory
 const markdownFiles = {
@@ -212,13 +213,7 @@ export default {
       });
     };
     const renderMathJax = () => {
-      if (window.MathJax) {
-        window.MathJax.typesetPromise([contentWrapper.value])
-          .then(() => {})
-          .catch((err) => console.error('MathJax error:', err));
-      } else {
-        console.warn('MathJax not loaded');
-      }
+      typesetMath(contentWrapper.value).catch((err) => console.error('MathJax error:', err));
     };
     const addCopyButtons = () => {
       document.querySelectorAll('pre').forEach((pre) => {

--- a/frontend/src/views/Terminal/CenterPanel/screens/Artifacts/Artifacts.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Artifacts/Artifacts.vue
@@ -366,6 +366,7 @@ import Tooltip from '@/views/Terminal/_components/Tooltip.vue';
 import { getFile, saveFile } from '@/services/fileSystemService.js';
 import { API_CONFIG } from '@/tt.config.js';
 import { fileUrlToLocalFileUrl } from '@/utils/localFileUrl.js';
+import { typesetMath } from '@/utils/lazyGlobalLibraries.js';
 
 // Lazy-loaded heavy library caches
 let _Chart = null;
@@ -1946,14 +1947,14 @@ export default {
     let mathJaxTimer = null;
     const renderMathJax = () => {
       clearTimeout(mathJaxTimer);
-      mathJaxTimer = setTimeout(() => {
+      mathJaxTimer = setTimeout(async () => {
         const el = markdownPreviewRef.value;
-        if (!el || typeof MathJax === 'undefined' || !MathJax.typesetPromise) return;
-        // Clear previous state and re-typeset scoped to this element only
-        MathJax.typesetClear([el]);
-        MathJax.typesetPromise([el]).catch((err) => {
+        if (!el) return;
+        try {
+          await typesetMath(el);
+        } catch (err) {
           console.error('MathJax rendering error:', err);
-        });
+        }
       }, 50);
     };
 

--- a/frontend/src/views/Terminal/CenterPanel/screens/Chat/Chat.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Chat/Chat.vue
@@ -189,6 +189,7 @@ import { resolveProviderKey, AI_PROVIDERS_WITH_API } from '@/store/app/aiProvide
 import PopupTutorial from '../../../../_components/utility/PopupTutorial.vue';
 import SimpleModal from '@/views/_components/common/SimpleModal.vue';
 import ChatScrollControls from '@/views/_components/chat/ChatScrollControls.vue';
+import { typesetMath } from '@/utils/lazyGlobalLibraries.js';
 
 export default {
   name: 'ChatScreen',
@@ -1856,9 +1857,9 @@ export default {
       window.addEventListener('keydown', handleChatKeyboardScroll);
 
       await nextTick();
-      if (typeof MathJax !== 'undefined' && MathJax.typesetPromise) {
-        MathJax.typesetPromise();
-      }
+      typesetMath(document.querySelector('.chat-main')).catch((error) => {
+        console.error('MathJax rendering error:', error);
+      });
 
       // Check for AI provider connection and show tutorial if needed
       if (!hasConnectedAIProvider.value) {

--- a/frontend/src/views/Terminal/CenterPanel/screens/Chat/components/MessageItem.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Chat/components/MessageItem.vue
@@ -316,6 +316,7 @@ import GoalProgressWidget from './GoalProgressWidget.vue';
 import Tooltip from '@/views/Terminal/_components/Tooltip.vue';
 import morphdom from 'morphdom';
 import { API_CONFIG } from '@/../user.config.js';
+import { typesetMath } from '@/utils/lazyGlobalLibraries.js';
 import {
   buildLocalFileUrl as sharedBuildLocalFileUrl,
   fileUrlToLocalFileUrl as sharedFileUrlToLocalFileUrl,
@@ -2216,15 +2217,18 @@ ${sourceCode.replace(/^\s*import\s+.*?from\s+['"][^'"]*['"];?\s*$/gm, '').replac
     // Typeset individual math containers — same pattern as charts.
     // Each .math-container has a stable ID so morphdom preserves it after typesetting.
     const renderMathElements = () => {
-      nextTick(() => {
-        if (!messageRef.value || typeof MathJax === 'undefined' || !MathJax.typesetPromise) return;
+      nextTick(async () => {
+        if (!messageRef.value) return;
         const containers = messageRef.value.querySelectorAll('.math-container:not([data-math-rendered])');
         if (containers.length === 0) return;
         const els = Array.from(containers);
         els.forEach((el) => el.setAttribute('data-math-rendered', 'true'));
-        MathJax.typesetPromise(els).catch((err) => {
+        try {
+          await typesetMath(els);
+        } catch (err) {
           console.error('MathJax rendering error:', err);
-        });
+          els.forEach((el) => el.removeAttribute('data-math-rendered'));
+        }
       });
     };
 

--- a/frontend/src/views/Terminal/CenterPanel/screens/ToolForge/components/ContentActions/ContentActions.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/ToolForge/components/ContentActions/ContentActions.vue
@@ -96,6 +96,7 @@ import axios from 'axios';
 import { API_CONFIG } from '@/tt.config.js';
 import SimpleModal from '@/views/_components/common/SimpleModal.vue';
 import Tooltip from '@/views/Terminal/_components/Tooltip.vue';
+import { highlightCodeBlocks, loadPdfExportLibraries, typesetMath } from '@/utils/lazyGlobalLibraries.js';
 
 export default {
   name: 'SharedContentActions',
@@ -347,26 +348,17 @@ export default {
           responseArea.setAttribute('data-tool-id', response.data.tool_id);
           document.getElementById('content-actions').style.display = 'flex';
 
-          // Highlight code blocks
-          responseArea.querySelectorAll('pre code:not([highlighted])').forEach((el) => {
-            hljs.highlightElement(el);
-            el.setAttribute('highlighted', 'true');
-          });
+          await highlightCodeBlocks(responseArea);
 
           // Set spellcheck to false for code elements
           responseArea.querySelectorAll('code').forEach((el) => {
             el.setAttribute('spellcheck', 'false');
           });
 
-          // Render MathJax content
-          if (typeof MathJax !== 'undefined' && MathJax.typesetPromise) {
-            try {
-              await MathJax.typesetPromise([responseArea]);
-            } catch (error) {
-              console.error('Error in MathJax typesetting:', error);
-            }
-          } else {
-            console.warn('MathJax is not available or not fully loaded');
+          try {
+            await typesetMath(responseArea);
+          } catch (error) {
+            console.error('Error in MathJax typesetting:', error);
           }
 
           // Add copy buttons to pre elements
@@ -427,8 +419,9 @@ export default {
         this.cleanup.addEventListener(button, 'click', clickHandler);
       });
     },
-    downloadPDF() {
+    async downloadPDF() {
       const responseArea = document.getElementById('response-area');
+      const { html2canvas, jspdf } = await loadPdfExportLibraries();
       const pdfDownloadLoaderDiv = document.createElement('div');
       const spinner = document.createElement('div'); // Create a new div element for the spinner
 

--- a/frontend/src/views/Terminal/Terminal.vue
+++ b/frontend/src/views/Terminal/Terminal.vue
@@ -11,7 +11,7 @@
       @screen-change="changeScreen"
     >
       <!-- KeepAlive caches visited screens so charts/data don't reload on every navigation -->
-      <KeepAlive>
+      <KeepAlive :max="4">
         <component
           v-if="isScreenReady"
           :is="activeScreenComponent"
@@ -37,7 +37,7 @@
 </template>
 
 <script>
-import { ref, computed, onMounted, watch, defineAsyncComponent, shallowReactive, markRaw, nextTick } from 'vue';
+import { ref, computed, onMounted, watch, shallowReactive, markRaw } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useStore } from 'vuex';
 
@@ -49,20 +49,14 @@ import OnboardingModal from '@/components/OnboardingModal.vue';
 // Canvas system (provides navigation sidebar + toolbar)
 import CanvasScreen from '@/canvas/CanvasScreen.vue';
 
-// Chat + Settings loaded eagerly (default screen + auth fallback)
-import ChatScreen from './CenterPanel/screens/Chat/Chat.vue';
-import SettingsScreen from './CenterPanel/screens/Settings/Settings.vue';
-
 // Shallow-reactive screen registry — screens register as they load
 // Must be shallowReactive so Vue doesn't deep-proxy component objects
 // (deep proxying breaks Vue internals like emitsOptions/HMR in dev mode)
-const screenComponents = shallowReactive({
-  ChatScreen: markRaw(ChatScreen),
-  SettingsScreen: markRaw(SettingsScreen),
-});
+const screenComponents = shallowReactive({});
 
-// Screens to preload in background after Chat renders
 const screenLoaders = [
+  ['ChatScreen', () => import('./CenterPanel/screens/Chat/Chat.vue')],
+  ['SettingsScreen', () => import('./CenterPanel/screens/Settings/Settings.vue')],
   ['AgentsScreen', () => import('./CenterPanel/screens/Agents/Agents.vue')],
   ['ToolsScreen', () => import('./CenterPanel/screens/Tools/Tools.vue')],
   ['WorkflowsScreen', () => import('./CenterPanel/screens/Workflows/Workflows.vue')],
@@ -84,13 +78,83 @@ const screenLoaders = [
   ['AutonomyScreen', () => import('./CenterPanel/screens/Autonomy/Autonomy.vue')],
 ];
 
-// Preload all screen chunks in parallel, register into reactive map as each resolves
-const preloadScreens = () => {
-  for (const [name, loader] of screenLoaders) {
-    loader()
-      .then((mod) => { screenComponents[name] = markRaw(mod.default); })
-      .catch((err) => console.warn(`[preload] Failed to load ${name}:`, err));
+const screenLoadersByName = new Map(screenLoaders);
+const screenLoadPromises = new Map();
+const preloadedGroups = new Set();
+const DASHBOARD_PREFETCH_SCREENS = new Set(['DashboardScreen', 'GoalsScreen', 'TracesScreen']);
+
+const screenPreloadGroups = {
+  DashboardScreen: ['GoalsScreen', 'TracesScreen'],
+  GoalsScreen: ['DashboardScreen', 'TracesScreen'],
+  TracesScreen: ['DashboardScreen', 'GoalsScreen'],
+  AgentsScreen: ['AgentForgeScreen'],
+  AgentForgeScreen: ['AgentsScreen'],
+  WorkflowsScreen: ['WorkflowForgeScreen'],
+  WorkflowForgeScreen: ['WorkflowsScreen'],
+  ToolsScreen: ['ToolForgeScreen'],
+  ToolForgeScreen: ['ToolsScreen'],
+  WidgetManagerScreen: ['WidgetForgeScreen'],
+  WidgetForgeScreen: ['WidgetManagerScreen'],
+  SkillsScreen: ['MemoryScreen', 'ExperimentsScreen', 'AutonomyScreen'],
+  MemoryScreen: ['SkillsScreen', 'ExperimentsScreen', 'AutonomyScreen'],
+  ExperimentsScreen: ['SkillsScreen', 'MemoryScreen', 'AutonomyScreen'],
+  AutonomyScreen: ['SkillsScreen', 'MemoryScreen', 'ExperimentsScreen'],
+};
+
+const idle = (cb, timeout = 2000) => (
+  typeof requestIdleCallback === 'function'
+    ? requestIdleCallback(cb, { timeout })
+    : setTimeout(cb, 100)
+);
+
+const loadScreen = (screenName) => {
+  if (screenComponents[screenName]) {
+    return Promise.resolve(screenComponents[screenName]);
   }
+
+  if (screenLoadPromises.has(screenName)) {
+    return screenLoadPromises.get(screenName);
+  }
+
+  const loader = screenLoadersByName.get(screenName);
+  if (!loader) {
+    return Promise.reject(new Error(`Unknown screen: ${screenName}`));
+  }
+
+  const promise = loader()
+    .then((mod) => {
+      screenComponents[screenName] = markRaw(mod.default);
+      return screenComponents[screenName];
+    })
+    .catch((err) => {
+      screenLoadPromises.delete(screenName);
+      console.warn(`[screen] Failed to load ${screenName}:`, err);
+      throw err;
+    });
+
+  screenLoadPromises.set(screenName, promise);
+  return promise;
+};
+
+const preloadLikelyScreens = (screenName) => {
+  const candidates = screenPreloadGroups[screenName] || [];
+  const groupKey = [screenName, ...candidates].join('|');
+  if (!candidates.length || preloadedGroups.has(groupKey)) return;
+  preloadedGroups.add(groupKey);
+
+  let index = 0;
+  const loadNext = () => {
+    const nextScreen = candidates[index++];
+    if (!nextScreen) return;
+
+    loadScreen(nextScreen)
+      .catch(() => {})
+      .finally(() => {
+        if (index < candidates.length) idle(loadNext, 4000);
+      });
+  };
+
+  idle(loadNext);
 };
 
 export default {
@@ -117,9 +181,6 @@ export default {
       return getDefaultScreen();
     };
     const activeScreen = ref(getScreenFromRoute());
-
-    // Placeholder shown while a screen chunk is still loading
-    const ScreenPlaceholder = { template: '<div style="flex:1;width:100%;height:100%;background:var(--color-background)"></div>' };
 
     const isScreenReady = computed(() => !!screenComponents[activeScreen.value]);
 
@@ -153,6 +214,8 @@ export default {
       };
 
       if (screenName in screenRoutes) {
+        ensureScreen(screenName);
+        prefetchScreenData(screenName);
         activeScreen.value = screenName;
         const targetPath = screenRoutes[screenName];
 
@@ -205,42 +268,40 @@ export default {
       store.dispatch('executionHistory/fetchExecutions').catch(() => {});
     };
 
-    onMounted(() => {
-      // Eagerly load the active screen if it's not already available
-      // This ensures reloading on /workflows (etc.) shows content immediately
-      const currentScreen = activeScreen.value;
-      if (!screenComponents[currentScreen]) {
-        const entry = screenLoaders.find(([name]) => name === currentScreen);
-        if (entry) {
-          entry[1]()
-            .then((mod) => { screenComponents[currentScreen] = markRaw(mod.default); })
-            .catch((err) => console.warn(`[eager] Failed to load ${currentScreen}:`, err));
-        }
-      }
+    const ensureScreen = (screenName) => {
+      loadScreen(screenName)
+        .then(() => preloadLikelyScreens(screenName))
+        .catch((err) => console.warn(`[screen] Failed to prepare ${screenName}:`, err));
+    };
 
-      // Preload remaining screens AND prime dashboard data in the same idle
-      // window. Both run in background so the active screen paints first.
-      const startPreload = () => {
-        preloadScreens();
-        prefetchDashboardData();
-      };
-      if (typeof requestIdleCallback === 'function') {
-        requestIdleCallback(startPreload);
-      } else {
-        setTimeout(startPreload, 100);
+    const prefetchScreenData = (screenName) => {
+      if (DASHBOARD_PREFETCH_SCREENS.has(screenName)) {
+        idle(prefetchDashboardData, 3000);
       }
+    };
+
+    onMounted(() => {
+      ensureScreen(activeScreen.value);
+      prefetchScreenData(activeScreen.value);
     });
 
     watch(
       () => route.path,
       () => {
+        let nextScreen = activeScreen.value;
         if (route.meta?.terminalScreen) {
-          activeScreen.value = route.meta.terminalScreen;
+          nextScreen = route.meta.terminalScreen;
         } else if (route.query.id) {
-          activeScreen.value = 'WorkflowForgeScreen';
+          nextScreen = 'WorkflowForgeScreen';
         } else if (route.path === '/') {
-          activeScreen.value = getDefaultScreen();
+          nextScreen = getDefaultScreen();
         }
+
+        if (nextScreen !== activeScreen.value) {
+          activeScreen.value = nextScreen;
+        }
+        ensureScreen(nextScreen);
+        prefetchScreenData(nextScreen);
       },
     );
 

--- a/frontend/src/views/_components/base/response.js
+++ b/frontend/src/views/_components/base/response.js
@@ -1,8 +1,10 @@
 import { removeStreamId } from './stream';
 import { useRoute } from 'vue-router';
 import axios from 'axios';
+import showdown from 'showdown';
 import { API_CONFIG } from '@/tt.config.js';
 import SimpleModal from '@/views/_components/common/SimpleModal.vue';
+import { highlightCodeBlocks, typesetMath } from '@/utils/lazyGlobalLibraries.js';
 
 // Track all event listeners for cleanup
 const eventListeners = new Map();
@@ -112,29 +114,17 @@ export function updateContentArea(fullMarkdownContent, message) {
   message.innerHTML = htmlText.trim();
   message.setAttribute('contenteditable', 'true');
 
-  message.querySelectorAll('pre code:not([highlighted])').forEach((el) => {
-    hljs.highlightElement(el);
-    el.setAttribute('highlighted', 'true');
+  highlightCodeBlocks(message).catch((error) => {
+    console.error('Error highlighting code blocks:', error);
   });
 
   message.querySelectorAll('code').forEach((el) => {
     el.setAttribute('spellcheck', 'false');
   });
 
-  // Modified MathJax handling
-  if (typeof MathJax !== 'undefined' && MathJax.typesetPromise) {
-    MathJax.typesetPromise()
-      .then(() => {
-        message.querySelectorAll('mjx-container').forEach((el) => {
-          MathJax.typesetClear([el]);
-        });
-      })
-      .catch((error) => {
-        console.error('Error in MathJax typesetting:', error);
-      });
-  } else {
-    console.warn('MathJax is not available or not fully loaded');
-  }
+  typesetMath(message).catch((error) => {
+    console.error('Error in MathJax typesetting:', error);
+  });
 
   // Add this new code to handle link clicks
   const linkClickHandler = (e) => {
@@ -232,31 +222,14 @@ export async function importOutputById(outputId) {
       responseArea.innerHTML = outputContent;
       document.getElementById('content-actions').style.display = 'flex';
 
-      // Highlight code blocks
-      responseArea.querySelectorAll('pre code:not([highlighted])').forEach((el) => {
-        hljs.highlightElement(el);
-        el.setAttribute('highlighted', 'true');
-      });
+      await highlightCodeBlocks(responseArea);
 
       // Set spellcheck to false for code elements
       responseArea.querySelectorAll('code').forEach((el) => {
         el.setAttribute('spellcheck', 'false');
       });
 
-      // Handle MathJax rendering
-      if (typeof MathJax !== 'undefined' && MathJax.typesetPromise) {
-        MathJax.typesetPromise()
-          .then(() => {
-            responseArea.querySelectorAll('mjx-container').forEach((el) => {
-              MathJax.typesetClear([el]);
-            });
-          })
-          .catch((error) => {
-            console.error('Error in MathJax typesetting:', error);
-          });
-      } else {
-        console.warn('MathJax is not available or not fully loaded');
-      }
+      await typesetMath(responseArea);
 
       // Add copy buttons to pre elements
       _addCopyButtonsToPre();

--- a/frontend/src/views/_components/feature/ContentActions.vue
+++ b/frontend/src/views/_components/feature/ContentActions.vue
@@ -97,6 +97,7 @@ import axios from 'axios';
 import { API_CONFIG } from '@/tt.config.js';
 import SimpleModal from '@/views/_components/common/SimpleModal.vue';
 import Tooltip from '@/views/Terminal/_components/Tooltip.vue';
+import { highlightCodeBlocks, loadPdfExportLibraries, typesetMath } from '@/utils/lazyGlobalLibraries.js';
 
 export default {
   name: 'SharedContentActions',
@@ -322,26 +323,17 @@ export default {
           responseArea.setAttribute('data-tool-id', response.data.tool_id);
           document.getElementById('content-actions').style.display = 'flex';
 
-          // Highlight code blocks
-          responseArea.querySelectorAll('pre code:not([highlighted])').forEach((el) => {
-            hljs.highlightElement(el);
-            el.setAttribute('highlighted', 'true');
-          });
+          await highlightCodeBlocks(responseArea);
 
           // Set spellcheck to false for code elements
           responseArea.querySelectorAll('code').forEach((el) => {
             el.setAttribute('spellcheck', 'false');
           });
 
-          // Render MathJax content
-          if (typeof MathJax !== 'undefined' && MathJax.typesetPromise) {
-            try {
-              await MathJax.typesetPromise([responseArea]);
-            } catch (error) {
-              console.error('Error in MathJax typesetting:', error);
-            }
-          } else {
-            console.warn('MathJax is not available or not fully loaded');
+          try {
+            await typesetMath(responseArea);
+          } catch (error) {
+            console.error('Error in MathJax typesetting:', error);
           }
 
           // Add copy buttons to pre elements
@@ -399,8 +391,9 @@ export default {
         this.cleanup.addEventListener(button, 'click', clickHandler);
       });
     },
-    downloadPDF() {
+    async downloadPDF() {
       const responseArea = document.getElementById('response-area');
+      const { html2canvas, jspdf } = await loadPdfExportLibraries();
       const pdfDownloadLoaderDiv = document.createElement('div');
       const spinner = document.createElement('div'); // Create a new div element for the spinner
 

--- a/frontend/src/views/_components/layout/TerminalLayout.vue
+++ b/frontend/src/views/_components/layout/TerminalLayout.vue
@@ -73,7 +73,11 @@ export default {
     const glitchDuration = 1000;
     const terminalScreenRef = ref(null);
     const hasUserInteracted = ref(false); // To track user interaction
-    const currentAudio = ref(null); // Track currently playing audio
+    const activeHtmlAudio = new Set();
+    const activeAudioSources = new Set();
+    const audioBuffers = new Map();
+    const pendingAudioBuffers = new Map();
+    let audioContext = null;
 
     // --- Background Layer ---
     const useCustomBackground = computed(() => store.getters['theme/useCustomBackground']);
@@ -114,15 +118,79 @@ export default {
       // keyPress: '/sounds/key-press.mp3',
       // notification: '/sounds/notification.mp3',
     };
+    const eagerSoundNames = ['buttonClick'];
 
     const setInteracted = () => {
       if (!hasUserInteracted.value) {
         hasUserInteracted.value = true;
         // console.log("User interaction detected. Sounds are now operational.");
       }
+      if (audioContext?.state === 'suspended') {
+        audioContext.resume().catch(() => {});
+      }
     };
 
-    const playSound = (soundName, volume = null) => {
+    const getAudioContext = () => {
+      if (audioContext) return audioContext;
+      const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+      if (!AudioContextCtor) return null;
+
+      audioContext = new AudioContextCtor();
+      return audioContext;
+    };
+
+    const getAudioBuffer = async (soundPath) => {
+      if (audioBuffers.has(soundPath)) return audioBuffers.get(soundPath);
+      if (pendingAudioBuffers.has(soundPath)) return pendingAudioBuffers.get(soundPath);
+
+      const context = getAudioContext();
+      if (!context) return null;
+
+      const pendingBuffer = fetch(soundPath)
+        .then((response) => {
+          if (!response.ok) throw new Error(`Unable to load ${soundPath}: ${response.status}`);
+          return response.arrayBuffer();
+        })
+        .then((arrayBuffer) => context.decodeAudioData(arrayBuffer))
+        .then((buffer) => {
+          audioBuffers.set(soundPath, buffer);
+          pendingAudioBuffers.delete(soundPath);
+          return buffer;
+        })
+        .catch((error) => {
+          pendingAudioBuffers.delete(soundPath);
+          console.warn(`Could not decode sound "${soundPath}":`, error);
+          return null;
+        });
+
+      pendingAudioBuffers.set(soundPath, pendingBuffer);
+      return pendingBuffer;
+    };
+
+    const preloadSoundBuffers = () => {
+      getAudioContext();
+      eagerSoundNames.forEach((soundName) => {
+        const soundPath = sounds[soundName];
+        if (soundPath) getAudioBuffer(soundPath).catch(() => {});
+      });
+    };
+
+    const playHtmlAudioFallback = (soundName, soundPath, volume) => {
+      const audio = new Audio(soundPath);
+      audio.volume = volume;
+      activeHtmlAudio.add(audio);
+
+      const cleanup = () => activeHtmlAudio.delete(audio);
+      audio.addEventListener('ended', cleanup, { once: true });
+      audio.addEventListener('error', cleanup, { once: true });
+
+      audio.play().catch((error) => {
+        console.warn(`Could not play sound "${soundName}" (HTML audio fallback):`, error);
+        cleanup();
+      });
+    };
+
+    const playSound = async (soundName, volume = null) => {
       // Check localStorage for sound settings
       const savedEnabled = localStorage.getItem('soundsEnabled');
       const soundsEnabled = savedEnabled === null ? true : savedEnabled === 'true';
@@ -145,53 +213,50 @@ export default {
         return;
       }
 
+      // Get saved volume or use provided/default
+      const savedVolume = localStorage.getItem('soundVolume');
+      let finalVolume;
+
+      if (volume !== null && typeof volume === 'number' && volume >= 0 && volume <= 1) {
+        // Use provided volume
+        finalVolume = volume;
+      } else if (savedVolume !== null) {
+        // Use saved volume
+        finalVolume = parseFloat(savedVolume);
+      } else {
+        // Use default
+        finalVolume = 0.3;
+      }
+
       try {
-        // Stop any currently playing sound
-        if (currentAudio.value) {
-          currentAudio.value.pause();
-          currentAudio.value.currentTime = 0;
-          currentAudio.value = null;
+        const context = getAudioContext();
+        if (!context) {
+          playHtmlAudioFallback(soundName, soundPath, finalVolume);
+          return;
         }
 
-        const audio = new Audio(soundPath);
-
-        // Get saved volume or use provided/default
-        const savedVolume = localStorage.getItem('soundVolume');
-        let finalVolume;
-
-        if (volume !== null && typeof volume === 'number' && volume >= 0 && volume <= 1) {
-          // Use provided volume
-          finalVolume = volume;
-        } else if (savedVolume !== null) {
-          // Use saved volume
-          finalVolume = parseFloat(savedVolume);
-        } else {
-          // Use default
-          finalVolume = 0.3;
+        if (context.state === 'suspended') {
+          await context.resume();
         }
 
-        audio.volume = finalVolume;
+        const buffer = await getAudioBuffer(soundPath);
+        if (!buffer) {
+          playHtmlAudioFallback(soundName, soundPath, finalVolume);
+          return;
+        }
 
-        // Track this audio as the current one
-        currentAudio.value = audio;
+        const source = context.createBufferSource();
+        const gain = context.createGain();
+        source.buffer = buffer;
+        gain.gain.value = finalVolume;
+        source.connect(gain).connect(context.destination);
 
-        // Clear the reference when the sound finishes
-        audio.addEventListener('ended', () => {
-          if (currentAudio.value === audio) {
-            currentAudio.value = null;
-          }
-        });
-
-        audio.play().catch((error) => {
-          // This catch handles errors other than NotAllowedError post-interaction
-          console.warn(`Could not play sound "${soundName}" (post-interaction attempt):`, error);
-          // Clear the reference on error
-          if (currentAudio.value === audio) {
-            currentAudio.value = null;
-          }
-        });
+        activeAudioSources.add(source);
+        source.onended = () => activeAudioSources.delete(source);
+        source.start();
       } catch (error) {
-        console.error(`Error creating or playing sound "${soundName}":`, error);
+        console.error(`Error playing sound "${soundName}":`, error);
+        playHtmlAudioFallback(soundName, soundPath, finalVolume);
       }
     };
 
@@ -252,6 +317,12 @@ export default {
 
     onMounted(() => {
       checkMobile();
+      const preloadSounds = () => preloadSoundBuffers();
+      if (typeof requestIdleCallback === 'function') {
+        requestIdleCallback(preloadSounds, { timeout: 2500 });
+      } else {
+        setTimeout(preloadSounds, 250);
+      }
       window.addEventListener('resize', checkMobile);
       window.addEventListener('sounds-settings-changed', handleSoundSettingsChange);
 
@@ -279,6 +350,19 @@ export default {
       if (terminalScreenRef.value) {
         terminalScreenRef.value.removeEventListener('click', handleGlobalButtonClick, true);
       }
+      activeAudioSources.forEach((source) => {
+        try {
+          source.stop();
+        } catch (e) {
+          // Source may have already ended.
+        }
+      });
+      activeAudioSources.clear();
+      activeHtmlAudio.forEach((audio) => {
+        audio.pause();
+        audio.currentTime = 0;
+      });
+      activeHtmlAudio.clear();
     });
 
     // Watch for the terminal becoming visible


### PR DESCRIPTION
## Summary
- Stacked on #42. This PR should be reviewed after #42, or rebased once #42 lands.
- Removes eager startup script tags for highlight.js, MathJax, Showdown, html2canvas, jsPDF, and jsPDF autotable.
- Adds a shared lazy global-library loader and updates markdown, math, highlighting, and PDF export call sites to load only when needed.

## Validation
- git diff --check
- npm run build
- Vite preview smoke on http://127.0.0.1:5301/settings confirmed the app shell loads and the heavyweight globals are absent on initial load.

## Notes
- Preview-only backend/auth/socket console errors are expected when serving the built frontend without the AGNT backend.