### PR TITLE
GitHub plugin v2.0.0 — 46 actions (was 15)

### DIFF
--- a/backend/plugins/dev/github-plugin/github-api.js
+++ b/backend/plugins/dev/github-plugin/github-api.js
@@ -1,110 +1,322 @@
 /**
- * GitHub API Plugin Tool
+ * GitHub API Plugin Tool (v2)
  *
- * Manage repositories, issues, pull requests, branches, and releases.
+ * Full repository lifecycle: repos, branches, files, issues, comments,
+ * pull requests, reviews, releases, GitHub Actions/CI, and search.
  */
+import fs from 'fs';
+import path from 'path';
+
+/** Per-action required parameters. Actions absent here require nothing beyond `action`. */
+const ACTION_REQUIREMENTS = {
+  // Issues
+  CREATE_ISSUE: ['owner', 'repo', 'title'],
+  LIST_ISSUES: ['owner', 'repo'],
+  GET_ISSUE: ['owner', 'repo', 'issueNumber'],
+  UPDATE_ISSUE: ['owner', 'repo', 'issueNumber'],
+  COMMENT_ON_ISSUE: ['owner', 'repo', 'issueNumber', 'body'],
+  LIST_COMMENTS: ['owner', 'repo', 'issueNumber'],
+  ADD_LABELS: ['owner', 'repo', 'issueNumber', 'labels'],
+  REMOVE_LABELS: ['owner', 'repo', 'issueNumber', 'labels'],
+  // Pull requests
+  CREATE_PR: ['owner', 'repo', 'title', 'head', 'base'],
+  LIST_PRS: ['owner', 'repo'],
+  GET_PR: ['owner', 'repo', 'pullNumber'],
+  UPDATE_PR: ['owner', 'repo', 'pullNumber'],
+  MERGE_PR: ['owner', 'repo', 'pullNumber'],
+  GET_PR_CHANGES: ['owner', 'repo', 'pullNumber'],
+  CREATE_PR_REVIEW: ['owner', 'repo', 'pullNumber', 'reviewEvent'],
+  LIST_PR_REVIEWS: ['owner', 'repo', 'pullNumber'],
+  REQUEST_REVIEWERS: ['owner', 'repo', 'pullNumber', 'reviewers'],
+  // Repos & branches
+  GET_REPO_INFO: ['owner', 'repo'],
+  LIST_REPOS: [],
+  CREATE_REPO: ['repo'],
+  FORK_REPO: ['owner', 'repo'],
+  LIST_BRANCHES: ['owner', 'repo'],
+  CREATE_BRANCH: ['owner', 'repo', 'baseBranch', 'newBranch'],
+  DELETE_BRANCH: ['owner', 'repo', 'branch'],
+  // Files & contents
+  GET_FILE_CONTENT: ['owner', 'repo', 'filePath'],
+  GET_REPO_CONTENTS: ['owner', 'repo'],
+  CREATE_FILE: ['owner', 'repo', 'filePath', 'content', 'commitMessage'],
+  UPDATE_FILE: ['owner', 'repo', 'filePath', 'content', 'commitMessage'],
+  DELETE_FILE: ['owner', 'repo', 'filePath', 'commitMessage'],
+  // Commits
+  LIST_COMMITS: ['owner', 'repo'],
+  GET_COMMIT: ['owner', 'repo', 'ref'],
+  COMPARE_COMMITS: ['owner', 'repo', 'base', 'head'],
+  // Releases
+  CREATE_RELEASE: ['owner', 'repo', 'tagName'],
+  LIST_RELEASES: ['owner', 'repo'],
+  GET_LATEST_RELEASE: ['owner', 'repo'],
+  UPLOAD_RELEASE_ASSET: ['owner', 'repo', 'releaseId', 'assetPath'],
+  // Actions / CI
+  LIST_WORKFLOWS: ['owner', 'repo'],
+  LIST_WORKFLOW_RUNS: ['owner', 'repo'],
+  GET_WORKFLOW_RUN: ['owner', 'repo', 'runId'],
+  TRIGGER_WORKFLOW: ['owner', 'repo', 'workflowId', 'ref'],
+  RERUN_WORKFLOW: ['owner', 'repo', 'runId'],
+  GET_CHECK_RUNS: ['owner', 'repo', 'ref'],
+  // Search & account
+  SEARCH_ISSUES: ['query'],
+  SEARCH_CODE: ['query'],
+  SEARCH_REPOS: ['query'],
+  GET_AUTHENTICATED_USER: [],
+};
+
 class GitHubAPI {
   constructor() {
     this.name = 'github-api';
     this.baseUrl = 'https://api.github.com';
+    this.uploadsUrl = 'https://uploads.github.com';
   }
 
   async execute(params, inputData, workflowEngine) {
-    console.log('[GitHubPlugin] Executing with params:', JSON.stringify(params, null, 2));
-    this.validateParams(params);
-
     try {
+      this.validateParams(params);
+
       const accessToken = params.__auth?.token;
       if (!accessToken) {
         throw new Error('Not connected to GitHub. Connect in Settings → Connections.');
       }
-
       params.accessToken = accessToken;
 
-      let result;
-      switch (params.action) {
-        case 'CREATE_ISSUE':
-          result = await this.createIssue(params);
-          break;
-        case 'CREATE_PR':
-          result = await this.createPullRequest(params);
-          break;
-        case 'GET_REPO_INFO':
-          result = await this.getRepoInfo(params);
-          break;
-        case 'CREATE_BRANCH':
-          result = await this.createBranch(params);
-          break;
-        case 'MERGE_PR':
-          result = await this.mergePullRequest(params);
-          break;
-        case 'LIST_PRS':
-          result = await this.listPullRequests(params);
-          break;
-        case 'GET_PR_CHANGES':
-          result = await this.getPullRequestChanges(params);
-          break;
-        case 'ADD_LABELS':
-          result = await this.addLabels(params);
-          break;
-        case 'REMOVE_LABELS':
-          result = await this.removeLabels(params);
-          break;
-        case 'GET_FILE_CONTENT':
-          result = await this.getFileContent(params);
-          break;
-        case 'GET_REPO_CONTENTS':
-          result = await this.getRepoContents(params);
-          break;
-        case 'CREATE_FILE':
-          result = await this.createFile(params);
-          break;
-        case 'UPDATE_FILE':
-          result = await this.updateFile(params);
-          break;
-        case 'CREATE_RELEASE':
-          result = await this.createRelease(params);
-          break;
-        case 'LIST_COMMITS':
-          result = await this.listCommits(params);
-          break;
-        default:
-          throw new Error(`Unsupported action: ${params.action}`);
+      const handlers = {
+        // Issues
+        CREATE_ISSUE: this.createIssue,
+        LIST_ISSUES: this.listIssues,
+        GET_ISSUE: this.getIssue,
+        UPDATE_ISSUE: this.updateIssue,
+        COMMENT_ON_ISSUE: this.commentOnIssue,
+        LIST_COMMENTS: this.listComments,
+        ADD_LABELS: this.addLabels,
+        REMOVE_LABELS: this.removeLabels,
+        // Pull requests
+        CREATE_PR: this.createPullRequest,
+        LIST_PRS: this.listPullRequests,
+        GET_PR: this.getPullRequest,
+        UPDATE_PR: this.updatePullRequest,
+        MERGE_PR: this.mergePullRequest,
+        GET_PR_CHANGES: this.getPullRequestChanges,
+        CREATE_PR_REVIEW: this.createPullRequestReview,
+        LIST_PR_REVIEWS: this.listPullRequestReviews,
+        REQUEST_REVIEWERS: this.requestReviewers,
+        // Repos & branches
+        GET_REPO_INFO: this.getRepoInfo,
+        LIST_REPOS: this.listRepos,
+        CREATE_REPO: this.createRepo,
+        FORK_REPO: this.forkRepo,
+        LIST_BRANCHES: this.listBranches,
+        CREATE_BRANCH: this.createBranch,
+        DELETE_BRANCH: this.deleteBranch,
+        // Files & contents
+        GET_FILE_CONTENT: this.getFileContent,
+        GET_REPO_CONTENTS: this.getRepoContents,
+        CREATE_FILE: this.createFile,
+        UPDATE_FILE: this.updateFile,
+        DELETE_FILE: this.deleteFile,
+        // Commits
+        LIST_COMMITS: this.listCommits,
+        GET_COMMIT: this.getCommit,
+        COMPARE_COMMITS: this.compareCommits,
+        // Releases
+        CREATE_RELEASE: this.createRelease,
+        LIST_RELEASES: this.listReleases,
+        GET_LATEST_RELEASE: this.getLatestRelease,
+        UPLOAD_RELEASE_ASSET: this.uploadReleaseAsset,
+        // Actions / CI
+        LIST_WORKFLOWS: this.listWorkflows,
+        LIST_WORKFLOW_RUNS: this.listWorkflowRuns,
+        GET_WORKFLOW_RUN: this.getWorkflowRun,
+        TRIGGER_WORKFLOW: this.triggerWorkflow,
+        RERUN_WORKFLOW: this.rerunWorkflow,
+        GET_CHECK_RUNS: this.getCheckRuns,
+        // Search & account
+        SEARCH_ISSUES: this.searchIssues,
+        SEARCH_CODE: this.searchCode,
+        SEARCH_REPOS: this.searchRepos,
+        GET_AUTHENTICATED_USER: this.getAuthenticatedUser,
+      };
+
+      const handler = handlers[params.action];
+      if (!handler) {
+        throw new Error(`Unsupported action: ${params.action}`);
       }
 
-      return {
-        success: true,
-        result: result,
-        error: null,
-      };
+      const result = await handler.call(this, params);
+      return { success: true, result, error: null };
     } catch (error) {
-      console.error('[GitHubPlugin] Error:', error);
-      return {
-        success: false,
-        result: null,
-        error: error.message,
-      };
+      console.error('[GitHubPlugin] Error:', error.message);
+      return { success: false, result: null, error: error.message };
     }
   }
 
+  // ─────────────────────────── Issues ───────────────────────────
+
   async createIssue(params) {
+    const body = {
+      title: params.title,
+      body: params.body || '',
+    };
+    const labels = this.normalizeList(params.labels);
+    if (labels.length) body.labels = labels;
+    const assignees = this.normalizeList(params.assignees);
+    if (assignees.length) body.assignees = assignees;
+
     const response = await this.makeRequest(
       `/repos/${params.owner}/${params.repo}/issues`,
-      {
-        method: 'POST',
-        body: JSON.stringify({
-          title: params.title,
-          body: params.body,
-        }),
-      },
+      { method: 'POST', body: JSON.stringify(body) },
       params.accessToken
     );
 
     return {
       issueNumber: response.number,
       issueUrl: response.html_url,
+      state: response.state,
     };
   }
+
+  async listIssues(params) {
+    const query = this.listQuery(params, {
+      state: params.state || 'open',
+      labels: this.normalizeList(params.labels).join(',') || undefined,
+    });
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/issues?${query}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    // The issues endpoint also returns PRs; exclude them.
+    return response
+      .filter((issue) => !issue.pull_request)
+      .map((issue) => ({
+        number: issue.number,
+        title: issue.title,
+        state: issue.state,
+        labels: (issue.labels || []).map((l) => l.name),
+        assignees: (issue.assignees || []).map((a) => a.login),
+        author: issue.user?.login,
+        comments: issue.comments,
+        createdAt: issue.created_at,
+        updatedAt: issue.updated_at,
+        url: issue.html_url,
+      }));
+  }
+
+  async getIssue(params) {
+    const issue = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/issues/${params.issueNumber}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return {
+      number: issue.number,
+      title: issue.title,
+      body: issue.body,
+      state: issue.state,
+      labels: (issue.labels || []).map((l) => l.name),
+      assignees: (issue.assignees || []).map((a) => a.login),
+      author: issue.user?.login,
+      comments: issue.comments,
+      isPullRequest: Boolean(issue.pull_request),
+      createdAt: issue.created_at,
+      updatedAt: issue.updated_at,
+      closedAt: issue.closed_at,
+      url: issue.html_url,
+    };
+  }
+
+  async updateIssue(params) {
+    const body = {};
+    if (params.title) body.title = params.title;
+    if (params.body) body.body = params.body;
+    if (params.issueState) body.state = params.issueState;
+    const labels = this.normalizeList(params.labels);
+    if (labels.length) body.labels = labels;
+    const assignees = this.normalizeList(params.assignees);
+    if (assignees.length) body.assignees = assignees;
+    if (Object.keys(body).length === 0) {
+      throw new Error('UPDATE_ISSUE requires at least one of: title, body, issueState, labels, assignees');
+    }
+
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/issues/${params.issueNumber}`,
+      { method: 'PATCH', body: JSON.stringify(body) },
+      params.accessToken
+    );
+
+    return {
+      issueNumber: response.number,
+      title: response.title,
+      state: response.state,
+      url: response.html_url,
+    };
+  }
+
+  async commentOnIssue(params) {
+    // Works for both issues and pull requests (PRs are issues in the comments API).
+    const number = params.issueNumber || params.pullNumber;
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/issues/${number}/comments`,
+      { method: 'POST', body: JSON.stringify({ body: params.body }) },
+      params.accessToken
+    );
+
+    return {
+      commentId: response.id,
+      commentUrl: response.html_url,
+      createdAt: response.created_at,
+    };
+  }
+
+  async listComments(params) {
+    const number = params.issueNumber || params.pullNumber;
+    const query = this.listQuery(params);
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/issues/${number}/comments?${query}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return response.map((comment) => ({
+      id: comment.id,
+      author: comment.user?.login,
+      body: comment.body,
+      createdAt: comment.created_at,
+      updatedAt: comment.updated_at,
+      url: comment.html_url,
+    }));
+  }
+
+  async addLabels(params) {
+    const labels = this.normalizeList(params.labels);
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/issues/${params.issueNumber}/labels`,
+      { method: 'POST', body: JSON.stringify({ labels }) },
+      params.accessToken
+    );
+
+    return { labels: response.map((label) => label.name) };
+  }
+
+  async removeLabels(params) {
+    const labels = this.normalizeList(params.labels);
+    const removed = [];
+    for (const label of labels) {
+      await this.makeRequest(
+        `/repos/${params.owner}/${params.repo}/issues/${params.issueNumber}/labels/${encodeURIComponent(label)}`,
+        { method: 'DELETE' },
+        params.accessToken
+      );
+      removed.push(label);
+    }
+    return { removedLabels: removed };
+  }
+
+  // ─────────────────────── Pull requests ────────────────────────
 
   async createPullRequest(params) {
     const response = await this.makeRequest(
@@ -113,9 +325,10 @@ class GitHubAPI {
         method: 'POST',
         body: JSON.stringify({
           title: params.title,
-          body: params.body,
+          body: params.body || '',
           head: params.head,
           base: params.base,
+          draft: this.flag(params.draft),
         }),
       },
       params.accessToken
@@ -124,8 +337,187 @@ class GitHubAPI {
     return {
       pullRequestNumber: response.number,
       pullRequestUrl: response.html_url,
+      draft: response.draft,
+      state: response.state,
     };
   }
+
+  async listPullRequests(params) {
+    const query = this.listQuery(params, {
+      state: params.state || 'open',
+      sort: params.sort || 'created',
+      direction: params.direction || 'desc',
+    });
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/pulls?${query}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return response.map((pr) => ({
+      number: pr.number,
+      title: pr.title,
+      state: pr.state,
+      draft: pr.draft,
+      author: pr.user?.login,
+      headRef: pr.head?.ref,
+      baseRef: pr.base?.ref,
+      createdAt: pr.created_at,
+      url: pr.html_url,
+    }));
+  }
+
+  async getPullRequest(params) {
+    const pr = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/pulls/${params.pullNumber}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return {
+      number: pr.number,
+      title: pr.title,
+      body: pr.body,
+      state: pr.state,
+      draft: pr.draft,
+      merged: pr.merged,
+      mergeable: pr.mergeable,
+      mergeableState: pr.mergeable_state,
+      headRef: pr.head?.ref,
+      headSha: pr.head?.sha,
+      baseRef: pr.base?.ref,
+      author: pr.user?.login,
+      additions: pr.additions,
+      deletions: pr.deletions,
+      changedFiles: pr.changed_files,
+      commits: pr.commits,
+      comments: pr.comments,
+      reviewComments: pr.review_comments,
+      labels: (pr.labels || []).map((l) => l.name),
+      createdAt: pr.created_at,
+      updatedAt: pr.updated_at,
+      mergedAt: pr.merged_at,
+      url: pr.html_url,
+    };
+  }
+
+  async updatePullRequest(params) {
+    const body = {};
+    if (params.title) body.title = params.title;
+    if (params.body) body.body = params.body;
+    if (params.issueState) body.state = params.issueState;
+    if (params.base) body.base = params.base;
+    if (Object.keys(body).length === 0) {
+      throw new Error('UPDATE_PR requires at least one of: title, body, issueState, base');
+    }
+
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/pulls/${params.pullNumber}`,
+      { method: 'PATCH', body: JSON.stringify(body) },
+      params.accessToken
+    );
+
+    return {
+      pullRequestNumber: response.number,
+      title: response.title,
+      state: response.state,
+      url: response.html_url,
+    };
+  }
+
+  async mergePullRequest(params) {
+    const body = { merge_method: params.mergeMethod || 'merge' };
+    if (params.commitTitle) body.commit_title = params.commitTitle;
+
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/pulls/${params.pullNumber}/merge`,
+      { method: 'PUT', body: JSON.stringify(body) },
+      params.accessToken
+    );
+
+    return {
+      merged: response.merged,
+      message: response.message,
+      sha: response.sha,
+    };
+  }
+
+  async getPullRequestChanges(params) {
+    const query = this.listQuery(params);
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/pulls/${params.pullNumber}/files?${query}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return response.map((file) => ({
+      filename: file.filename,
+      status: file.status,
+      additions: file.additions,
+      deletions: file.deletions,
+      changes: file.changes,
+      patch: file.patch,
+    }));
+  }
+
+  async createPullRequestReview(params) {
+    const event = String(params.reviewEvent || '').toUpperCase();
+    if (!['APPROVE', 'REQUEST_CHANGES', 'COMMENT'].includes(event)) {
+      throw new Error(`Invalid reviewEvent: ${params.reviewEvent}. Use APPROVE, REQUEST_CHANGES, or COMMENT.`);
+    }
+    if ((event === 'REQUEST_CHANGES' || event === 'COMMENT') && !params.body) {
+      throw new Error(`A review body is required when reviewEvent is ${event}.`);
+    }
+
+    const body = { event };
+    if (params.body) body.body = params.body;
+
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/pulls/${params.pullNumber}/reviews`,
+      { method: 'POST', body: JSON.stringify(body) },
+      params.accessToken
+    );
+
+    return {
+      reviewId: response.id,
+      state: response.state,
+      url: response.html_url,
+    };
+  }
+
+  async listPullRequestReviews(params) {
+    const query = this.listQuery(params);
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/pulls/${params.pullNumber}/reviews?${query}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return response.map((review) => ({
+      id: review.id,
+      author: review.user?.login,
+      state: review.state,
+      body: review.body,
+      submittedAt: review.submitted_at,
+      url: review.html_url,
+    }));
+  }
+
+  async requestReviewers(params) {
+    const reviewers = this.normalizeList(params.reviewers);
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/pulls/${params.pullNumber}/requested_reviewers`,
+      { method: 'POST', body: JSON.stringify({ reviewers }) },
+      params.accessToken
+    );
+
+    return {
+      requestedReviewers: (response.requested_reviewers || []).map((r) => r.login),
+      url: response.html_url,
+    };
+  }
+
+  // ─────────────────── Repositories & branches ──────────────────
 
   async getRepoInfo(params) {
     const response = await this.makeRequest(
@@ -138,16 +530,98 @@ class GitHubAPI {
       name: response.name,
       fullName: response.full_name,
       description: response.description,
+      private: response.private,
       stars: response.stargazers_count,
       forks: response.forks_count,
       openIssues: response.open_issues_count,
       defaultBranch: response.default_branch,
+      language: response.language,
+      url: response.html_url,
     };
+  }
+
+  async listRepos(params) {
+    const query = this.listQuery(params, {
+      visibility: params.visibility && params.visibility !== 'all' ? params.visibility : undefined,
+      sort: params.sort || 'updated',
+    });
+    const response = await this.makeRequest(
+      `/user/repos?${query}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return response.map((repo) => ({
+      name: repo.name,
+      fullName: repo.full_name,
+      owner: repo.owner?.login,
+      private: repo.private,
+      description: repo.description,
+      defaultBranch: repo.default_branch,
+      stars: repo.stargazers_count,
+      language: repo.language,
+      updatedAt: repo.updated_at,
+      url: repo.html_url,
+    }));
+  }
+
+  async createRepo(params) {
+    const response = await this.makeRequest(
+      '/user/repos',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          name: params.repo,
+          description: params.description || '',
+          private: this.flag(params.private),
+          auto_init: true,
+        }),
+      },
+      params.accessToken
+    );
+
+    return {
+      name: response.name,
+      fullName: response.full_name,
+      private: response.private,
+      defaultBranch: response.default_branch,
+      url: response.html_url,
+    };
+  }
+
+  async forkRepo(params) {
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/forks`,
+      { method: 'POST', body: JSON.stringify({}) },
+      params.accessToken
+    );
+
+    return {
+      fullName: response.full_name,
+      owner: response.owner?.login,
+      url: response.html_url,
+      note: 'Forking is asynchronous; the fork may take a few seconds to be fully available.',
+    };
+  }
+
+  async listBranches(params) {
+    const query = this.listQuery(params);
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/branches?${query}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return response.map((branch) => ({
+      name: branch.name,
+      sha: branch.commit?.sha,
+      protected: branch.protected,
+    }));
   }
 
   async createBranch(params) {
     const getRefResponse = await this.makeRequest(
-      `/repos/${params.owner}/${params.repo}/git/ref/heads/${params.baseBranch}`,
+      `/repos/${params.owner}/${params.repo}/git/ref/heads/${this.encodePath(params.baseBranch)}`,
       { method: 'GET' },
       params.accessToken
     );
@@ -166,119 +640,27 @@ class GitHubAPI {
 
     return {
       branchName: params.newBranch,
+      sha: response.object?.sha,
       branchUrl: response.url,
     };
   }
 
-  async mergePullRequest(params) {
-    const response = await this.makeRequest(
-      `/repos/${params.owner}/${params.repo}/pulls/${params.pullNumber}/merge`,
-      {
-        method: 'PUT',
-        body: JSON.stringify({
-          merge_method: params.mergeMethod || 'merge',
-        }),
-      },
+  async deleteBranch(params) {
+    await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/git/refs/heads/${this.encodePath(params.branch)}`,
+      { method: 'DELETE' },
       params.accessToken
     );
 
-    return {
-      merged: response.merged,
-      message: response.message,
-    };
+    return { deleted: true, branchName: params.branch };
   }
 
-  async listPullRequests(params) {
-    const queryParams = new URLSearchParams({
-      state: params.state || 'open',
-      sort: params.sort || 'created',
-      direction: params.direction || 'desc',
-    });
-
-    const response = await this.makeRequest(
-      `/repos/${params.owner}/${params.repo}/pulls?${queryParams.toString()}`,
-      { method: 'GET' },
-      params.accessToken
-    );
-
-    return response.map((pr) => ({
-      number: pr.number,
-      title: pr.title,
-      state: pr.state,
-      url: pr.html_url,
-    }));
-  }
-
-  async getPullRequestChanges(params) {
-    const response = await this.makeRequest(
-      `/repos/${params.owner}/${params.repo}/pulls/${params.pullNumber}/files`,
-      { method: 'GET' },
-      params.accessToken
-    );
-
-    return response.map((file) => ({
-      filename: file.filename,
-      status: file.status,
-      additions: file.additions,
-      deletions: file.deletions,
-      changes: file.changes,
-      patch: file.patch,
-    }));
-  }
-
-  async addLabels(params) {
-    const response = await this.makeRequest(
-      `/repos/${params.owner}/${params.repo}/issues/${params.issueNumber}/labels`,
-      {
-        method: 'POST',
-        body: JSON.stringify(params.labels),
-      },
-      params.accessToken
-    );
-
-    return {
-      labels: response.map((label) => label.name),
-    };
-  }
-
-  async removeLabels(params) {
-    for (const label of params.labels) {
-      await this.makeRequest(
-        `/repos/${params.owner}/${params.repo}/issues/${params.issueNumber}/labels/${label}`,
-        { method: 'DELETE' },
-        params.accessToken
-      );
-    }
-
-    return {
-      removedLabels: params.labels,
-    };
-  }
-
-  async createFile(params) {
-    const response = await this.makeRequest(
-      `/repos/${params.owner}/${params.repo}/contents/${params.filePath}`,
-      {
-        method: 'PUT',
-        body: JSON.stringify({
-          message: params.commitMessage,
-          content: Buffer.from(params.content).toString('base64'),
-          branch: params.branch,
-        }),
-      },
-      params.accessToken
-    );
-
-    return {
-      fileUrl: response.content.html_url,
-      commitSha: response.commit.sha,
-    };
-  }
+  // ─────────────────────── Files & contents ─────────────────────
 
   async getFileContent(params) {
-    const queryParams = params.ref ? `?ref=${params.ref}` : '';
+    const queryParams = params.ref ? `?ref=${encodeURIComponent(params.ref)}` : '';
     const response = await this.makeRequest(
-      `/repos/${params.owner}/${params.repo}/contents/${params.filePath}${queryParams}`,
+      `/repos/${params.owner}/${params.repo}/contents/${this.encodePath(params.filePath)}${queryParams}`,
       { method: 'GET' },
       params.accessToken
     );
@@ -301,70 +683,204 @@ class GitHubAPI {
   }
 
   async getRepoContents(params) {
-    const path = params.filePath || '';
-    const recursive = params.recursive || false;
+    // Recursive listing uses the git trees API: one request, metadata only.
+    // (v1 downloaded every file's full content recursively — a rate-limit bomb.)
+    if (this.flag(params.recursive)) {
+      let ref = params.ref;
+      if (!ref) {
+        const repoInfo = await this.makeRequest(
+          `/repos/${params.owner}/${params.repo}`,
+          { method: 'GET' },
+          params.accessToken
+        );
+        ref = repoInfo.default_branch;
+      }
 
-    const listContents = async (path) => {
-      const queryParams = params.ref ? `?ref=${params.ref}` : '';
       const response = await this.makeRequest(
-        `/repos/${params.owner}/${params.repo}/contents/${path}${queryParams}`,
+        `/repos/${params.owner}/${params.repo}/git/trees/${this.encodePath(ref)}?recursive=1`,
         { method: 'GET' },
         params.accessToken
       );
 
-      const contents = await Promise.all(
-        response.map(async (item) => {
-          if (item.type === 'file') {
-            const fileContent = await this.getFileContent({
-              ...params,
-              filePath: item.path,
-            });
-            return {
-              ...item,
-              content: fileContent.content,
-            };
-          } else if (item.type === 'dir' && recursive) {
-            return {
-              ...item,
-              contents: await listContents(item.path),
-            };
-          }
-          return item;
-        })
-      );
+      return {
+        ref,
+        truncated: response.truncated,
+        entries: (response.tree || []).map((item) => ({
+          path: item.path,
+          type: item.type === 'tree' ? 'dir' : 'file',
+          size: item.size,
+          sha: item.sha,
+        })),
+      };
+    }
 
-      return contents;
-    };
-
-    return listContents(path);
-  }
-
-  async updateFile(params) {
-    const currentFile = await this.makeRequest(
-      `/repos/${params.owner}/${params.repo}/contents/${params.filePath}`,
+    const dirPath = params.filePath || '';
+    const queryParams = params.ref ? `?ref=${encodeURIComponent(params.ref)}` : '';
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/contents/${this.encodePath(dirPath)}${queryParams}`,
       { method: 'GET' },
       params.accessToken
     );
 
+    const items = Array.isArray(response) ? response : [response];
+    return {
+      path: dirPath || '/',
+      entries: items.map((item) => ({
+        name: item.name,
+        path: item.path,
+        type: item.type,
+        size: item.size,
+        sha: item.sha,
+        url: item.html_url,
+      })),
+    };
+  }
+
+  async createFile(params) {
+    const body = {
+      message: params.commitMessage,
+      content: Buffer.from(params.content).toString('base64'),
+    };
+    if (params.branch) body.branch = params.branch;
+
     const response = await this.makeRequest(
-      `/repos/${params.owner}/${params.repo}/contents/${params.filePath}`,
-      {
-        method: 'PUT',
-        body: JSON.stringify({
-          message: params.commitMessage,
-          content: Buffer.from(params.content).toString('base64'),
-          sha: currentFile.sha,
-          branch: params.branch,
-        }),
-      },
+      `/repos/${params.owner}/${params.repo}/contents/${this.encodePath(params.filePath)}`,
+      { method: 'PUT', body: JSON.stringify(body) },
       params.accessToken
     );
 
     return {
-      fileUrl: response.content.html_url,
-      commitSha: response.commit.sha,
+      fileUrl: response.content?.html_url,
+      commitSha: response.commit?.sha,
     };
   }
+
+  async updateFile(params) {
+    const refQuery = params.branch ? `?ref=${encodeURIComponent(params.branch)}` : '';
+    const currentFile = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/contents/${this.encodePath(params.filePath)}${refQuery}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    const body = {
+      message: params.commitMessage,
+      content: Buffer.from(params.content).toString('base64'),
+      sha: currentFile.sha,
+    };
+    if (params.branch) body.branch = params.branch;
+
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/contents/${this.encodePath(params.filePath)}`,
+      { method: 'PUT', body: JSON.stringify(body) },
+      params.accessToken
+    );
+
+    return {
+      fileUrl: response.content?.html_url,
+      commitSha: response.commit?.sha,
+    };
+  }
+
+  async deleteFile(params) {
+    const refQuery = params.branch ? `?ref=${encodeURIComponent(params.branch)}` : '';
+    const currentFile = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/contents/${this.encodePath(params.filePath)}${refQuery}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    const body = {
+      message: params.commitMessage,
+      sha: currentFile.sha,
+    };
+    if (params.branch) body.branch = params.branch;
+
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/contents/${this.encodePath(params.filePath)}`,
+      { method: 'DELETE', body: JSON.stringify(body) },
+      params.accessToken
+    );
+
+    return {
+      deleted: true,
+      filePath: params.filePath,
+      commitSha: response.commit?.sha,
+    };
+  }
+
+  // ───────────────────────── Commits ────────────────────────────
+
+  async listCommits(params) {
+    const query = this.listQuery(params, {
+      sha: params.branch || undefined,
+    });
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/commits?${query}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return response.map((commit) => ({
+      sha: commit.sha,
+      message: commit.commit.message,
+      author: commit.commit.author?.name,
+      date: commit.commit.author?.date,
+      url: commit.html_url,
+    }));
+  }
+
+  async getCommit(params) {
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/commits/${this.encodePath(params.ref)}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return {
+      sha: response.sha,
+      message: response.commit?.message,
+      author: response.commit?.author?.name,
+      date: response.commit?.author?.date,
+      stats: response.stats,
+      files: (response.files || []).map((file) => ({
+        filename: file.filename,
+        status: file.status,
+        additions: file.additions,
+        deletions: file.deletions,
+      })),
+      url: response.html_url,
+    };
+  }
+
+  async compareCommits(params) {
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/compare/${this.encodePath(params.base)}...${this.encodePath(params.head)}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return {
+      status: response.status,
+      aheadBy: response.ahead_by,
+      behindBy: response.behind_by,
+      totalCommits: response.total_commits,
+      commits: (response.commits || []).map((c) => ({
+        sha: c.sha,
+        message: c.commit?.message,
+        author: c.commit?.author?.name,
+      })),
+      files: (response.files || []).map((file) => ({
+        filename: file.filename,
+        status: file.status,
+        additions: file.additions,
+        deletions: file.deletions,
+      })),
+      url: response.html_url,
+    };
+  }
+
+  // ───────────────────────── Releases ───────────────────────────
 
   async createRelease(params) {
     const response = await this.makeRequest(
@@ -373,10 +889,10 @@ class GitHubAPI {
         method: 'POST',
         body: JSON.stringify({
           tag_name: params.tagName,
-          name: params.releaseName,
-          body: params.releaseNotes,
-          draft: params.draft || false,
-          prerelease: params.prerelease || false,
+          name: params.releaseName || params.tagName,
+          body: params.releaseNotes || '',
+          draft: this.flag(params.draft),
+          prerelease: this.flag(params.prerelease),
         }),
       },
       params.accessToken
@@ -385,72 +901,425 @@ class GitHubAPI {
     return {
       releaseId: response.id,
       releaseUrl: response.html_url,
+      tagName: response.tag_name,
     };
   }
 
-  async listCommits(params) {
-    const queryParams = new URLSearchParams();
-    if (params.branch) queryParams.set('sha', params.branch);
-    queryParams.set('per_page', params.perPage || '30');
-
+  async listReleases(params) {
+    const query = this.listQuery(params);
     const response = await this.makeRequest(
-      `/repos/${params.owner}/${params.repo}/commits?${queryParams.toString()}`,
+      `/repos/${params.owner}/${params.repo}/releases?${query}`,
       { method: 'GET' },
       params.accessToken
     );
 
-    return response.map((commit) => ({
-      sha: commit.sha,
-      message: commit.commit.message,
-      author: commit.commit.author.name,
-      date: commit.commit.author.date,
+    return response.map((release) => ({
+      id: release.id,
+      tagName: release.tag_name,
+      name: release.name,
+      draft: release.draft,
+      prerelease: release.prerelease,
+      publishedAt: release.published_at,
+      assets: (release.assets || []).map((a) => ({ id: a.id, name: a.name, size: a.size, downloadUrl: a.browser_download_url })),
+      url: release.html_url,
     }));
   }
 
-  async makeRequest(endpoint, options, accessToken) {
-    const url = `${this.baseUrl}${endpoint}`;
-    const headers = {
-      Authorization: `Bearer ${accessToken}`,
-      Accept: 'application/vnd.github.v3+json',
-      'Content-Type': 'application/json',
+  async getLatestRelease(params) {
+    const release = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/releases/latest`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return {
+      id: release.id,
+      tagName: release.tag_name,
+      name: release.name,
+      body: release.body,
+      publishedAt: release.published_at,
+      assets: (release.assets || []).map((a) => ({ id: a.id, name: a.name, size: a.size, downloadUrl: a.browser_download_url })),
+      url: release.html_url,
     };
+  }
 
-    const response = await fetch(url, {
-      ...options,
-      headers: {
-        ...headers,
-        ...options.headers,
+  async uploadReleaseAsset(params) {
+    if (!fs.existsSync(params.assetPath)) {
+      throw new Error(`Asset file not found: ${params.assetPath}`);
+    }
+    const data = fs.readFileSync(params.assetPath);
+    const name = params.assetName || path.basename(params.assetPath);
+
+    const url = `${this.uploadsUrl}/repos/${params.owner}/${params.repo}/releases/${params.releaseId}/assets?name=${encodeURIComponent(name)}`;
+    const response = await this.makeRequest(
+      url,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: data,
       },
+      params.accessToken
+    );
+
+    return {
+      assetId: response.id,
+      name: response.name,
+      size: response.size,
+      downloadUrl: response.browser_download_url,
+    };
+  }
+
+  // ──────────────────── GitHub Actions / CI ─────────────────────
+
+  async listWorkflows(params) {
+    const query = this.listQuery(params);
+    const response = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/actions/workflows?${query}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return {
+      totalCount: response.total_count,
+      workflows: (response.workflows || []).map((wf) => ({
+        id: wf.id,
+        name: wf.name,
+        path: wf.path,
+        state: wf.state,
+        url: wf.html_url,
+      })),
+    };
+  }
+
+  async listWorkflowRuns(params) {
+    const query = this.listQuery(params, {
+      branch: params.branch || undefined,
+      status: params.runStatus || undefined,
     });
+    const endpoint = params.workflowId
+      ? `/repos/${params.owner}/${params.repo}/actions/workflows/${this.encodePath(String(params.workflowId))}/runs?${query}`
+      : `/repos/${params.owner}/${params.repo}/actions/runs?${query}`;
 
-    const responseData = await response.json();
+    const response = await this.makeRequest(endpoint, { method: 'GET' }, params.accessToken);
 
-    if (!response.ok) {
-      if (responseData.message === 'Resource not accessible by integration') {
-        throw new Error(
-          `Insufficient permissions. Please re-authorize the GitHub integration with the necessary permissions.`
-        );
-      }
-      throw new Error(`GitHub API error: ${JSON.stringify(responseData)}`);
+    return {
+      totalCount: response.total_count,
+      runs: (response.workflow_runs || []).map((run) => ({
+        id: run.id,
+        name: run.name,
+        headBranch: run.head_branch,
+        headSha: run.head_sha,
+        event: run.event,
+        status: run.status,
+        conclusion: run.conclusion,
+        runNumber: run.run_number,
+        createdAt: run.created_at,
+        url: run.html_url,
+      })),
+    };
+  }
+
+  async getWorkflowRun(params) {
+    const run = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/actions/runs/${params.runId}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    let jobs = [];
+    try {
+      const jobsResponse = await this.makeRequest(
+        `/repos/${params.owner}/${params.repo}/actions/runs/${params.runId}/jobs`,
+        { method: 'GET' },
+        params.accessToken
+      );
+      jobs = (jobsResponse.jobs || []).map((job) => ({
+        id: job.id,
+        name: job.name,
+        status: job.status,
+        conclusion: job.conclusion,
+        startedAt: job.started_at,
+        completedAt: job.completed_at,
+      }));
+    } catch (error) {
+      // Jobs are supplementary; don't fail the whole action if they're unavailable.
+      console.error('[GitHubPlugin] Could not fetch run jobs:', error.message);
     }
 
-    return responseData;
+    return {
+      id: run.id,
+      name: run.name,
+      headBranch: run.head_branch,
+      headSha: run.head_sha,
+      event: run.event,
+      status: run.status,
+      conclusion: run.conclusion,
+      runNumber: run.run_number,
+      runAttempt: run.run_attempt,
+      createdAt: run.created_at,
+      updatedAt: run.updated_at,
+      jobs,
+      url: run.html_url,
+    };
   }
+
+  async triggerWorkflow(params) {
+    const body = { ref: params.ref };
+    if (params.workflowInputs) {
+      body.inputs = this.parseMaybeJson(params.workflowInputs, 'workflowInputs');
+    }
+
+    await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/actions/workflows/${this.encodePath(String(params.workflowId))}/dispatches`,
+      { method: 'POST', body: JSON.stringify(body) },
+      params.accessToken
+    );
+
+    return {
+      triggered: true,
+      workflowId: params.workflowId,
+      ref: params.ref,
+      note: 'Dispatch accepted. Use LIST_WORKFLOW_RUNS to find the new run (it may take a few seconds to appear).',
+    };
+  }
+
+  async rerunWorkflow(params) {
+    await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/actions/runs/${params.runId}/rerun`,
+      { method: 'POST' },
+      params.accessToken
+    );
+
+    return { rerunTriggered: true, runId: params.runId };
+  }
+
+  async getCheckRuns(params) {
+    const checkRunsResponse = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/commits/${this.encodePath(params.ref)}/check-runs`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    const statusResponse = await this.makeRequest(
+      `/repos/${params.owner}/${params.repo}/commits/${this.encodePath(params.ref)}/status`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return {
+      ref: params.ref,
+      combinedStatus: statusResponse.state,
+      totalCheckRuns: checkRunsResponse.total_count,
+      checkRuns: (checkRunsResponse.check_runs || []).map((check) => ({
+        id: check.id,
+        name: check.name,
+        status: check.status,
+        conclusion: check.conclusion,
+        startedAt: check.started_at,
+        completedAt: check.completed_at,
+        url: check.html_url,
+      })),
+      statuses: (statusResponse.statuses || []).map((s) => ({
+        context: s.context,
+        state: s.state,
+        description: s.description,
+      })),
+    };
+  }
+
+  // ────────────────────── Search & account ──────────────────────
+
+  async searchIssues(params) {
+    const query = this.listQuery(params, { q: params.query });
+    const response = await this.makeRequest(
+      `/search/issues?${query}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return {
+      totalCount: response.total_count,
+      items: (response.items || []).map((item) => ({
+        number: item.number,
+        title: item.title,
+        state: item.state,
+        isPullRequest: Boolean(item.pull_request),
+        repository: item.repository_url?.replace('https://api.github.com/repos/', ''),
+        author: item.user?.login,
+        labels: (item.labels || []).map((l) => l.name),
+        createdAt: item.created_at,
+        url: item.html_url,
+      })),
+    };
+  }
+
+  async searchCode(params) {
+    const query = this.listQuery(params, { q: params.query });
+    const response = await this.makeRequest(
+      `/search/code?${query}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return {
+      totalCount: response.total_count,
+      items: (response.items || []).map((item) => ({
+        name: item.name,
+        path: item.path,
+        repository: item.repository?.full_name,
+        sha: item.sha,
+        url: item.html_url,
+      })),
+    };
+  }
+
+  async searchRepos(params) {
+    const query = this.listQuery(params, { q: params.query });
+    const response = await this.makeRequest(
+      `/search/repositories?${query}`,
+      { method: 'GET' },
+      params.accessToken
+    );
+
+    return {
+      totalCount: response.total_count,
+      items: (response.items || []).map((repo) => ({
+        fullName: repo.full_name,
+        description: repo.description,
+        stars: repo.stargazers_count,
+        language: repo.language,
+        updatedAt: repo.updated_at,
+        url: repo.html_url,
+      })),
+    };
+  }
+
+  async getAuthenticatedUser(params) {
+    const user = await this.makeRequest('/user', { method: 'GET' }, params.accessToken);
+
+    return {
+      login: user.login,
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      publicRepos: user.public_repos,
+      privateRepos: user.total_private_repos,
+      url: user.html_url,
+    };
+  }
+
+  // ──────────────────────── HTTP core ───────────────────────────
+
+  async makeRequest(endpoint, options = {}, accessToken) {
+    const url = endpoint.startsWith('http') ? endpoint : `${this.baseUrl}${endpoint}`;
+    const headers = {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type': 'application/json',
+      ...options.headers,
+    };
+
+    const response = await fetch(url, { ...options, headers });
+
+    // Rate-limit exhaustion: surface a clear, actionable error.
+    if (
+      (response.status === 403 || response.status === 429) &&
+      response.headers.get('x-ratelimit-remaining') === '0'
+    ) {
+      const resetEpoch = Number(response.headers.get('x-ratelimit-reset'));
+      const resetAt = resetEpoch ? new Date(resetEpoch * 1000).toISOString() : 'unknown';
+      throw new Error(`GitHub API rate limit exceeded. Limit resets at ${resetAt}.`);
+    }
+
+    // 204/205 (and any empty body) have no JSON to parse.
+    const text = await response.text();
+    let data = null;
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = { raw: text };
+      }
+    }
+
+    if (!response.ok) {
+      const message = data?.message || text || response.statusText;
+      if (message === 'Resource not accessible by integration') {
+        throw new Error(
+          'Insufficient permissions. Please re-authorize the GitHub integration with the necessary permissions.'
+        );
+      }
+      const details = data?.errors ? ` Details: ${JSON.stringify(data.errors)}` : '';
+      throw new Error(`GitHub API error (${response.status}): ${message}${details}`);
+    }
+
+    return data ?? { status: response.status };
+  }
+
+  // ───────────────────────── Helpers ────────────────────────────
 
   validateParams(params) {
     if (!params.action) {
       throw new Error('Action is required');
     }
-    if (!params.owner) {
-      throw new Error('Owner is required');
+    const required = ACTION_REQUIREMENTS[params.action];
+    if (!required) {
+      throw new Error(`Unsupported action: ${params.action}`);
     }
-    if (!params.repo) {
-      throw new Error('Repository name is required');
-    }
-    if (params.action === 'GET_PR_CHANGES') {
-      if (!params.pullNumber) {
-        throw new Error('Pull request number is required');
+    for (const field of required) {
+      const value = params[field];
+      if (value === undefined || value === null || value === '') {
+        throw new Error(`"${field}" is required for ${params.action}`);
       }
+    }
+  }
+
+  /** Build a query string with pagination + extra filters (empty values omitted). */
+  listQuery(params, extra = {}) {
+    const query = new URLSearchParams();
+    query.set('per_page', String(parseInt(params.perPage, 10) || 30));
+    query.set('page', String(parseInt(params.page, 10) || 1));
+    for (const [key, value] of Object.entries(extra)) {
+      if (value !== undefined && value !== null && value !== '') {
+        query.set(key, String(value));
+      }
+    }
+    return query.toString();
+  }
+
+  /** Accept an array OR a comma-separated string; return a clean string array. */
+  normalizeList(value) {
+    if (!value) return [];
+    if (Array.isArray(value)) {
+      return value.map((item) => String(item).trim()).filter(Boolean);
+    }
+    return String(value)
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+
+  /** Checkbox params arrive as boolean or the string "true". */
+  flag(value) {
+    return value === true || value === 'true';
+  }
+
+  /** Encode a path, preserving `/` separators (handles spaces & special chars in segments). */
+  encodePath(value) {
+    return String(value)
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/');
+  }
+
+  /** Parse a JSON object param that may arrive as a string or an object. */
+  parseMaybeJson(value, label) {
+    if (typeof value === 'object' && value !== null) return value;
+    try {
+      return JSON.parse(value);
+    } catch {
+      throw new Error(`"${label}" must be a valid JSON object`);
     }
   }
 }

--- a/backend/plugins/dev/github-plugin/manifest.json
+++ b/backend/plugins/dev/github-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "github-plugin",
-  "version": "1.0.0",
-  "description": "GitHub integration plugin for AGNT - Manage repositories, issues, pull requests, branches, and releases",
+  "version": "2.0.0",
+  "description": "GitHub integration plugin for AGNT - Full repository lifecycle: repos, branches, files, issues, comments, pull requests, reviews, releases, GitHub Actions/CI, and search",
   "author": "AGNT",
   "icon": "github",
   "tools": [
@@ -13,7 +13,7 @@
         "category": "action",
         "type": "github-api",
         "icon": "github",
-        "description": "Interact with GitHub to perform various operations on repositories, issues, pull requests, and more.",
+        "description": "Interact with GitHub: repos, branches, files, issues, comments, pull requests, reviews, releases, Actions/CI, and search.",
         "authRequired": "oauth",
         "authProvider": "github",
         "parameters": {
@@ -21,35 +21,68 @@
             "type": "string",
             "inputType": "select",
             "options": [
-              "CREATE_ISSUE",
-              "CREATE_PR",
+              "GET_AUTHENTICATED_USER",
               "GET_REPO_INFO",
+              "LIST_REPOS",
+              "CREATE_REPO",
+              "FORK_REPO",
+              "LIST_BRANCHES",
               "CREATE_BRANCH",
-              "MERGE_PR",
-              "LIST_PRS",
-              "GET_PR_CHANGES",
-              "ADD_LABELS",
-              "REMOVE_LABELS",
+              "DELETE_BRANCH",
               "GET_FILE_CONTENT",
               "GET_REPO_CONTENTS",
               "CREATE_FILE",
               "UPDATE_FILE",
+              "DELETE_FILE",
+              "CREATE_ISSUE",
+              "LIST_ISSUES",
+              "GET_ISSUE",
+              "UPDATE_ISSUE",
+              "COMMENT_ON_ISSUE",
+              "LIST_COMMENTS",
+              "ADD_LABELS",
+              "REMOVE_LABELS",
+              "CREATE_PR",
+              "LIST_PRS",
+              "GET_PR",
+              "UPDATE_PR",
+              "MERGE_PR",
+              "GET_PR_CHANGES",
+              "CREATE_PR_REVIEW",
+              "LIST_PR_REVIEWS",
+              "REQUEST_REVIEWERS",
+              "LIST_COMMITS",
+              "GET_COMMIT",
+              "COMPARE_COMMITS",
               "CREATE_RELEASE",
-              "LIST_COMMITS"
+              "LIST_RELEASES",
+              "GET_LATEST_RELEASE",
+              "UPLOAD_RELEASE_ASSET",
+              "LIST_WORKFLOWS",
+              "LIST_WORKFLOW_RUNS",
+              "GET_WORKFLOW_RUN",
+              "TRIGGER_WORKFLOW",
+              "RERUN_WORKFLOW",
+              "GET_CHECK_RUNS",
+              "SEARCH_ISSUES",
+              "SEARCH_CODE",
+              "SEARCH_REPOS"
             ],
             "description": "The action to perform on GitHub"
           },
           "owner": {
             "type": "string",
             "inputType": "text",
-            "description": "The owner of the repository",
-            "inputSize": "half"
+            "description": "The owner of the repository (not needed for account-level or search actions)",
+            "inputSize": "half",
+            "required": false
           },
           "repo": {
             "type": "string",
             "inputType": "text",
-            "description": "The name of the repository",
-            "inputSize": "half"
+            "description": "The name of the repository (for CREATE_REPO: the name of the new repository)",
+            "inputSize": "half",
+            "required": false
           },
           "title": {
             "type": "string",
@@ -57,42 +90,72 @@
             "description": "The title of the issue or pull request",
             "conditional": {
               "field": "action",
-              "value": ["CREATE_ISSUE", "CREATE_PR"]
+              "value": ["CREATE_ISSUE", "UPDATE_ISSUE", "CREATE_PR", "UPDATE_PR"]
             }
           },
           "body": {
             "type": "string",
             "inputType": "textarea",
-            "description": "The body of the issue or pull request",
+            "description": "The body text (issue/PR description, comment body, or review body)",
             "conditional": {
               "field": "action",
-              "value": ["CREATE_ISSUE", "CREATE_PR"]
+              "value": ["CREATE_ISSUE", "UPDATE_ISSUE", "CREATE_PR", "UPDATE_PR", "COMMENT_ON_ISSUE", "CREATE_PR_REVIEW"]
+            }
+          },
+          "issueNumber": {
+            "type": "string",
+            "inputType": "text",
+            "description": "The number of the issue (or PR, for comments/labels)",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": ["GET_ISSUE", "UPDATE_ISSUE", "COMMENT_ON_ISSUE", "LIST_COMMENTS", "ADD_LABELS", "REMOVE_LABELS"]
+            }
+          },
+          "pullNumber": {
+            "type": "string",
+            "inputType": "text",
+            "description": "The number of the pull request",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": ["GET_PR", "UPDATE_PR", "MERGE_PR", "GET_PR_CHANGES", "CREATE_PR_REVIEW", "LIST_PR_REVIEWS", "REQUEST_REVIEWERS"]
             }
           },
           "head": {
             "type": "string",
             "inputType": "text",
-            "description": "The name of the branch where your changes are implemented",
+            "description": "The branch with your changes (CREATE_PR) or the head ref (COMPARE_COMMITS)",
             "inputSize": "half",
             "conditional": {
               "field": "action",
-              "value": "CREATE_PR"
+              "value": ["CREATE_PR", "COMPARE_COMMITS"]
             }
           },
           "base": {
             "type": "string",
             "inputType": "text",
-            "description": "The name of the branch you want the changes pulled into",
+            "description": "The branch to merge into (CREATE_PR/UPDATE_PR) or the base ref (COMPARE_COMMITS)",
             "inputSize": "half",
             "conditional": {
               "field": "action",
-              "value": "CREATE_PR"
+              "value": ["CREATE_PR", "UPDATE_PR", "COMPARE_COMMITS"]
+            }
+          },
+          "draft": {
+            "type": "boolean",
+            "inputType": "checkbox",
+            "description": "Create as a draft (PR or release)",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": ["CREATE_PR", "CREATE_RELEASE"]
             }
           },
           "baseBranch": {
             "type": "string",
             "inputType": "text",
-            "description": "The name of the branch to create the new branch from",
+            "description": "The branch to create the new branch from",
             "inputSize": "half",
             "conditional": {
               "field": "action",
@@ -109,13 +172,14 @@
               "value": "CREATE_BRANCH"
             }
           },
-          "pullNumber": {
+          "branch": {
             "type": "string",
             "inputType": "text",
-            "description": "The number of the pull request",
+            "description": "The branch to operate on (defaults to the repository's default branch)",
+            "inputSize": "half",
             "conditional": {
               "field": "action",
-              "value": ["MERGE_PR", "GET_PR_CHANGES"]
+              "value": ["LIST_COMMITS", "CREATE_FILE", "UPDATE_FILE", "DELETE_FILE", "DELETE_BRANCH", "LIST_WORKFLOW_RUNS"]
             }
           },
           "mergeMethod": {
@@ -123,6 +187,17 @@
             "inputType": "select",
             "options": ["merge", "squash", "rebase"],
             "description": "The method to use when merging the pull request",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": "MERGE_PR"
+            }
+          },
+          "commitTitle": {
+            "type": "string",
+            "inputType": "text",
+            "description": "Optional title for the merge commit",
+            "inputSize": "half",
             "conditional": {
               "field": "action",
               "value": "MERGE_PR"
@@ -132,29 +207,68 @@
             "type": "string",
             "inputType": "select",
             "options": ["open", "closed", "all"],
-            "description": "The state of pull requests to list",
+            "description": "Filter by state",
+            "inputSize": "half",
             "conditional": {
               "field": "action",
-              "value": "LIST_PRS"
+              "value": ["LIST_PRS", "LIST_ISSUES"]
+            }
+          },
+          "issueState": {
+            "type": "string",
+            "inputType": "select",
+            "options": ["open", "closed"],
+            "description": "Set the state (use \"closed\" to close, \"open\" to reopen)",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": ["UPDATE_ISSUE", "UPDATE_PR"]
             }
           },
           "labels": {
-            "type": "array",
-            "items": { "type": "string" },
+            "type": "string",
             "inputType": "text",
-            "description": "The labels to add or remove (comma-separated)",
+            "description": "Labels, comma-separated (e.g. \"bug, urgent\")",
             "conditional": {
               "field": "action",
-              "value": ["ADD_LABELS", "REMOVE_LABELS"]
+              "value": ["ADD_LABELS", "REMOVE_LABELS", "CREATE_ISSUE", "UPDATE_ISSUE", "LIST_ISSUES"]
+            }
+          },
+          "assignees": {
+            "type": "string",
+            "inputType": "text",
+            "description": "Usernames to assign, comma-separated",
+            "conditional": {
+              "field": "action",
+              "value": ["CREATE_ISSUE", "UPDATE_ISSUE"]
+            }
+          },
+          "reviewers": {
+            "type": "string",
+            "inputType": "text",
+            "description": "Usernames to request reviews from, comma-separated",
+            "conditional": {
+              "field": "action",
+              "value": "REQUEST_REVIEWERS"
+            }
+          },
+          "reviewEvent": {
+            "type": "string",
+            "inputType": "select",
+            "options": ["APPROVE", "REQUEST_CHANGES", "COMMENT"],
+            "description": "The review action (body is required for REQUEST_CHANGES and COMMENT)",
+            "conditional": {
+              "field": "action",
+              "value": "CREATE_PR_REVIEW"
             }
           },
           "filePath": {
             "type": "string",
             "inputType": "text",
-            "description": "The path to the file",
+            "description": "The path to the file (or directory, for GET_REPO_CONTENTS)",
             "conditional": {
               "field": "action",
-              "value": ["GET_FILE_CONTENT", "CREATE_FILE", "UPDATE_FILE"]
+              "value": ["GET_FILE_CONTENT", "GET_REPO_CONTENTS", "CREATE_FILE", "UPDATE_FILE", "DELETE_FILE"]
             }
           },
           "content": {
@@ -172,13 +286,33 @@
             "description": "The commit message",
             "conditional": {
               "field": "action",
-              "value": ["CREATE_FILE", "UPDATE_FILE"]
+              "value": ["CREATE_FILE", "UPDATE_FILE", "DELETE_FILE"]
+            }
+          },
+          "ref": {
+            "type": "string",
+            "inputType": "text",
+            "description": "Git ref: branch name, tag, or commit SHA",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": ["GET_FILE_CONTENT", "GET_REPO_CONTENTS", "GET_COMMIT", "GET_CHECK_RUNS", "TRIGGER_WORKFLOW"]
+            }
+          },
+          "recursive": {
+            "type": "boolean",
+            "inputType": "checkbox",
+            "description": "List the entire repository tree recursively (metadata only, no file contents)",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": "GET_REPO_CONTENTS"
             }
           },
           "tagName": {
             "type": "string",
             "inputType": "text",
-            "description": "The name of the tag",
+            "description": "The name of the tag (e.g. v1.0.0)",
             "inputSize": "half",
             "conditional": {
               "field": "action",
@@ -188,7 +322,7 @@
           "releaseName": {
             "type": "string",
             "inputType": "text",
-            "description": "The name of the release",
+            "description": "The name of the release (defaults to the tag name)",
             "inputSize": "half",
             "conditional": {
               "field": "action",
@@ -198,19 +332,148 @@
           "releaseNotes": {
             "type": "string",
             "inputType": "textarea",
-            "description": "The release notes",
+            "description": "The release notes (markdown supported)",
             "conditional": {
               "field": "action",
               "value": "CREATE_RELEASE"
             }
           },
-          "branch": {
-            "type": "string",
-            "inputType": "text",
-            "description": "The branch to list commits from",
+          "prerelease": {
+            "type": "boolean",
+            "inputType": "checkbox",
+            "description": "Mark as a prerelease",
+            "inputSize": "half",
             "conditional": {
               "field": "action",
-              "value": "LIST_COMMITS"
+              "value": "CREATE_RELEASE"
+            }
+          },
+          "releaseId": {
+            "type": "string",
+            "inputType": "text",
+            "description": "The ID of the release (from CREATE_RELEASE or LIST_RELEASES)",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": "UPLOAD_RELEASE_ASSET"
+            }
+          },
+          "assetPath": {
+            "type": "string",
+            "inputType": "text",
+            "description": "Local file path of the asset to upload",
+            "conditional": {
+              "field": "action",
+              "value": "UPLOAD_RELEASE_ASSET"
+            }
+          },
+          "assetName": {
+            "type": "string",
+            "inputType": "text",
+            "description": "Display name for the asset (defaults to the file name)",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": "UPLOAD_RELEASE_ASSET"
+            }
+          },
+          "workflowId": {
+            "type": "string",
+            "inputType": "text",
+            "description": "The workflow ID or file name (e.g. ci.yml). Optional for LIST_WORKFLOW_RUNS.",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": ["TRIGGER_WORKFLOW", "LIST_WORKFLOW_RUNS"]
+            }
+          },
+          "runId": {
+            "type": "string",
+            "inputType": "text",
+            "description": "The ID of the workflow run",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": ["GET_WORKFLOW_RUN", "RERUN_WORKFLOW"]
+            }
+          },
+          "workflowInputs": {
+            "type": "string",
+            "inputType": "textarea",
+            "description": "JSON object of inputs to pass to the workflow (e.g. {\"env\": \"prod\"})",
+            "conditional": {
+              "field": "action",
+              "value": "TRIGGER_WORKFLOW"
+            }
+          },
+          "runStatus": {
+            "type": "string",
+            "inputType": "select",
+            "options": ["", "queued", "in_progress", "completed", "success", "failure"],
+            "description": "Filter workflow runs by status",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": "LIST_WORKFLOW_RUNS"
+            }
+          },
+          "query": {
+            "type": "string",
+            "inputType": "text",
+            "description": "Search query using GitHub search syntax (e.g. \"is:open label:bug repo:owner/name\")",
+            "conditional": {
+              "field": "action",
+              "value": ["SEARCH_ISSUES", "SEARCH_CODE", "SEARCH_REPOS"]
+            }
+          },
+          "visibility": {
+            "type": "string",
+            "inputType": "select",
+            "options": ["all", "public", "private"],
+            "description": "Filter repositories by visibility",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": "LIST_REPOS"
+            }
+          },
+          "private": {
+            "type": "boolean",
+            "inputType": "checkbox",
+            "description": "Create the repository as private",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": "CREATE_REPO"
+            }
+          },
+          "description": {
+            "type": "string",
+            "inputType": "text",
+            "description": "Description for the new repository",
+            "conditional": {
+              "field": "action",
+              "value": "CREATE_REPO"
+            }
+          },
+          "perPage": {
+            "type": "string",
+            "inputType": "text",
+            "description": "Results per page (default 30, max 100)",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": ["LIST_ISSUES", "LIST_COMMENTS", "LIST_PRS", "GET_PR_CHANGES", "LIST_PR_REVIEWS", "LIST_REPOS", "LIST_BRANCHES", "LIST_COMMITS", "LIST_RELEASES", "LIST_WORKFLOWS", "LIST_WORKFLOW_RUNS", "SEARCH_ISSUES", "SEARCH_CODE", "SEARCH_REPOS"]
+            }
+          },
+          "page": {
+            "type": "string",
+            "inputType": "text",
+            "description": "Page number (default 1)",
+            "inputSize": "half",
+            "conditional": {
+              "field": "action",
+              "value": ["LIST_ISSUES", "LIST_COMMENTS", "LIST_PRS", "GET_PR_CHANGES", "LIST_PR_REVIEWS", "LIST_REPOS", "LIST_BRANCHES", "LIST_COMMITS", "LIST_RELEASES", "LIST_WORKFLOWS", "LIST_WORKFLOW_RUNS", "SEARCH_ISSUES", "SEARCH_CODE", "SEARCH_REPOS"]
             }
           }
         },

--- a/backend/plugins/dev/github-plugin/package.json
+++ b/backend/plugins/dev/github-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-plugin",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "GitHub integration plugin for AGNT",
   "type": "module",
   "main": "github-api.js",

--- a/backend/plugins/marketplace.json
+++ b/backend/plugins/marketplace.json
@@ -426,18 +426,21 @@
       "name": "github-plugin",
       "displayName": "GitHub",
       "icon": "github",
-      "version": "1.0.0",
-      "description": "GitHub integration plugin for AGNT - Manage repositories, issues, pull requests, branches, and releases.",
+      "version": "2.0.0",
+      "description": "GitHub integration plugin for AGNT - Full repository lifecycle: repos, branches, files, issues, comments, pull requests, reviews, releases, GitHub Actions/CI, and search. 46 actions.",
       "author": "AGNT",
       "homepage": "https://github.com/agnt-gg/agnt",
       "downloadUrl": "file://marketplace-default/github-plugin.agnt",
-      "size": 800000,
+      "size": 10299,
       "tags": [
         "github",
         "git",
         "repository",
         "code",
-        "developer"
+        "developer",
+        "ci",
+        "issues",
+        "pull-requests"
       ],
       "category": "developer",
       "tools": [
@@ -445,7 +448,7 @@
           "type": "github-api",
           "schema": {
             "title": "GitHub API",
-            "description": "Interact with GitHub to perform various operations on repositories, issues, pull requests, and more."
+            "description": "Interact with GitHub: repos, branches, files, issues, comments, pull requests, reviews, releases, Actions/CI, and search."
           }
         }
       ]
@@ -867,7 +870,8 @@
         "utility"
       ],
       "category": "utility",
-      "tools": [        {
+      "tools": [
+        {
           "type": "list-files",
           "schema": {
             "title": "List Files in Directory",


### PR DESCRIPTION
## Summary

Rewrites the GitHub plugin from 15 write-lopsided actions to 46 agent-complete actions, all live-tested against real GitHub through the production tool pipeline.

### New capability areas
- **Issues**: list, get, update/close/reopen, comments (works on PRs too), label filters
- **Pull requests**: get (mergeable state), update/close, draft PRs, reviews (approve/request-changes/comment), request reviewers
- **Repos/branches**: list repos, create repo, fork, list/delete branches, delete file
- **Commits**: get single commit, compare refs
- **Releases**: list, latest, upload binary assets
- **Actions/CI**: list workflows, trigger `workflow_dispatch`, list/get runs (with jobs), check runs + combined status, rerun
- **Search**: issues, code, repos
- **Account**: authenticated user

### Structural fixes
- 204/empty-body responses no longer crash JSON parsing
- Per-action validation map replaces blanket owner/repo requirement (unblocks account-level actions)
- Pagination (`perPage`/`page`) on all 14 list endpoints
- `labels` accepts comma-separated strings or arrays
- Recursive repo contents now uses the git trees API (1 request, metadata only)
- Rate-limit detection with reset timestamp in error message

### Testing
46/46 actions verified live (repo lifecycle, PR review flow, CI dispatch → completed run, release asset upload, error paths).

🤖 Committed entirely via the github-api v2 plugin itself — branch, file commits, this PR, and the merge all went through the plugin as its final end-to-end test.