### PR TITLE
feat: desktop external backend and workflow crash-storm fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,35 @@ FRONTEND_URL=http://localhost:3333
 # Default: 3333
 PORT=3333
 
+# === DESKTOP HYBRID / EXTERNAL BACKEND =========================
+# Electron only. When enabled, the desktop app does NOT start a local
+# Express backend. It serves this package's UI on http://127.0.0.1:19333
+# and reverse-proxies /api + /socket.io to BACKEND_URL (remote needs API
+# + /api/health only — not the frontend). Prefer Settings → Connection;
+# env overrides the saved desktop-connection.json for this process.
+#
+# First launch on 127.0.0.1:19333 is a new browser origin — sign in once
+# even if you already logged in via http://SERVER:3333 in a normal browser.
+# Empty agents/chat until login does NOT mean the remote DB was wiped.
+#
+# USE_EXTERNAL_BACKEND=true
+# BACKEND_URL=http://192.168.1.50:3333
+# Optional fixed UI port (default 19333):
+# AGNT_UI_PORT=19333
+# ==============================================================
+
+# === DIAGNOSTICS / FATAL POLICY ================================
+# After uncaughtException / unhandledRejection:
+#   exit — dump once (deduped), then exit (supervisor/bridge can respawn)
+#   stay — dump once (deduped), keep running
+# Defaults: workflow workers = exit; backend = stay.
+# Benign EPIPE/broken-pipe errors never dump full crash JSON.
+# See docs/DIAGNOSTICS.md
+#
+# AGNT_FATAL_POLICY=exit
+# AGNT_FATAL_POLICY=stay
+# ==============================================================
+
 # SECURITY SECRETS
 # IMPORTANT: Generate new secure random values for production!
 # Generate with: openssl rand -base64 32 (for JWT_SECRET)

--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,8 @@ PORT=3333
 # BACKEND_URL=http://192.168.1.50:3333
 # Optional fixed UI port (default 19333):
 # AGNT_UI_PORT=19333
+# Self-signed HTTPS remotes only (default verifies TLS):
+# AGNT_PROXY_INSECURE_TLS=1
 # ==============================================================
 
 # === DIAGNOSTICS / FATAL POLICY ================================

--- a/README.md
+++ b/README.md
@@ -919,6 +919,8 @@ On startup, AGNT logs the resolved data path:
 | [🔨 Build Instructions](docs/_BUILD-INSTRUCTIONS.md)          | Detailed build guide.                      |
 | [🐧 GNU/Linux Build Guide](docs/_LINUX-BUILD-INSTRUCTIONS.md) | GNU/Linux-specific setup.                  |
 | [🐳 Self-Hosting Guide](docs/SELF_HOSTING.md)                 | Docker deployment and hosting.             |
+| [🔀 Hybrid Mode](docs/QUICKSTART_HYBRID.md)                   | Shared backend + Electron/browser clients. |
+| [🩺 Diagnostics & fatal policy](docs/DIAGNOSTICS.md)          | Crash dumps, EPIPE, `AGNT_FATAL_POLICY`.   |
 | [🪶 Docker Lite Mode](docs/LITE_MODE.md)                      | Docker without browser automation.         |
 | [🪶 Electron Lite Mode](docs/ELECTRON_LITE_MODE.md)           | Desktop builds without browser automation. |
 | [🔌 Plugin Development](backend/plugins/README.md)            | Creating custom plugins.                   |

--- a/backend/server.js
+++ b/backend/server.js
@@ -75,22 +75,52 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Server configuration
+// Static allowlist + loopback any-port. Electron hybrid desktop UI uses
+// reverse-proxy same-origin (no CORS needed for that path); loopback origins
+// still help Vite (5173) and any direct loopback tooling. Socket.IO shares this.
+const corsStaticOrigins = [
+  process.env.FRONTEND_DEV_URL,
+  process.env.FRONTEND_DIST_URL,
+  'http://127.0.0.1:5173',
+  'http://127.0.0.1:3333',
+  'http://127.0.0.1:33333',
+  'http://localhost:5173',
+  'http://localhost:3333',
+  'http://localhost:33333',
+  'https://agnt.gg',
+  'https://www.agnt.gg',
+  'https://alpha.agnt.gg',
+  'https://www.alpha.agnt.gg',
+].filter(Boolean);
+
+function isLoopbackOrigin(origin) {
+  if (!origin || typeof origin !== 'string') return false;
+  try {
+    const u = new URL(origin);
+    return (
+      (u.protocol === 'http:' || u.protocol === 'https:') &&
+      (u.hostname === '127.0.0.1' || u.hostname === 'localhost' || u.hostname === '[::1]')
+    );
+  } catch {
+    return false;
+  }
+}
+
 const config = {
   port: process.env.PORT || 3333,
   corsOptions: {
-    origin: [
-      process.env.FRONTEND_DEV_URL,
-      process.env.FRONTEND_DIST_URL,
-      'http://127.0.0.1:5173',
-      'http://127.0.0.1:3333',
-      'http://127.0.0.1:33333',
-      'http://localhost:3333',
-      'http://localhost:33333',
-      'https://agnt.gg',
-      'https://www.agnt.gg',
-      'https://alpha.agnt.gg',
-      'https://www.alpha.agnt.gg',
-    ],
+    origin(origin, callback) {
+      // Non-browser / same-origin tools often omit Origin
+      if (!origin) {
+        callback(null, true);
+        return;
+      }
+      if (corsStaticOrigins.includes(origin) || isLoopbackOrigin(origin)) {
+        callback(null, true);
+        return;
+      }
+      callback(null, false);
+    },
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
     credentials: true,

--- a/backend/src/diagnostics/bootstrap.js
+++ b/backend/src/diagnostics/bootstrap.js
@@ -10,13 +10,12 @@
  * WorkflowProcess.js is exactly one line each. Observability should not require
  * restructuring the thing it observes.
  *
- * NOTE ON FATAL POLICY — this ships as 'stay', which is byte-for-byte today's
- * behaviour: uncaught exceptions are logged and the process keeps running.
- * That is almost certainly wrong (a process in an undefined state should not
- * keep serving; the supervisor in main.js exists precisely to respawn it), but
- * flipping it changes restart semantics, and bundling a behaviour change into
- * an observability change is how you end up unable to tell which one broke
- * things. Set AGNT_FATAL_POLICY=exit to opt in.
+ * FATAL POLICY
+ *   - workflow workers default to **exit** after a real fatal (parent bridge
+ *     restarts them). 'stay' after EPIPE previously caused crash-file storms.
+ *   - backend still defaults to **stay** for compatibility with existing
+ *     deployments; set AGNT_FATAL_POLICY=exit to opt the backend into exit+respawn.
+ *   - AGNT_FATAL_POLICY=exit|stay always wins when set.
  */
 import PathManager from '../utils/PathManager.js';
 import { installDiagnostics } from './install.js';
@@ -24,11 +23,22 @@ import { installDiagnostics } from './install.js';
 const isWorkflow = process.env.IS_WORKFLOW_PROCESS === 'true';
 const proc = isWorkflow ? 'workflow' : 'backend';
 
-const fatalPolicy = process.env.AGNT_FATAL_POLICY === 'exit' ? 'exit' : 'stay';
+const envPolicy = process.env.AGNT_FATAL_POLICY;
+const fatalPolicy =
+  envPolicy === 'exit' || envPolicy === 'stay'
+    ? envPolicy
+    : isWorkflow
+      ? 'exit'
+      : 'stay';
 
 /** Cheap, high-signal state for crash records. Must never throw. */
 function getState() {
-  const state = { proc, argv1: process.argv[1] };
+  const state = {
+    proc,
+    argv1: process.argv[1],
+    connected: process.connected,
+    ppid: process.ppid,
+  };
   try {
     state.cwd = process.cwd();
   } catch {

--- a/backend/src/diagnostics/diagnostics.test.js
+++ b/backend/src/diagnostics/diagnostics.test.js
@@ -9,6 +9,11 @@ import { installConsoleBridge } from './consoleBridge.js';
 import { withContext } from './context.js';
 import { sweep, purgeLegacyLogs } from './retention.js';
 import { readRecords, readCrashes } from './read.js';
+import {
+  isBenignPipeError,
+  shouldDumpCrash,
+  _resetDiagnosticsInstallForTests,
+} from './install.js';
 
 let DIR;
 
@@ -29,6 +34,38 @@ beforeEach(() => {
 afterEach(() => {
   fs.rmSync(DIR, { recursive: true, force: true });
   vi.restoreAllMocks();
+  _resetDiagnosticsInstallForTests();
+});
+
+/* ------------------------------------------------------------------ *
+ * Fatal handling — EPIPE must not produce crash-file storms
+ * ------------------------------------------------------------------ */
+describe('fatal pipe / crash dedupe', () => {
+  it('treats EPIPE / broken pipe / destroyed stream as benign', () => {
+    expect(isBenignPipeError(Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))).toBe(true);
+    expect(isBenignPipeError(Object.assign(new Error('x'), { code: 'ERR_STREAM_DESTROYED' }))).toBe(true);
+    expect(isBenignPipeError(new Error('write broken pipe after parent exit'))).toBe(true);
+    expect(isBenignPipeError(new Error('something else blew up'))).toBe(false);
+    expect(isBenignPipeError(Object.assign(new Error('x'), { code: 'ENOENT' }))).toBe(false);
+  });
+
+  it('dedupes identical crash dumps within the window', () => {
+    _resetDiagnosticsInstallForTests();
+    const err = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+    // shouldDumpCrash is for non-benign dumps; use a real app error
+    const boom = new Error('kaboom');
+    expect(shouldDumpCrash('uncaughtException', boom, 1000)).toBe(true);
+    expect(shouldDumpCrash('uncaughtException', boom, 2000)).toBe(false);
+    expect(shouldDumpCrash('uncaughtException', boom, 3000)).toBe(false);
+    // After window elapses, dump again
+    expect(shouldDumpCrash('uncaughtException', boom, 1000 + 60_000 + 1)).toBe(true);
+  });
+
+  it('does not dedupe different errors', () => {
+    _resetDiagnosticsInstallForTests();
+    expect(shouldDumpCrash('uncaughtException', new Error('a'), 1)).toBe(true);
+    expect(shouldDumpCrash('uncaughtException', new Error('b'), 2)).toBe(true);
+  });
 });
 
 /* ------------------------------------------------------------------ *

--- a/backend/src/diagnostics/install.js
+++ b/backend/src/diagnostics/install.js
@@ -5,12 +5,13 @@
  * bridge, process-level fatal handlers, and a final flush on exit.
  *
  * `fatalPolicy` differs by process on purpose:
- *   backend  — 'exit': a process in an undefined state must not keep serving.
- *              The supervisor in main.js respawns it. Today this is 'stay',
- *              which produces a zombie backend that looks alive and isn't.
- *   workflow — 'stay': the parent bridge owns restart, and an in-flight
- *              workflow is often still salvageable.
+ *   backend  — default 'stay' for compatibility (opt into exit via AGNT_FATAL_POLICY).
+ *   workflow — default 'exit' after one real fatal: parent bridge restarts the worker.
+ *              'stay' after EPIPE previously produced crash-file storms.
  *   main     — 'stay': quitting is decided by Electron lifecycle code.
+ *
+ * Benign pipe/stream errors (EPIPE after parent closes stdout/IPC) do NOT dump
+ * full crash JSON and do not keep the process alive to re-throw.
  */
 import path from 'path';
 import { randomUUID } from 'crypto';
@@ -18,6 +19,75 @@ import { Recorder } from './Recorder.js';
 import { installConsoleBridge } from './consoleBridge.js';
 
 let installed = null;
+
+/** @type {{ key: string, at: number, count: number } | null} */
+let lastCrashDedupe = null;
+
+const DEDUPE_WINDOW_MS = 60_000;
+
+/**
+ * Errors that mean "the other end of stdout/stderr/IPC is gone" — not app bugs.
+ * Dumping a 500KB crash per throw + stay = crash-file storms on workers.
+ */
+export function isBenignPipeError(err) {
+  if (!err) return false;
+  const code = err.code || err.errno;
+  if (code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED' || code === 'EIO') return true;
+  const msg = String(err.message || err);
+  // Node sometimes surfaces only the message for broken pipes
+  if (/broken pipe/i.test(msg) || /EPIPE/i.test(msg)) return true;
+  return false;
+}
+
+function crashDedupeKey(reason, err) {
+  return `${reason}|${err?.code || ''}|${String(err?.message || '').slice(0, 200)}`;
+}
+
+/**
+ * @returns {boolean} true if this crash should be dumped (first in window)
+ */
+export function shouldDumpCrash(reason, err, now = Date.now()) {
+  const key = crashDedupeKey(reason, err);
+  if (lastCrashDedupe && lastCrashDedupe.key === key && now - lastCrashDedupe.at < DEDUPE_WINDOW_MS) {
+    lastCrashDedupe.count += 1;
+    return false;
+  }
+  lastCrashDedupe = { key, at: now, count: 1 };
+  return true;
+}
+
+/** Test helper — reset module state between tests. */
+export function _resetDiagnosticsInstallForTests() {
+  if (installed) {
+    try {
+      installed.uninstall();
+    } catch {
+      /* ignore */
+    }
+  }
+  installed = null;
+  lastCrashDedupe = null;
+}
+
+function attachStdioPipeGuards() {
+  const swallowPipe = (stream) => {
+    if (!stream || typeof stream.on !== 'function') return;
+    // Avoid stacking handlers if install is somehow re-entered after reset
+    if (stream.__agntPipeGuard) return;
+    stream.__agntPipeGuard = true;
+    stream.on('error', (err) => {
+      if (isBenignPipeError(err)) return;
+      // Non-pipe stream errors: leave a breadcrumb; don't rethrow.
+      try {
+        process.stderr.write(`[diagnostics] stdio error: ${err?.message || err}\n`);
+      } catch {
+        /* ignore */
+      }
+    });
+  };
+  swallowPipe(process.stdout);
+  swallowPipe(process.stderr);
+}
 
 /**
  * @param {object}   opts
@@ -46,6 +116,8 @@ export function installDiagnostics({
   const recorder = new Recorder({ dir, proc, bootId: resolvedBoot, level });
   const uninstallBridge = bridgeConsole ? installConsoleBridge(recorder) : () => {};
 
+  attachStdioPipeGuards();
+
   const safeState = () => {
     try {
       return getState() || {};
@@ -54,16 +126,69 @@ export function installDiagnostics({
     }
   };
 
+  const quietExit = (code = 0) => {
+    try {
+      recorder.close();
+    } catch {
+      /* ignore */
+    }
+    process.exitCode = code;
+    setTimeout(() => process.exit(code), 50).unref?.();
+  };
+
   const onFatal = (reason) => (errOrReason) => {
     const err = errOrReason instanceof Error ? errOrReason : new Error(String(errOrReason));
+
+    // Parent closed the pipe / IPC — common when Electron or the bridge shuts down.
+    // Do not write multi-hundred-KB crash dumps; do not stay alive to rethrow.
+    if (isBenignPipeError(err)) {
+      try {
+        process.stderr.write(
+          `[diagnostics] ${proc} ${reason}: benign pipe/stream error (${err.code || err.message}) — not dumping crash\n`
+        );
+      } catch {
+        /* stderr may be the broken pipe */
+      }
+      // Workflow workers (and any disconnected child) should exit so the parent can restart.
+      const isChild = process.env.IS_WORKFLOW_PROCESS === 'true' || typeof process.send === 'function';
+      if (isChild && !process.connected) {
+        quietExit(0);
+        return;
+      }
+      if (isChild && process.env.IS_WORKFLOW_PROCESS === 'true') {
+        // Even if connected flag races, EPIPE on stdout almost always means parent is gone.
+        quietExit(0);
+        return;
+      }
+      return;
+    }
+
+    if (!shouldDumpCrash(reason, err)) {
+      const n = lastCrashDedupe?.count || 0;
+      try {
+        process.stderr.write(
+          `[diagnostics] ${proc} ${reason}: suppressed duplicate crash dump (×${n} in ${DEDUPE_WINDOW_MS / 1000}s): ${err.message}\n`
+        );
+      } catch {
+        /* ignore */
+      }
+      // Still honor exit policy so we don't spin forever
+      if (fatalPolicy === 'exit') {
+        quietExit(1);
+      }
+      return;
+    }
+
     const file = recorder.dumpCrash(reason, err, safeState());
     // Bypass the bridge so this reaches the terminal even mid-teardown.
-    process.stderr.write(`[diagnostics] ${proc} ${reason}: ${err.message}\n  crash record: ${file}\n`);
+    try {
+      process.stderr.write(`[diagnostics] ${proc} ${reason}: ${err.message}\n  crash record: ${file}\n`);
+    } catch {
+      /* ignore */
+    }
 
     if (fatalPolicy === 'exit') {
-      recorder.close();
-      process.exitCode = 1;
-      setTimeout(() => process.exit(1), 250).unref?.();
+      quietExit(1);
     }
   };
 
@@ -82,6 +207,7 @@ export function installDiagnostics({
     recorder,
     bootId: resolvedBoot,
     dir,
+    fatalPolicy,
     uninstall() {
       uninstallBridge();
       process.off('uncaughtException', handlers.uncaughtException);

--- a/backend/src/workflow/WorkflowProcess.js
+++ b/backend/src/workflow/WorkflowProcess.js
@@ -37,6 +37,13 @@ function safeSend(message) {
     process.send(message);
     return true;
   } catch (err) {
+    // EPIPE / closed channel — parent is gone; exit so we don't keep throwing.
+    const code = err?.code;
+    if (code === 'EPIPE' || code === 'ERR_IPC_CHANNEL_CLOSED' || /broken pipe/i.test(err?.message || '')) {
+      console.warn('[WorkflowProcess] IPC channel closed — exiting worker');
+      setTimeout(() => process.exit(0), 10).unref?.();
+      return false;
+    }
     console.warn('[WorkflowProcess] IPC send failed:', err.message);
     return false;
   }
@@ -265,17 +272,10 @@ ProcessManager.on('workflowStatusUpdate', (workflowId, statusData) => {
   });
 });
 
-// Handle uncaught exceptions
-process.on('uncaughtException', (error) => {
-  console.error('Uncaught Exception in workflow process:', error);
-  // Don't exit - let the parent process handle restart if needed
-});
-
-// Handle unhandled promise rejections
-process.on('unhandledRejection', (reason, promise) => {
-  console.error('Unhandled Rejection in workflow process at:', promise, 'reason:', reason);
-  // Don't exit - let the parent process handle restart if needed
-});
+// Fatal handling (uncaughtException / unhandledRejection) is owned by
+// diagnostics/bootstrap.js: EPIPE is treated as benign, crash dumps are
+// deduped, and workflow workers exit so WorkflowProcessBridge can restart.
+// Do not register a second "stay alive" handler here — that caused crash storms.
 
 // Memory monitoring
 setInterval(() => {

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -1,0 +1,85 @@
+# Diagnostics & Fatal Policy
+
+AGNT writes process diagnostics (JSONL logs + crash dumps) under the data root:
+
+| Run mode | Typical path |
+|----------|----------------|
+| Electron (macOS) | `~/Library/Application Support/AGNT/diagnostics/` |
+| Electron (Windows) | `%APPDATA%\AGNT\diagnostics\` |
+| Electron (Linux) | `~/.config/AGNT/diagnostics/` |
+| Docker / `AGNT_HOME` | `$AGNT_HOME/.agnt/data/diagnostics/` or PathManager root |
+
+Crash records land in `diagnostics/crashes/*.json` (ring buffer + system snapshot).
+
+## Fatal policy (`AGNT_FATAL_POLICY`)
+
+Controls what happens after `uncaughtException` / `unhandledRejection` once a crash is recorded:
+
+| Value | Behavior |
+|-------|----------|
+| **`exit`** | Dump (if not deduped), then exit with code 1 so a supervisor can respawn |
+| **`stay`** | Dump (if not deduped), keep running |
+
+### Defaults
+
+| Process | Default | Why |
+|---------|---------|-----|
+| **Workflow worker** (`IS_WORKFLOW_PROCESS=true`) | **`exit`** | Parent `WorkflowProcessBridge` restarts the child. Staying alive after a broken pipe used to storm crash files. |
+| **Backend** (Express) | **`stay`** | Compatibility; set `AGNT_FATAL_POLICY=exit` if you want hard fail + Electron supervisor respawn. |
+| **Electron main** | installed separately with **`stay`** | Exit is owned by Electron lifecycle. |
+
+Override always wins when set:
+
+```bash
+# Force exit after fatals (backend + workers)
+AGNT_FATAL_POLICY=exit
+
+# Force stay (not recommended for workflow workers)
+AGNT_FATAL_POLICY=stay
+```
+
+## Broken pipe (EPIPE) handling
+
+When a **parent process closes stdout/stderr/IPC**, child writes can throw:
+
+- `EPIPE` / “broken pipe”
+- `ERR_STREAM_DESTROYED`
+- some `EIO` cases
+
+These are treated as **benign**:
+
+- **No** multi-hundred-KB crash dump
+- Workflow workers **exit cleanly** so the bridge can restart
+- stdout/stderr have error guards so closed pipes don’t become uncaughtException storms
+
+Real application bugs still dump (once) and follow `fatalPolicy`.
+
+## Crash dump dedupe
+
+Identical fatals (same reason + code + message) within **60 seconds** write **one** crash file. Further occurrences log a short “suppressed duplicate” line to stderr instead of filling disk.
+
+## Cleaning up after a storm
+
+If an older build already wrote many crash files:
+
+```bash
+# macOS Electron example
+rm -rf ~/Library/Application\ Support/AGNT/diagnostics/crashes/*
+
+# Docker / AGNT_HOME example
+rm -rf "${AGNT_HOME:-$HOME}/.agnt/data/diagnostics/crashes/"*
+```
+
+Leave `diagnostics/` itself (JSONL logs may still be useful).
+
+## Related code
+
+- `backend/src/diagnostics/install.js` — handlers, EPIPE, dedupe  
+- `backend/src/diagnostics/bootstrap.js` — backend/workflow defaults  
+- `backend/src/workflow/WorkflowProcess.js` — IPC EPIPE → clean exit  
+- Tests: `backend/src/diagnostics/diagnostics.test.js`  
+
+## See also
+
+- Hybrid desktop remote backend: [QUICKSTART_HYBRID.md](QUICKSTART_HYBRID.md)  
+- Self-hosting: [SELF_HOSTING.md](SELF_HOSTING.md)  

--- a/docs/QUICKSTART_HYBRID.md
+++ b/docs/QUICKSTART_HYBRID.md
@@ -79,7 +79,7 @@ http://your-domain.com:3333
 > Env wins for that process over the saved file (`desktop-connection.json` in app data).  
 > If the remote is unreachable at launch, the app opens a **connection setup** screen so you can fix the URL, switch back to local, or retry—without deleting config by hand.  
 >  
-> **UI vs API:** In external mode the desktop app serves **its own packaged frontend** on a fixed local origin (`http://127.0.0.1:19333`) and **reverse-proxies** `/api` + `/socket.io` to `BACKEND_URL`. That keeps Settings → Connection in *this* build, same-origin auth/localStorage, and works with older remotes (no CORS setup required).  
+> **UI vs API:** In external mode the desktop app serves **its own packaged frontend** on a fixed local origin (`http://127.0.0.1:19333`) and **reverse-proxies** `/api` + `/socket.io` to `BACKEND_URL`. That keeps Settings → Connection in *this* build, same-origin auth/localStorage, and works with older remotes (no CORS setup required). HTTPS remotes verify TLS by default; self-signed LAN certs need `AGNT_PROXY_INSECURE_TLS=1`.  
 >  
 > **Sign-in / empty agents:** `http://127.0.0.1:19333` is a **new browser origin**. A token saved for `http://SERVER:3333` in Safari/Chrome is **not** reused. Sign in once in the desktop app (banner explains this). Empty agents/chat until then does **not** mean the remote database was wiped. Use **Settings → Connection** from the banner if the remote URL is wrong.
 

--- a/docs/QUICKSTART_HYBRID.md
+++ b/docs/QUICKSTART_HYBRID.md
@@ -72,14 +72,21 @@ http://your-domain.com:3333
 
 #### Access Method 2: Native Desktop App (Optional)
 
+> **Desktop connection (Settings or env)**  
+> Point Electron at the Docker/server backend with either:
+> - **In-app:** Settings → Configuration → **Connection** (toggle external backend, set URL, Test, Save, Restart), or  
+> - **Env / launch:** `USE_EXTERNAL_BACKEND=true BACKEND_URL=http://SERVER_IP:3333`  
+> Env wins for that process over the saved file (`desktop-connection.json` in app data).  
+> If the remote is unreachable at launch, the app opens a **connection setup** screen so you can fix the URL, switch back to local, or retry—without deleting config by hand.  
+>  
+> **UI vs API:** In external mode the desktop app serves **its own packaged frontend** on a fixed local origin (`http://127.0.0.1:19333`) and **reverse-proxies** `/api` + `/socket.io` to `BACKEND_URL`. That keeps Settings → Connection in *this* build, same-origin auth/localStorage, and works with older remotes (no CORS setup required).  
+>  
+> **Sign-in / empty agents:** `http://127.0.0.1:19333` is a **new browser origin**. A token saved for `http://SERVER:3333` in Safari/Chrome is **not** reused. Sign in once in the desktop app (banner explains this). Empty agents/chat until then does **not** mean the remote database was wiped. Use **Settings → Connection** from the banner if the remote URL is wrong.
+
 **Option A: Use Electron Full** (~348MB AppImage)
 1. Download from [agnt.gg/downloads](https://agnt.gg/downloads)
 2. Install on user's desktop
-3. Configure to use external backend:
-   ```bash
-   USE_EXTERNAL_BACKEND=true
-   BACKEND_URL=http://SERVER_IP:3333
-   ```
+3. Configure to use external backend (Settings → Connection, or env above)
 4. Launch AGNT
 
 **Option B: Use Electron Lite** (~344MB AppImage)
@@ -309,6 +316,23 @@ docker-compose restart
 BACKEND_URL=http://SERVER_IP:3333  # Good
 BACKEND_URL=http://localhost:3333  # Bad (points to client)
 ```
+
+If the remote is down at launch, AGNT shows a **connection setup** window (fix URL, switch to local, test, save & restart). You can also open Settings → Connection after a successful local boot (and while signed out via the external-mode banner).
+
+### Signed in to the server in a browser, but desktop shows empty agents
+
+**Cause:** External mode UI origin is `http://127.0.0.1:19333`, not `http://SERVER:3333`. Login tokens are per-origin.
+
+**Fix:**
+1. Confirm Settings → Connection points at the correct `BACKEND_URL` and Test succeeds.
+2. Sign in again inside the desktop app (same account as on the server).
+3. Agents/chat should load from the remote DB.
+
+### Crash files filling `diagnostics/crashes` (workflow worker / EPIPE)
+
+Older builds could dump a large crash JSON on every **broken pipe** while the worker stayed alive. Current builds treat EPIPE as benign, dedupe dumps, and exit workflow workers so the parent restarts them.
+
+See **[DIAGNOSTICS.md](DIAGNOSTICS.md)** (`AGNT_FATAL_POLICY`, cleanup commands).
 
 ### Different users see different data
 

--- a/docs/QUICKSTART_INDEX.md
+++ b/docs/QUICKSTART_INDEX.md
@@ -24,6 +24,12 @@ Choose your installation method and get AGNT running in under 5 minutes.
 |-------|------------|----------|
 | **[Hybrid Mode](QUICKSTART_HYBRID.md)** | Docker + Electron + Web | Mix native apps + browser + shared backend |
 
+### 🔧 Ops & internals
+
+| Guide | Best For |
+|-------|----------|
+| **[Diagnostics & fatal policy](DIAGNOSTICS.md)** | Crash dumps, EPIPE, `AGNT_FATAL_POLICY`, log locations |
+
 ---
 
 ## 🤔 Which Guide Should I Use?

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -832,6 +832,10 @@ docker run --rm \
 
 ## Troubleshooting
 
+### Crash dumps / diagnostics filling disk
+
+See **[DIAGNOSTICS.md](DIAGNOSTICS.md)** for locations, `AGNT_FATAL_POLICY`, EPIPE handling, and how to clear `diagnostics/crashes/`.
+
 ### Container Won't Start
 
 Check logs:

--- a/electron/connection-config.js
+++ b/electron/connection-config.js
@@ -195,8 +195,13 @@ export function probeBackendHealth(backendUrl, timeoutMs = 8000) {
         path: target.pathname + target.search,
         method: 'GET',
         timeout: timeoutMs,
-        // Self-hosted LAN certs are common; health probe is not security-critical.
-        rejectUnauthorized: false,
+        // Verify TLS by default. LAN self-signed: AGNT_PROXY_INSECURE_TLS=1
+        rejectUnauthorized: !(
+          process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0' ||
+          process.env.AGNT_PROXY_INSECURE_TLS === '1' ||
+          process.env.AGNT_PROXY_INSECURE_TLS === 'true' ||
+          process.env.AGNT_PROXY_INSECURE_TLS === 'yes'
+        ),
       },
       (res) => {
         res.resume();

--- a/electron/connection-config.js
+++ b/electron/connection-config.js
@@ -1,0 +1,262 @@
+/**
+ * Desktop connection config for hybrid / external-backend mode.
+ *
+ * Resolution order (highest wins):
+ *   1. process.env.USE_EXTERNAL_BACKEND / process.env.BACKEND_URL (session override)
+ *   2. userData/desktop-connection.json (Settings UI, survives restarts)
+ *   3. Defaults: local backend on PORT||3333
+ *
+ * When useExternalBackend is true, Electron skips forking the local Express
+ * server, serves this package's frontend on loopback (default :19333), and
+ * reverse-proxies /api + /socket.io to BACKEND_URL. The remote host only needs
+ * the AGNT API (and /api/health) — it does not need to serve the UI.
+ */
+import fs from 'fs';
+import path from 'path';
+import http from 'http';
+import https from 'https';
+
+const CONFIG_FILENAME = 'desktop-connection.json';
+
+/**
+ * @param {string} userDataPath - Electron app.getPath('userData')
+ * @returns {string}
+ */
+export function connectionConfigPath(userDataPath) {
+  return path.join(userDataPath, CONFIG_FILENAME);
+}
+
+/**
+ * @param {string} userDataPath
+ * @returns {{ useExternalBackend: boolean, backendUrl: string }}
+ */
+export function readStoredConnectionConfig(userDataPath) {
+  const filePath = connectionConfigPath(userDataPath);
+  try {
+    if (!fs.existsSync(filePath)) {
+      return { useExternalBackend: false, backendUrl: '' };
+    }
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    return {
+      useExternalBackend: Boolean(raw.useExternalBackend),
+      backendUrl: typeof raw.backendUrl === 'string' ? raw.backendUrl.trim() : '',
+    };
+  } catch (err) {
+    console.warn('[connection] Failed to read desktop-connection.json:', err.message);
+    return { useExternalBackend: false, backendUrl: '' };
+  }
+}
+
+/**
+ * Persist connection settings (does not apply env overrides).
+ * @param {string} userDataPath
+ * @param {{ useExternalBackend: boolean, backendUrl: string }} config
+ */
+export function writeStoredConnectionConfig(userDataPath, config) {
+  const filePath = connectionConfigPath(userDataPath);
+  const payload = {
+    useExternalBackend: Boolean(config.useExternalBackend),
+    backendUrl: typeof config.backendUrl === 'string' ? config.backendUrl.trim().replace(/\/+$/, '') : '',
+  };
+  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), 'utf8');
+  return payload;
+}
+
+/**
+ * Normalize a backend base URL (no trailing slash, no /api suffix).
+ * @param {string} url
+ * @returns {string}
+ */
+export function normalizeBackendUrl(url) {
+  if (!url || typeof url !== 'string') return '';
+  let cleaned = url.trim().replace(/\/+$/, '');
+  if (cleaned.endsWith('/api')) {
+    cleaned = cleaned.slice(0, -4).replace(/\/+$/, '');
+  }
+  return cleaned;
+}
+
+/**
+ * Validate that a string is an absolute http(s) URL.
+ * @param {string} url
+ * @returns {{ ok: boolean, error?: string, parsed?: URL }}
+ */
+export function validateBackendUrl(url) {
+  const cleaned = normalizeBackendUrl(url);
+  if (!cleaned) {
+    return { ok: false, error: 'Backend URL is required when using an external backend.' };
+  }
+  let parsed;
+  try {
+    parsed = new URL(cleaned);
+  } catch {
+    return { ok: false, error: 'Backend URL is not a valid URL.' };
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, error: 'Backend URL must use http:// or https://' };
+  }
+  return { ok: true, parsed, cleaned };
+}
+
+/**
+ * Resolve effective connection mode for this app session.
+ * @param {object} opts
+ * @param {string} opts.userDataPath
+ * @param {NodeJS.ProcessEnv} [opts.env]
+ * @returns {{
+ *   useExternalBackend: boolean,
+ *   backendUrl: string,
+ *   loadUrl: string,
+ *   healthUrl: string,
+ *   source: 'env' | 'file' | 'default',
+ *   envOverrides: boolean,
+ *   stored: { useExternalBackend: boolean, backendUrl: string },
+ * }}
+ */
+export function resolveConnectionConfig({ userDataPath, env = process.env }) {
+  const stored = readStoredConnectionConfig(userDataPath);
+  const defaultPort = env.PORT || '3333';
+  const defaultLocal = `http://127.0.0.1:${defaultPort}`;
+
+  const envHasExternal = env.USE_EXTERNAL_BACKEND !== undefined && env.USE_EXTERNAL_BACKEND !== '';
+  const envExternal =
+    env.USE_EXTERNAL_BACKEND === 'true' ||
+    env.USE_EXTERNAL_BACKEND === '1' ||
+    env.USE_EXTERNAL_BACKEND === 'yes';
+  const envUrl = typeof env.BACKEND_URL === 'string' ? env.BACKEND_URL.trim() : '';
+
+  let useExternalBackend;
+  let backendUrl;
+  let source;
+
+  if (envHasExternal || envUrl) {
+    // Env wins for this process so docs / launch scripts keep working.
+    useExternalBackend = envHasExternal ? envExternal : Boolean(stored.useExternalBackend) || Boolean(envUrl);
+    backendUrl = normalizeBackendUrl(envUrl || stored.backendUrl || defaultLocal);
+    source = 'env';
+  } else if (stored.useExternalBackend || stored.backendUrl) {
+    useExternalBackend = Boolean(stored.useExternalBackend);
+    backendUrl = normalizeBackendUrl(stored.backendUrl || defaultLocal);
+    source = 'file';
+  } else {
+    useExternalBackend = false;
+    backendUrl = defaultLocal;
+    source = 'default';
+  }
+
+  if (useExternalBackend) {
+    const check = validateBackendUrl(backendUrl);
+    if (!check.ok) {
+      console.warn('[connection] Invalid external BACKEND_URL, falling back to local:', check.error);
+      useExternalBackend = false;
+      backendUrl = defaultLocal;
+      source = 'default';
+    } else {
+      backendUrl = check.cleaned;
+    }
+  } else {
+    backendUrl = defaultLocal;
+  }
+
+  return {
+    useExternalBackend,
+    backendUrl,
+    loadUrl: backendUrl,
+    healthUrl: `${backendUrl}/api/health`,
+    source,
+    envOverrides: source === 'env',
+    stored,
+  };
+}
+
+/**
+ * One-shot health check against a backend base URL.
+ * @param {string} backendUrl
+ * @param {number} [timeoutMs]
+ * @returns {Promise<{ ok: boolean, status?: number, error?: string, latencyMs?: number }>}
+ */
+export function probeBackendHealth(backendUrl, timeoutMs = 8000) {
+  return new Promise((resolve) => {
+    const check = validateBackendUrl(backendUrl);
+    if (!check.ok) {
+      resolve({ ok: false, error: check.error });
+      return;
+    }
+
+    const target = new URL('/api/health', check.cleaned);
+    const lib = target.protocol === 'https:' ? https : http;
+    const started = Date.now();
+
+    const req = lib.request(
+      {
+        protocol: target.protocol,
+        hostname: target.hostname,
+        port: target.port || (target.protocol === 'https:' ? 443 : 80),
+        path: target.pathname + target.search,
+        method: 'GET',
+        timeout: timeoutMs,
+        // Self-hosted LAN certs are common; health probe is not security-critical.
+        rejectUnauthorized: false,
+      },
+      (res) => {
+        res.resume();
+        const latencyMs = Date.now() - started;
+        if (res.statusCode === 200) {
+          resolve({ ok: true, status: res.statusCode, latencyMs });
+        } else {
+          resolve({ ok: false, status: res.statusCode, error: `Health returned HTTP ${res.statusCode}`, latencyMs });
+        }
+      }
+    );
+
+    req.on('error', (err) => {
+      resolve({ ok: false, error: err.message, latencyMs: Date.now() - started });
+    });
+    req.on('timeout', () => {
+      req.destroy();
+      resolve({ ok: false, error: 'Connection timed out', latencyMs: Date.now() - started });
+    });
+    req.end();
+  });
+}
+
+/**
+ * Poll probeBackendHealth until success or maxAttempts.
+ * Single health primitive used by boot, activate, and tests.
+ *
+ * @param {string} backendUrl base URL (not .../api/health)
+ * @param {object} [opts]
+ * @param {number} [opts.maxAttempts] default Infinity
+ * @param {number} [opts.intervalMs] delay between attempts
+ * @param {number} [opts.requestTimeoutMs] per-probe timeout
+ * @param {(attempt: number, backendUrl: string, last: object) => void} [opts.onAttempt]
+ * @returns {Promise<{ ok: boolean, attempts: number, status?: number, error?: string, latencyMs?: number }>}
+ */
+export async function waitUntilHealthy(backendUrl, opts = {}) {
+  const maxAttempts = opts.maxAttempts ?? Infinity;
+  const intervalMs = opts.intervalMs ?? 250;
+  const requestTimeoutMs = opts.requestTimeoutMs ?? 30000;
+  let attempt = 0;
+  let last = { ok: false, error: 'not started' };
+
+  while (attempt < maxAttempts) {
+    attempt += 1;
+    last = await probeBackendHealth(backendUrl, requestTimeoutMs);
+    if (typeof opts.onAttempt === 'function') {
+      opts.onAttempt(attempt, backendUrl, last);
+    }
+    if (last.ok) {
+      return { ...last, attempts: attempt };
+    }
+    if (attempt >= maxAttempts) break;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+
+  return {
+    ok: false,
+    attempts: attempt,
+    status: last.status,
+    error: last.error,
+    latencyMs: last.latencyMs,
+  };
+}

--- a/electron/connection-setup.html
+++ b/electron/connection-setup.html
@@ -1,0 +1,391 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AGNT — Connection Setup</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #070710;
+        --panel: rgba(18, 22, 40, 0.95);
+        --border: rgba(80, 120, 200, 0.28);
+        --text: #e8ecf8;
+        --muted: #9aa3bd;
+        --primary: #5b9dff;
+        --primary-rgb: 91, 157, 255;
+        --danger: #ff7b7b;
+        --ok: #3dd68c;
+        --warn: #ffc400;
+        font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(1200px 600px at 20% -10%, rgba(var(--primary-rgb), 0.18), transparent),
+          radial-gradient(900px 500px at 100% 0%, rgba(120, 80, 255, 0.12), transparent), var(--bg);
+        color: var(--text);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+      }
+      .card {
+        width: min(560px, 100%);
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 28px;
+        box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+      }
+      .eyebrow {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        color: var(--primary);
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        font-weight: 600;
+        margin-bottom: 10px;
+      }
+      h1 {
+        margin: 0 0 8px;
+        font-size: 1.45rem;
+        font-weight: 650;
+      }
+      .lead {
+        margin: 0 0 20px;
+        color: var(--muted);
+        line-height: 1.45;
+        font-size: 0.95rem;
+      }
+      .error-box {
+        display: none;
+        margin-bottom: 18px;
+        padding: 12px 14px;
+        border-radius: 10px;
+        border: 1px solid rgba(255, 123, 123, 0.4);
+        background: rgba(255, 123, 123, 0.08);
+        color: #ffc9c9;
+        font-size: 0.9rem;
+        line-height: 1.4;
+        word-break: break-word;
+      }
+      .error-box.show {
+        display: block;
+      }
+      label {
+        display: block;
+        font-size: 0.85rem;
+        font-weight: 600;
+        margin-bottom: 6px;
+      }
+      .field {
+        margin-bottom: 16px;
+      }
+      .toggle-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        padding: 14px;
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        background: rgba(var(--primary-rgb), 0.06);
+        margin-bottom: 16px;
+      }
+      .toggle-row p {
+        margin: 4px 0 0;
+        color: var(--muted);
+        font-size: 0.82rem;
+        line-height: 1.35;
+      }
+      input[type='url'],
+      input[type='text'] {
+        width: 100%;
+        padding: 11px 12px;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        background: rgba(0, 0, 0, 0.28);
+        color: var(--text);
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-size: 0.9rem;
+      }
+      input:focus {
+        outline: none;
+        border-color: var(--primary);
+        box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.2);
+      }
+      input:disabled {
+        opacity: 0.5;
+      }
+      .switch {
+        position: relative;
+        width: 48px;
+        height: 26px;
+        flex-shrink: 0;
+      }
+      .switch input {
+        opacity: 0;
+        width: 0;
+        height: 0;
+      }
+      .slider {
+        position: absolute;
+        inset: 0;
+        cursor: pointer;
+        background: rgba(127, 129, 147, 0.35);
+        border-radius: 26px;
+        border: 1px solid var(--border);
+        transition: 0.2s;
+      }
+      .slider:before {
+        content: '';
+        position: absolute;
+        height: 18px;
+        width: 18px;
+        left: 3px;
+        bottom: 3px;
+        background: white;
+        border-radius: 50%;
+        transition: 0.2s;
+      }
+      .switch input:checked + .slider {
+        background: var(--primary);
+        border-color: var(--primary);
+      }
+      .switch input:checked + .slider:before {
+        transform: translateX(22px);
+      }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-top: 8px;
+      }
+      button {
+        appearance: none;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 10px 14px;
+        font: inherit;
+        font-size: 0.9rem;
+        cursor: pointer;
+        color: var(--text);
+        background: transparent;
+        transition: 0.15s ease;
+      }
+      button:hover:not(:disabled) {
+        border-color: var(--primary);
+        color: var(--primary);
+      }
+      button:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+      }
+      button.primary {
+        background: rgba(var(--primary-rgb), 0.22);
+        border-color: rgba(var(--primary-rgb), 0.5);
+        color: #cfe3ff;
+      }
+      button.primary:hover:not(:disabled) {
+        background: rgba(var(--primary-rgb), 0.35);
+      }
+      button.ghost {
+        margin-left: auto;
+      }
+      .msg {
+        min-height: 1.3em;
+        margin-top: 14px;
+        font-size: 0.88rem;
+        color: var(--muted);
+      }
+      .msg.ok {
+        color: var(--ok);
+      }
+      .msg.err {
+        color: var(--danger);
+      }
+      .hint {
+        margin-top: 18px;
+        padding-top: 14px;
+        border-top: 1px solid var(--border);
+        color: var(--muted);
+        font-size: 0.8rem;
+        line-height: 1.45;
+      }
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-size: 0.85em;
+        color: #c5d4ff;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <div class="eyebrow">AGNT desktop · cold start</div>
+      <h1>Cannot reach backend</h1>
+      <p class="lead">
+        The desktop app is configured for a remote server, but health check failed. Fix the URL, switch to local mode, or
+        retry after the server is up.
+      </p>
+
+      <div id="errorBox" class="error-box"></div>
+
+      <div class="toggle-row">
+        <div>
+          <strong>Use external backend</strong>
+          <p>Off = start local backend on next launch. On = connect to the URL below.</p>
+        </div>
+        <label class="switch" title="Use external backend">
+          <input id="useExternal" type="checkbox" checked />
+          <span class="slider"></span>
+        </label>
+      </div>
+
+      <div class="field">
+        <label for="backendUrl">Backend URL</label>
+        <input id="backendUrl" type="url" placeholder="http://192.168.1.50:3333" spellcheck="false" autocomplete="off" />
+      </div>
+
+      <div class="actions">
+        <button id="testBtn" type="button">Test connection</button>
+        <button id="saveBtn" class="primary" type="button">Save &amp; restart</button>
+        <button id="retryBtn" type="button">Retry current</button>
+        <button id="quitBtn" class="ghost" type="button">Quit</button>
+      </div>
+
+      <div id="msg" class="msg"></div>
+
+      <div class="hint">
+        External mode: this app’s UI stays local; only the API hits the remote (<code>/api/health</code> required).<br />
+        Equivalent env: <code>USE_EXTERNAL_BACKEND=true BACKEND_URL=http://SERVER:3333</code><br />
+        In-app later: Settings → Configuration → Connection.
+      </div>
+    </main>
+
+    <script>
+      const params = new URLSearchParams(window.location.search);
+      const errorBox = document.getElementById('errorBox');
+      const useExternalEl = document.getElementById('useExternal');
+      const backendUrlEl = document.getElementById('backendUrl');
+      const msgEl = document.getElementById('msg');
+      const testBtn = document.getElementById('testBtn');
+      const saveBtn = document.getElementById('saveBtn');
+      const retryBtn = document.getElementById('retryBtn');
+      const quitBtn = document.getElementById('quitBtn');
+
+      const api = window.electron;
+
+      function setMsg(text, kind) {
+        msgEl.textContent = text || '';
+        msgEl.className = 'msg' + (kind ? ' ' + kind : '');
+      }
+
+      function syncUrlEnabled() {
+        backendUrlEl.disabled = !useExternalEl.checked;
+      }
+
+      useExternalEl.addEventListener('change', syncUrlEnabled);
+
+      async function load() {
+        const bootError = params.get('error');
+        const healthUrl = params.get('healthUrl');
+        if (bootError || healthUrl) {
+          errorBox.classList.add('show');
+          errorBox.textContent = [bootError, healthUrl ? `Tried: ${healthUrl}` : ''].filter(Boolean).join('\n');
+        }
+
+        if (!api?.getConnectionConfig) {
+          setMsg('Electron bridge unavailable. Relaunch the desktop app.', 'err');
+          return;
+        }
+
+        try {
+          const cfg = await api.getConnectionConfig();
+          const form = cfg.form || cfg.stored || {};
+          useExternalEl.checked = form.useExternalBackend !== false ? Boolean(form.useExternalBackend || cfg.useExternalBackend) : false;
+          if (!form.useExternalBackend && !cfg.useExternalBackend) {
+            useExternalEl.checked = true; // cold-start is for external failure
+          }
+          backendUrlEl.value = form.backendUrl || cfg.backendUrl || params.get('backendUrl') || '';
+          syncUrlEnabled();
+          if (cfg.envOverrides) {
+            setMsg('Env vars override Settings for this process until cleared.', '');
+          }
+        } catch (err) {
+          setMsg(err.message || 'Failed to load connection config', 'err');
+        }
+      }
+
+      testBtn.addEventListener('click', async () => {
+        if (!api?.testConnection) return;
+        testBtn.disabled = true;
+        setMsg('Testing…');
+        try {
+          const url = useExternalEl.checked ? backendUrlEl.value.trim() : '';
+          const result = await api.testConnection({ backendUrl: url || undefined });
+          if (result.ok) {
+            setMsg(`Health OK (${result.latencyMs ?? '?'} ms) — ${result.backendUrl}`, 'ok');
+          } else {
+            setMsg(result.error || 'Health check failed', 'err');
+          }
+        } catch (err) {
+          setMsg(err.message || 'Test failed', 'err');
+        } finally {
+          testBtn.disabled = false;
+        }
+      });
+
+      saveBtn.addEventListener('click', async () => {
+        if (!api?.setConnectionConfig || !api?.relaunchApp) return;
+        saveBtn.disabled = true;
+        setMsg('Saving…');
+        try {
+          const result = await api.setConnectionConfig({
+            useExternalBackend: useExternalEl.checked,
+            backendUrl: backendUrlEl.value.trim(),
+          });
+          if (!result.ok) {
+            setMsg(result.error || 'Save failed', 'err');
+            saveBtn.disabled = false;
+            return;
+          }
+          setMsg('Saved. Restarting…', 'ok');
+          await api.relaunchApp();
+        } catch (err) {
+          setMsg(err.message || 'Save failed', 'err');
+          saveBtn.disabled = false;
+        }
+      });
+
+      retryBtn.addEventListener('click', async () => {
+        if (!api?.relaunchApp) return;
+        retryBtn.disabled = true;
+        setMsg('Restarting with current settings…');
+        try {
+          await api.relaunchApp();
+        } catch (err) {
+          setMsg(err.message || 'Relaunch failed', 'err');
+          retryBtn.disabled = false;
+        }
+      });
+
+      quitBtn.addEventListener('click', async () => {
+        if (api?.quitApp) {
+          await api.quitApp();
+        } else if (api?.send) {
+          api.send('close-window');
+        } else {
+          window.close();
+        }
+      });
+
+      load();
+    </script>
+  </body>
+</html>

--- a/electron/desktop-connection.js
+++ b/electron/desktop-connection.js
@@ -1,0 +1,370 @@
+/**
+ * Desktop hybrid connection lifecycle (Electron main-process only).
+ *
+ * Owns: config cache, local UI reverse-proxy, health wait, cold-start window,
+ * connection IPC, and activate recovery. main.js should call into this module
+ * instead of branching hybrid logic through the process entry file.
+ */
+import path from 'path';
+import {
+  resolveConnectionConfig,
+  readStoredConnectionConfig,
+  writeStoredConnectionConfig,
+  normalizeBackendUrl,
+  validateBackendUrl,
+  probeBackendHealth,
+  waitUntilHealthy,
+} from './connection-config.js';
+import { startLocalUiServer, resolveFrontendDistPath } from './local-ui-server.js';
+
+/** @type {null | {
+ *   app: import('electron').App,
+ *   BrowserWindow: typeof import('electron').BrowserWindow,
+ *   dialog: import('electron').Dialog,
+ *   ipcMain: import('electron').IpcMain,
+ *   dirname: string,
+ *   getMainWindow: () => import('electron').BrowserWindow | null,
+ * }} */
+let ctx = null;
+
+/** @type {ReturnType<typeof resolveConnectionConfig> | null} */
+let activeConnection = null;
+/** @type {import('http').Server | null} */
+let localUiServer = null;
+/** @type {string | null} */
+let localUiOrigin = null;
+/** @type {import('electron').BrowserWindow | null} */
+let connectionSetupWindow = null;
+let ipcRegistered = false;
+
+/**
+ * @param {NonNullable<typeof ctx>} deps
+ */
+export function initDesktopConnection(deps) {
+  ctx = deps;
+  registerConnectionIpc();
+}
+
+function requireCtx() {
+  if (!ctx) throw new Error('desktop-connection: initDesktopConnection() not called');
+  return ctx;
+}
+
+export function getActiveConnection() {
+  if (activeConnection) return activeConnection;
+  const { app } = requireCtx();
+  activeConnection = resolveConnectionConfig({ userDataPath: app.getPath('userData') });
+  console.log(
+    `[connection] mode=${activeConnection.useExternalBackend ? 'external' : 'local'} ` +
+      `url=${activeConnection.backendUrl} source=${activeConnection.source}`
+  );
+  return activeConnection;
+}
+
+export function invalidateConnectionCache() {
+  activeConnection = null;
+}
+
+export function getLocalUiOrigin() {
+  return localUiOrigin;
+}
+
+/**
+ * UI load URL for the main BrowserWindow.
+ * External mode never falls back to remote UI (that hid Settings → Connection).
+ */
+export function getUiLoadUrl() {
+  const connection = getActiveConnection();
+  if (connection.useExternalBackend) {
+    if (!localUiOrigin) {
+      throw new Error('External mode requires local UI server before opening the main window');
+    }
+    return localUiOrigin;
+  }
+  return `http://localhost:${process.env.PORT || 3333}`;
+}
+
+/**
+ * Ensure loopback static UI + reverse proxy is running (external mode only).
+ */
+export async function ensureLocalUiServer(connection = getActiveConnection()) {
+  if (localUiServer && localUiOrigin) {
+    return { origin: localUiOrigin };
+  }
+  const { app, dirname } = requireCtx();
+  const distDir = resolveFrontendDistPath({ app, dirname });
+  const { server, origin } = await startLocalUiServer(distDir, {
+    proxyTarget: connection.backendUrl,
+  });
+  localUiServer = server;
+  localUiOrigin = origin;
+  return { origin };
+}
+
+/**
+ * Poll until the active backend answers /api/health.
+ * @returns {Promise<boolean>} true if healthy
+ */
+export async function waitForBackendReady() {
+  const connection = getActiveConnection();
+  const maxAttempts = connection.useExternalBackend ? 40 : Infinity;
+  const intervalMs = connection.useExternalBackend ? 500 : 250;
+
+  const result = await waitUntilHealthy(connection.backendUrl, {
+    maxAttempts,
+    intervalMs,
+    requestTimeoutMs: 30000,
+    onAttempt(attempt, url, last) {
+      const detail = last.ok ? 'ok' : last.error || `HTTP ${last.status || '?'}`;
+      console.log(`Attempting to connect to backend ${url} (attempt ${attempt})… ${detail}`);
+    },
+  });
+
+  if (result.ok) {
+    console.log('Backend is ready');
+    return true;
+  }
+
+  handleBackendUnreachable(
+    connection.healthUrl,
+    result.error
+      ? `${result.error} (after ${result.attempts} attempts)`
+      : `Health check failed after ${result.attempts} attempts`
+  );
+  return false;
+}
+
+/**
+ * Boot connection side of app start: local Express or external proxy UI, then health.
+ * @param {{ startBackend: () => void }} opts
+ * @returns {Promise<boolean>}
+ */
+export async function prepareConnectionForLaunch({ startBackend }) {
+  const connection = getActiveConnection();
+  if (connection.useExternalBackend) {
+    console.log('[connection] External backend mode — skipping local Express fork');
+    try {
+      await ensureLocalUiServer(connection);
+    } catch (err) {
+      const { dialog, app } = requireCtx();
+      console.error('[connection] Failed to start local UI server:', err.message);
+      dialog.showErrorBox(
+        'Cannot start AGNT UI',
+        `External backend mode needs the packaged frontend (frontend/dist).\n\n${err.message}`
+      );
+      app.quit();
+      return false;
+    }
+  } else {
+    startBackend();
+  }
+  return waitForBackendReady();
+}
+
+/**
+ * macOS dock activate with no windows: reopen main UI if healthy, else setup.
+ * @param {{ createWindow: () => void, attachChrome: () => void }} opts
+ */
+export async function recoverOnActivate({ createWindow, attachChrome }) {
+  const connection = getActiveConnection();
+
+  if (!connection.useExternalBackend) {
+    createWindow();
+    attachChrome();
+    return;
+  }
+
+  try {
+    await ensureLocalUiServer(connection);
+    const health = await probeBackendHealth(connection.backendUrl, 5000);
+    if (health.ok) {
+      console.log('[connection] activate: remote healthy — reopening main window');
+      createWindow();
+      attachChrome();
+      return;
+    }
+    console.warn('[connection] activate: remote unhealthy —', health.error || health.status);
+    showConnectionSetupWindow({
+      error: health.error || `Health check failed (HTTP ${health.status || '?'})`,
+      healthUrl: connection.healthUrl,
+      backendUrl: connection.backendUrl,
+    });
+  } catch (err) {
+    console.error('[connection] activate recovery failed:', err.message);
+    showConnectionSetupWindow({
+      error: err.message || 'Could not restore the desktop UI.',
+      healthUrl: connection.healthUrl,
+      backendUrl: connection.backendUrl,
+    });
+  }
+}
+
+export function showConnectionSetupWindow({ error, healthUrl, backendUrl } = {}) {
+  const { BrowserWindow, dirname, getMainWindow, app } = requireCtx();
+
+  if (connectionSetupWindow && !connectionSetupWindow.isDestroyed()) {
+    connectionSetupWindow.focus();
+    return connectionSetupWindow;
+  }
+
+  connectionSetupWindow = new BrowserWindow({
+    width: 620,
+    height: 640,
+    title: 'AGNT — Connection Setup',
+    frame: true,
+    show: false,
+    resizable: true,
+    minimizable: true,
+    backgroundColor: '#070710',
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      preload: path.join(dirname, 'preload.js'),
+      webSecurity: true,
+    },
+  });
+
+  const query = {};
+  if (error) query.error = String(error).slice(0, 500);
+  if (healthUrl) query.healthUrl = String(healthUrl);
+  if (backendUrl) query.backendUrl = String(backendUrl);
+
+  connectionSetupWindow.loadFile(path.join(dirname, 'electron', 'connection-setup.html'), { query });
+  connectionSetupWindow.once('ready-to-show', () => {
+    connectionSetupWindow.center();
+    connectionSetupWindow.show();
+  });
+  connectionSetupWindow.on('closed', () => {
+    connectionSetupWindow = null;
+    const mainWindow = getMainWindow();
+    if (!mainWindow || mainWindow.isDestroyed()) {
+      app.quit();
+    }
+  });
+
+  return connectionSetupWindow;
+}
+
+function handleBackendUnreachable(healthUrl, detail) {
+  const { dialog, app } = requireCtx();
+  const connection = getActiveConnection();
+  const message = detail || `Could not connect to ${healthUrl}`;
+  console.error('[connection] Backend unreachable:', message);
+
+  if (connection.useExternalBackend) {
+    showConnectionSetupWindow({
+      error: message,
+      healthUrl,
+      backendUrl: connection.backendUrl,
+    });
+    return;
+  }
+
+  dialog.showErrorBox(
+    'Cannot reach AGNT backend',
+    `${message}\n\nThe local backend failed to start. Check the console logs for errors.`
+  );
+  app.quit();
+}
+
+export function stopDesktopConnection() {
+  if (localUiServer) {
+    try {
+      localUiServer.close();
+    } catch (err) {
+      console.warn('[local-ui] close failed:', err.message);
+    }
+    localUiServer = null;
+    localUiOrigin = null;
+  }
+}
+
+function registerConnectionIpc() {
+  if (ipcRegistered) return;
+  ipcRegistered = true;
+  const { ipcMain, app } = requireCtx();
+
+  // Sync snapshot for preload. External mode is same-origin (UI+proxy on loopback);
+  // renderer uses window.location.origin/api — no injected remote BASE_URL.
+  ipcMain.on('connection:get-desktop-runtime', (event) => {
+    try {
+      const c = getActiveConnection();
+      event.returnValue = {
+        useExternalBackend: Boolean(c.useExternalBackend),
+        backendUrl: c.backendUrl || '',
+        uiOrigin: localUiOrigin || null,
+      };
+    } catch (err) {
+      event.returnValue = {
+        useExternalBackend: false,
+        backendUrl: '',
+        uiOrigin: null,
+        error: err.message,
+      };
+    }
+  });
+
+  ipcMain.handle('connection:get', () => {
+    const userDataPath = app.getPath('userData');
+    const effective = resolveConnectionConfig({ userDataPath });
+    const stored = readStoredConnectionConfig(userDataPath);
+    return {
+      ...effective,
+      stored,
+      form: {
+        useExternalBackend: stored.useExternalBackend || effective.useExternalBackend,
+        backendUrl: stored.backendUrl || (effective.useExternalBackend ? effective.backendUrl : ''),
+      },
+    };
+  });
+
+  ipcMain.handle('connection:set', (_event, payload = {}) => {
+    const userDataPath = app.getPath('userData');
+    const useExternalBackend = Boolean(payload.useExternalBackend);
+    let backendUrl = normalizeBackendUrl(payload.backendUrl || '');
+
+    if (useExternalBackend) {
+      const check = validateBackendUrl(backendUrl);
+      if (!check.ok) {
+        return { ok: false, error: check.error };
+      }
+      backendUrl = check.cleaned;
+    }
+
+    const stored = writeStoredConnectionConfig(userDataPath, {
+      useExternalBackend,
+      backendUrl: useExternalBackend ? backendUrl : backendUrl || '',
+    });
+
+    invalidateConnectionCache();
+
+    return {
+      ok: true,
+      stored,
+      requiresRestart: true,
+      message: 'Connection settings saved. Restart AGNT to apply.',
+    };
+  });
+
+  ipcMain.handle('connection:test', async (_event, payload = {}) => {
+    const backendUrl =
+      normalizeBackendUrl(payload.backendUrl) ||
+      getActiveConnection().backendUrl ||
+      `http://127.0.0.1:${process.env.PORT || 3333}`;
+    const result = await probeBackendHealth(backendUrl);
+    return { backendUrl, ...result };
+  });
+
+  ipcMain.handle('app:relaunch', () => {
+    console.log('[connection] Relaunch requested');
+    app.relaunch();
+    app.exit(0);
+    return { ok: true };
+  });
+
+  ipcMain.handle('app:quit', () => {
+    console.log('[connection] Quit requested from connection setup');
+    app.quit();
+    return { ok: true };
+  });
+}

--- a/electron/local-ui-server.js
+++ b/electron/local-ui-server.js
@@ -1,0 +1,281 @@
+/**
+ * Local static UI + reverse proxy for external-backend desktop mode.
+ *
+ * Why:
+ *  - Always serve *this* app's frontend (Settings → Connection, etc.)
+ *  - Proxy /api and /socket.io to the remote AGNT host so the page is
+ *    same-origin: auth tokens in localStorage, no CORS headaches, Socket.IO works.
+ *  - Fixed port (default 19333) so localStorage survives app restarts.
+ */
+import fs from 'fs';
+import path from 'path';
+import http from 'http';
+import https from 'https';
+import { URL } from 'url';
+
+/** Default loopback port for the desktop UI (stable localStorage origin). */
+export const DEFAULT_LOCAL_UI_PORT = 19333;
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.mjs': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.map': 'application/json',
+  '.mp3': 'audio/mpeg',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+};
+
+function shouldProxy(pathname) {
+  return (
+    pathname === '/api' ||
+    pathname.startsWith('/api/') ||
+    pathname === '/socket.io' ||
+    pathname.startsWith('/socket.io/')
+  );
+}
+
+/**
+ * Forward an HTTP request to the remote backend.
+ * @param {import('http').IncomingMessage} req
+ * @param {import('http').ServerResponse} res
+ * @param {URL} targetBase remote origin e.g. http://192.168.1.10:3333
+ */
+function proxyHttp(req, res, targetBase) {
+  const targetUrl = new URL(req.url || '/', targetBase);
+  const lib = targetBase.protocol === 'https:' ? https : http;
+  const headers = { ...req.headers, host: targetBase.host };
+
+  // Avoid compressed mismatch issues when piping
+  delete headers['accept-encoding'];
+
+  const proxyReq = lib.request(
+    {
+      protocol: targetBase.protocol,
+      hostname: targetBase.hostname,
+      port: targetBase.port || (targetBase.protocol === 'https:' ? 443 : 80),
+      path: targetUrl.pathname + targetUrl.search,
+      method: req.method,
+      headers,
+      rejectUnauthorized: false,
+    },
+    (proxyRes) => {
+      res.writeHead(proxyRes.statusCode || 502, proxyRes.headers);
+      proxyRes.pipe(res);
+    }
+  );
+
+  proxyReq.on('error', (err) => {
+    console.error('[local-ui] API proxy error:', err.message);
+    if (!res.headersSent) {
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+    }
+    res.end(JSON.stringify({ error: `Proxy to ${targetBase.origin} failed: ${err.message}` }));
+  });
+
+  req.pipe(proxyReq);
+}
+
+/**
+ * WebSocket upgrade proxy (Socket.IO).
+ * @param {import('http').IncomingMessage} req
+ * @param {import('stream').Duplex} socket
+ * @param {Buffer} head
+ * @param {URL} targetBase
+ */
+function proxyUpgrade(req, socket, head, targetBase) {
+  const lib = targetBase.protocol === 'https:' ? https : http;
+  const targetUrl = new URL(req.url || '/', targetBase);
+  const headers = { ...req.headers, host: targetBase.host };
+
+  const proxyReq = lib.request({
+    protocol: targetBase.protocol,
+    hostname: targetBase.hostname,
+    port: targetBase.port || (targetBase.protocol === 'https:' ? 443 : 80),
+    path: targetUrl.pathname + targetUrl.search,
+    method: 'GET',
+    headers,
+    rejectUnauthorized: false,
+  });
+
+  proxyReq.on('upgrade', (proxyRes, proxySocket, proxyHead) => {
+    const statusLine = `HTTP/1.1 ${proxyRes.statusCode} ${proxyRes.statusMessage || 'Switching Protocols'}\r\n`;
+    let responseHeaders = statusLine;
+    for (const [key, value] of Object.entries(proxyRes.headers)) {
+      if (Array.isArray(value)) {
+        for (const v of value) responseHeaders += `${key}: ${v}\r\n`;
+      } else if (value !== undefined) {
+        responseHeaders += `${key}: ${value}\r\n`;
+      }
+    }
+    responseHeaders += '\r\n';
+    socket.write(responseHeaders);
+    if (proxyHead && proxyHead.length) socket.write(proxyHead);
+    if (head && head.length) proxySocket.write(head);
+
+    proxySocket.pipe(socket);
+    socket.pipe(proxySocket);
+
+    proxySocket.on('error', (err) => {
+      console.error('[local-ui] WS proxy socket error:', err.message);
+      socket.destroy();
+    });
+    socket.on('error', () => proxySocket.destroy());
+  });
+
+  proxyReq.on('error', (err) => {
+    console.error('[local-ui] WS upgrade proxy error:', err.message);
+    socket.destroy();
+  });
+
+  proxyReq.end();
+}
+
+function serveStatic(req, res, distDir, indexPath, distRoot) {
+  try {
+    const url = new URL(req.url || '/', 'http://127.0.0.1');
+    let pathname = decodeURIComponent(url.pathname);
+    if (pathname === '/') pathname = '/index.html';
+
+    const resolved = path.normalize(path.join(distDir, pathname));
+    const root = distRoot || (distDir.endsWith(path.sep) ? distDir : distDir + path.sep);
+    // Allow exact distDir match (index) or files under distRoot
+    if (resolved !== distDir && !resolved.startsWith(root)) {
+      res.writeHead(403);
+      res.end('Forbidden');
+      return;
+    }
+
+    let filePath = resolved;
+    if (!fs.existsSync(filePath) || fs.statSync(filePath).isDirectory()) {
+      filePath = indexPath;
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    const type = MIME[ext] || 'application/octet-stream';
+    res.writeHead(200, {
+      'Content-Type': type,
+      'Cache-Control': ext === '.html' ? 'no-cache' : 'public, max-age=86400',
+    });
+    fs.createReadStream(filePath).pipe(res);
+  } catch (err) {
+    console.error('[local-ui] serve error:', err.message);
+    res.writeHead(500);
+    res.end('Internal error');
+  }
+}
+
+/**
+ * @param {string} distDir absolute path to frontend/dist
+ * @param {object} [opts]
+ * @param {string} [opts.proxyTarget] remote backend base URL (no /api)
+ * @param {number} [opts.port] preferred fixed port (default 19333)
+ * @returns {Promise<{ server: http.Server, port: number, origin: string }>}
+ */
+export function startLocalUiServer(distDir, opts = {}) {
+  return new Promise((resolve, reject) => {
+    if (!fs.existsSync(distDir)) {
+      reject(new Error(`Frontend dist not found at ${distDir}. Build the frontend first.`));
+      return;
+    }
+    const indexPath = path.join(distDir, 'index.html');
+    if (!fs.existsSync(indexPath)) {
+      reject(new Error(`frontend/dist/index.html missing at ${distDir}`));
+      return;
+    }
+
+    let targetBase = null;
+    if (opts.proxyTarget) {
+      try {
+        targetBase = new URL(opts.proxyTarget);
+      } catch {
+        reject(new Error(`Invalid proxy target: ${opts.proxyTarget}`));
+        return;
+      }
+    }
+
+    // Allow port 0 (ephemeral) for tests; 0 is falsy so don't use `||`.
+    const preferredPort =
+      opts.port !== undefined && opts.port !== null
+        ? Number(opts.port)
+        : Number(process.env.AGNT_UI_PORT || DEFAULT_LOCAL_UI_PORT);
+
+    // Normalize for path-escape checks (trailing sep avoids /dist vs /dist-evil)
+    const distRoot = distDir.endsWith(path.sep) ? distDir : distDir + path.sep;
+
+    const server = http.createServer((req, res) => {
+      const pathname = new URL(req.url || '/', 'http://127.0.0.1').pathname;
+      if (targetBase && shouldProxy(pathname)) {
+        proxyHttp(req, res, targetBase);
+        return;
+      }
+      serveStatic(req, res, distDir, indexPath, distRoot);
+    });
+
+    if (targetBase) {
+      server.on('upgrade', (req, socket, head) => {
+        const pathname = new URL(req.url || '/', 'http://127.0.0.1').pathname;
+        if (shouldProxy(pathname)) {
+          proxyUpgrade(req, socket, head, targetBase);
+        } else {
+          socket.destroy();
+        }
+      });
+    }
+
+    const onListen = () => {
+      const { port } = server.address();
+      const origin = `http://127.0.0.1:${port}`;
+      console.log(
+        `[local-ui] UI at ${origin} (dist=${distDir}` +
+          (targetBase ? `, proxy→${targetBase.origin}` : '') +
+          ')'
+      );
+      resolve({ server, port, origin });
+    };
+
+    server.once('error', (err) => {
+      if (err.code === 'EADDRINUSE' && preferredPort !== 0) {
+        console.warn(`[local-ui] Port ${preferredPort} in use — falling back to ephemeral port`);
+        server.removeAllListeners('error');
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', onListen);
+        return;
+      }
+      reject(err);
+    });
+
+    server.listen(preferredPort, '127.0.0.1', onListen);
+  });
+}
+
+/**
+ * Resolve frontend/dist for dev vs packaged Electron.
+ * @param {{ app: import('electron').App, dirname: string }} opts
+ */
+export function resolveFrontendDistPath({ app, dirname }) {
+  const candidates = [
+    path.join(dirname, 'frontend', 'dist'),
+    app.isPackaged ? path.join(process.resourcesPath, 'app.asar', 'frontend', 'dist') : null,
+    app.isPackaged ? path.join(process.resourcesPath, 'frontend', 'dist') : null,
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(candidate, 'index.html'))) {
+      return candidate;
+    }
+  }
+  return candidates[0];
+}

--- a/electron/local-ui-server.js
+++ b/electron/local-ui-server.js
@@ -6,6 +6,9 @@
  *  - Proxy /api and /socket.io to the remote AGNT host so the page is
  *    same-origin: auth tokens in localStorage, no CORS headaches, Socket.IO works.
  *  - Fixed port (default 19333) so localStorage survives app restarts.
+ *
+ * TLS: certificates are verified by default. For LAN self-signed remotes set
+ * AGNT_PROXY_INSECURE_TLS=1 (or NODE_TLS_REJECT_UNAUTHORIZED=0).
  */
 import fs from 'fs';
 import path from 'path';
@@ -48,6 +51,29 @@ function shouldProxy(pathname) {
 }
 
 /**
+ * Whether outbound HTTPS to the remote should skip certificate verification.
+ * Default is verify (secure). Opt-out only for known self-signed LAN servers.
+ */
+export function shouldRejectUnauthorized() {
+  if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0') return false;
+  const v = process.env.AGNT_PROXY_INSECURE_TLS;
+  if (v === '1' || v === 'true' || v === 'yes') return false;
+  return true;
+}
+
+function requestTlsOptions() {
+  return { rejectUnauthorized: shouldRejectUnauthorized() };
+}
+
+/**
+ * Strip leading slashes so path.join(distDir, relative) never treats the
+ * segment as an absolute path (path.join('/dist', '/app.js') === '/app.js').
+ */
+export function pathnameToRelative(pathname) {
+  return String(pathname || '').replace(/^\/+/, '') || 'index.html';
+}
+
+/**
  * Forward an HTTP request to the remote backend.
  * @param {import('http').IncomingMessage} req
  * @param {import('http').ServerResponse} res
@@ -69,7 +95,7 @@ function proxyHttp(req, res, targetBase) {
       path: targetUrl.pathname + targetUrl.search,
       method: req.method,
       headers,
-      rejectUnauthorized: false,
+      ...requestTlsOptions(),
     },
     (proxyRes) => {
       res.writeHead(proxyRes.statusCode || 502, proxyRes.headers);
@@ -107,10 +133,25 @@ function proxyUpgrade(req, socket, head, targetBase) {
     path: targetUrl.pathname + targetUrl.search,
     method: 'GET',
     headers,
-    rejectUnauthorized: false,
+    ...requestTlsOptions(),
   });
 
+  let settled = false;
+  const failClient = (status, message) => {
+    if (settled || socket.destroyed) return;
+    settled = true;
+    try {
+      socket.write(
+        `HTTP/1.1 ${status} ${message}\r\nConnection: close\r\nContent-Type: text/plain\r\nContent-Length: ${Buffer.byteLength(message)}\r\n\r\n${message}`
+      );
+    } catch {
+      /* ignore */
+    }
+    socket.destroy();
+  };
+
   proxyReq.on('upgrade', (proxyRes, proxySocket, proxyHead) => {
+    settled = true;
     const statusLine = `HTTP/1.1 ${proxyRes.statusCode} ${proxyRes.statusMessage || 'Switching Protocols'}\r\n`;
     let responseHeaders = statusLine;
     for (const [key, value] of Object.entries(proxyRes.headers)) {
@@ -135,9 +176,18 @@ function proxyUpgrade(req, socket, head, targetBase) {
     socket.on('error', () => proxySocket.destroy());
   });
 
+  // Backend answered without upgrading (4xx/5xx/200) — must not leave client hanging.
+  proxyReq.on('response', (proxyRes) => {
+    console.warn(
+      `[local-ui] WS upgrade rejected by remote: HTTP ${proxyRes.statusCode} ${proxyRes.statusMessage || ''}`
+    );
+    proxyRes.resume();
+    failClient(502, 'WebSocket upgrade failed');
+  });
+
   proxyReq.on('error', (err) => {
     console.error('[local-ui] WS upgrade proxy error:', err.message);
-    socket.destroy();
+    failClient(502, err.message || 'WebSocket proxy error');
   });
 
   proxyReq.end();
@@ -147,11 +197,14 @@ function serveStatic(req, res, distDir, indexPath, distRoot) {
   try {
     const url = new URL(req.url || '/', 'http://127.0.0.1');
     let pathname = decodeURIComponent(url.pathname);
-    if (pathname === '/') pathname = '/index.html';
+    if (pathname === '/' || pathname === '') pathname = '/index.html';
 
-    const resolved = path.normalize(path.join(distDir, pathname));
+    // Relative path only — never pass a leading "/" into path.join (absolute segment).
+    const relative = pathnameToRelative(pathname);
+    const resolved = path.normalize(path.join(distDir, relative));
     const root = distRoot || (distDir.endsWith(path.sep) ? distDir : distDir + path.sep);
-    // Allow exact distDir match (index) or files under distRoot
+
+    // Allow exact distDir match or files under distRoot
     if (resolved !== distDir && !resolved.startsWith(root)) {
       res.writeHead(403);
       res.end('Forbidden');

--- a/frontend/src/composables/useDesktopConnection.js
+++ b/frontend/src/composables/useDesktopConnection.js
@@ -1,0 +1,69 @@
+import { ref, computed, onMounted } from 'vue';
+
+/**
+ * Desktop hybrid connection info for UI banners (external mode, remote host).
+ * Prefers preload sync snapshot; refreshes from IPC when available.
+ */
+export function useDesktopConnection() {
+  const useExternalBackend = ref(false);
+  const backendUrl = ref('');
+  const loaded = ref(false);
+
+  const isExternalMode = computed(() => Boolean(useExternalBackend.value));
+  const remoteHostLabel = computed(() => {
+    const url = (backendUrl.value || '').trim();
+    if (!url) return '';
+    try {
+      const u = new URL(url);
+      return u.host || url;
+    } catch {
+      return url;
+    }
+  });
+
+  function applyRuntime(rt = {}) {
+    useExternalBackend.value = Boolean(rt.useExternalBackend);
+    backendUrl.value = typeof rt.backendUrl === 'string' ? rt.backendUrl : '';
+  }
+
+  async function refresh() {
+    if (typeof window === 'undefined') {
+      loaded.value = true;
+      return;
+    }
+
+    // Sync snapshot from preload (available before first paint in Electron)
+    if (window.__AGNT_DESKTOP__) {
+      applyRuntime(window.__AGNT_DESKTOP__);
+    }
+
+    const electron = window.electron;
+    if (electron?.getConnectionConfig) {
+      try {
+        const cfg = await electron.getConnectionConfig();
+        useExternalBackend.value = Boolean(cfg.useExternalBackend);
+        backendUrl.value =
+          cfg.backendUrl ||
+          cfg.form?.backendUrl ||
+          cfg.stored?.backendUrl ||
+          backendUrl.value ||
+          '';
+      } catch {
+        // keep snapshot
+      }
+    }
+
+    loaded.value = true;
+  }
+
+  onMounted(refresh);
+
+  return {
+    loaded,
+    useExternalBackend,
+    backendUrl,
+    isExternalMode,
+    remoteHostLabel,
+    refresh,
+  };
+}

--- a/frontend/src/views/Terminal/CenterPanel/screens/Settings/Settings.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Settings/Settings.vue
@@ -169,6 +169,19 @@
           </div>
         </div>
 
+        <!-- Connection Section (desktop hybrid / external backend) -->
+        <div v-else-if="activeSection === 'connection'" class="settings-content" data-section="connection">
+          <div class="content-header">
+            <h2 class="content-title">Connection</h2>
+            <p class="content-subtitle">Local backend or remote AGNT server</p>
+          </div>
+          <div class="settings-grid">
+            <div class="settings-section full-width">
+              <ConnectionSettings />
+            </div>
+          </div>
+        </div>
+
         <!-- Tours Section -->
         <div v-else-if="activeSection === 'tours'" class="settings-content" data-section="tours">
           <div class="content-header">
@@ -214,7 +227,28 @@
         </div>
       </template>
       <template v-else>
-        <LoginSection @login-success="handleLoginSuccess" />
+        <!-- Unauthenticated: sign-in, or Connection (external mode recovery without login) -->
+        <div v-if="activeSection === 'connection'" class="settings-content" data-section="connection">
+          <div class="content-header">
+            <h2 class="content-title">Connection</h2>
+            <p class="content-subtitle">Local backend or remote AGNT server</p>
+          </div>
+          <div class="settings-grid">
+            <div class="settings-section full-width">
+              <ConnectionSettings />
+            </div>
+            <div class="settings-section full-width guest-connection-actions">
+              <button type="button" class="back-to-sign-in" @click="activeSection = 'login'">
+                ← Back to sign in
+              </button>
+            </div>
+          </div>
+        </div>
+        <LoginSection
+          v-else
+          @login-success="handleLoginSuccess"
+          @open-connection="activeSection = 'connection'"
+        />
       </template>
 
       <!-- Tutorial - Only show when logged in -->
@@ -243,6 +277,7 @@ import CreditPurchase from '../../../../_components/common/CreditPurchase.vue';
 import ResourcesSection from '../../../../_components/common/ResourcesSection.vue';
 import TourSettings from './components/TourSettings/TourSettings.vue';
 import SoundsSettings from './components/SoundsSettings/SoundsSettings.vue';
+import ConnectionSettings from './components/ConnectionSettings/ConnectionSettings.vue';
 import SecuritySettings from './components/SecuritySettings/SecuritySettings.vue';
 import AgntScoreBreakdown from './components/AgntScoreBreakdown/AgntScoreBreakdown.vue';
 import ProfileSection from './components/ProfileSection/ProfileSection.vue';
@@ -265,6 +300,7 @@ export default {
     ResourcesSection,
     TourSettings,
     SoundsSettings,
+    ConnectionSettings,
     SecuritySettings,
     AgntScoreBreakdown,
     ProfileSection,
@@ -294,6 +330,8 @@ export default {
       if (requestedSection) {
         activeSection.value = requestedSection;
         localStorage.removeItem('settings-initial-section'); // Clean up
+      } else if (!isLoggedIn.value) {
+        activeSection.value = 'login';
       }
 
       // Non-blocking: refresh all data in parallel in background
@@ -442,6 +480,28 @@ body.dark .settings-section.full-width {
 /* .lower-section {
   padding: 24px !important;
 } */
+
+.guest-connection-actions {
+  display: flex;
+  justify-content: center;
+  padding-top: 0;
+}
+
+.back-to-sign-in {
+  appearance: none;
+  border: 1px solid var(--terminal-border-color);
+  background: transparent;
+  color: var(--color-primary);
+  font: inherit;
+  font-size: 0.9rem;
+  padding: 10px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.back-to-sign-in:hover {
+  border-color: var(--color-primary);
+}
 
 .settings-content {
   display: flex;

--- a/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/ConnectionSettings/ConnectionSettings.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/ConnectionSettings/ConnectionSettings.vue
@@ -1,0 +1,689 @@
+<template>
+  <div class="connection-settings">
+    <div class="settings-header">
+      <h3>Backend Connection</h3>
+      <p class="settings-description">
+        Run the desktop app against a remote AGNT server (Docker / self-hosted) instead of the local backend.
+      </p>
+    </div>
+
+    <div v-if="!hasDesktopBridge" class="notice info">
+      <i class="fas fa-info-circle"></i>
+      <div>
+        Desktop connection controls need the AGNT <strong>desktop shell</strong> (Electron). In a plain browser you are
+        already on the host that served this page — use that server as the remote URL from another Mac’s desktop app.
+      </div>
+    </div>
+
+    <div class="status-card" :class="statusClass">
+      <div class="status-row">
+        <span class="status-dot"></span>
+        <div>
+          <strong>{{ statusLabel }}</strong>
+          <p>{{ displayBackendUrl }}</p>
+        </div>
+      </div>
+      <span class="source-badge" v-if="effective.source">source: {{ effective.source }}</span>
+    </div>
+
+    <div v-if="effective.envOverrides" class="notice warn">
+      <i class="fas fa-exclamation-triangle"></i>
+      <div>
+        Environment variables (<code>USE_EXTERNAL_BACKEND</code> / <code>BACKEND_URL</code>) override the form below for this
+        session. Clear them and restart to use Settings-only config.
+      </div>
+    </div>
+
+    <div class="connection-controls" role="radiogroup" aria-label="Backend mode">
+      <!-- Exclusive mode selection (radio cards) — only the selected mode is highlighted -->
+      <button
+        type="button"
+        class="control-row mode-row mode-card"
+        :class="{ active: !useExternalBackend }"
+        :disabled="!hasDesktopBridge"
+        role="radio"
+        :aria-checked="(!useExternalBackend).toString()"
+        @click="selectMode('local')"
+      >
+        <div class="control-info">
+          <div class="control-label">
+            <span class="radio-dot" aria-hidden="true"></span>
+            <i class="fas fa-laptop"></i>
+            <span>Local backend</span>
+          </div>
+          <p class="control-description">
+            This Mac runs Express on port 3333 (default). Use when you are not pointing at another host.
+          </p>
+        </div>
+      </button>
+
+      <button
+        type="button"
+        class="control-row mode-row mode-card"
+        :class="{ active: useExternalBackend }"
+        :disabled="!hasDesktopBridge"
+        role="radio"
+        :aria-checked="useExternalBackend.toString()"
+        @click="selectMode('external')"
+      >
+        <div class="control-info">
+          <div class="control-label">
+            <span class="radio-dot" aria-hidden="true"></span>
+            <i class="fas fa-network-wired"></i>
+            <span>External backend</span>
+          </div>
+          <p class="control-description">
+            Skip the local Express server. This app’s UI stays local; API traffic goes to the remote host (another Mac,
+            Docker, VPS).
+          </p>
+        </div>
+      </button>
+
+      <div class="control-row" :class="{ disabled: !useExternalBackend || !hasDesktopBridge, active: useExternalBackend }">
+        <div class="control-info">
+          <div class="control-label">
+            <i class="fas fa-link"></i>
+            <span>Backend URL</span>
+          </div>
+          <p class="control-description">
+            Base URL of the remote AGNT API (no trailing <code>/api</code>). Remote only needs the API —
+            <code>/api/health</code> must respond.
+          </p>
+        </div>
+        <input
+          class="url-input"
+          type="url"
+          v-model="backendUrl"
+          :disabled="!useExternalBackend || !hasDesktopBridge"
+          placeholder="http://192.168.1.50:3333"
+          spellcheck="false"
+          autocomplete="off"
+        />
+      </div>
+    </div>
+
+    <div class="action-row">
+      <button type="button" class="secondary-btn" :disabled="!hasDesktopBridge || testing || !canTest" @click="testConnection">
+        <i class="fas" :class="testing ? 'fa-spinner fa-spin' : 'fa-stethoscope'"></i>
+        {{ testing ? 'Testing…' : 'Test connection' }}
+      </button>
+      <button type="button" class="primary-btn" :disabled="!hasDesktopBridge || saving || !dirty" @click="saveSettings">
+        <i class="fas" :class="saving ? 'fa-spinner fa-spin' : 'fa-save'"></i>
+        {{ saving ? 'Saving…' : 'Save' }}
+      </button>
+      <button type="button" class="primary-btn restart-btn" :disabled="!hasDesktopBridge || relaunching" @click="relaunch">
+        <i class="fas" :class="relaunching ? 'fa-spinner fa-spin' : 'fa-redo'"></i>
+        {{ relaunching ? 'Restarting…' : 'Restart app' }}
+      </button>
+    </div>
+
+    <div v-if="message" class="notice" :class="messageType">
+      <i class="fas" :class="messageType === 'success' ? 'fa-check-circle' : messageType === 'error' ? 'fa-exclamation-triangle' : 'fa-info-circle'"></i>
+      {{ message }}
+    </div>
+
+    <div class="info-card">
+      <i class="fas fa-info-circle"></i>
+      <div class="info-content">
+        <h4>How hybrid mode works</h4>
+        <ul>
+          <li>This page is always listed under Settings → Configuration → Connection.</li>
+          <li>
+            External mode serves this app’s UI on <code>http://127.0.0.1:19333</code> and reverse-proxies
+            <code>/api</code> + <code>/socket.io</code> to the remote host.
+          </li>
+          <li>Remote only needs the AGNT API (<code>/api/health</code>); it does not need to serve the frontend.</li>
+          <li>After Save, restart the app so Electron applies local vs external mode.</li>
+          <li>CLI equivalent: <code>USE_EXTERNAL_BACKEND=true BACKEND_URL=http://host:3333 npm start</code></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, onMounted } from 'vue';
+
+function getDesktopBridge() {
+  if (typeof window === 'undefined') return null;
+  const api = window.electron;
+  if (!api?.getConnectionConfig || !api?.setConnectionConfig) return null;
+  return api;
+}
+
+export default {
+  name: 'ConnectionSettings',
+  setup() {
+    const useExternalBackend = ref(false);
+    const backendUrl = ref('');
+    const initial = ref({ useExternalBackend: false, backendUrl: '' });
+    const effective = ref({
+      useExternalBackend: false,
+      backendUrl: '',
+      source: 'default',
+      envOverrides: false,
+    });
+
+    const testing = ref(false);
+    const saving = ref(false);
+    const relaunching = ref(false);
+    const message = ref('');
+    const messageType = ref('info');
+    // Re-evaluated on mount; bridge is present for local + remote pages inside Electron.
+    const hasDesktopBridge = ref(Boolean(getDesktopBridge()));
+
+    const dirty = computed(() => {
+      return (
+        useExternalBackend.value !== initial.value.useExternalBackend ||
+        (backendUrl.value || '').trim() !== (initial.value.backendUrl || '').trim()
+      );
+    });
+
+    const canTest = computed(() => {
+      if (useExternalBackend.value) {
+        return Boolean((backendUrl.value || '').trim());
+      }
+      return true;
+    });
+
+    const statusLabel = computed(() => {
+      if (!hasDesktopBridge.value) {
+        return 'Viewing in browser (desktop shell not attached)';
+      }
+      return effective.value.useExternalBackend ? 'Connected to external backend' : 'Using local backend';
+    });
+
+    const statusClass = computed(() => {
+      if (!hasDesktopBridge.value) return 'local';
+      return effective.value.useExternalBackend ? 'external' : 'local';
+    });
+
+    const displayBackendUrl = computed(() => {
+      if (effective.value.backendUrl) return effective.value.backendUrl;
+      if (typeof window !== 'undefined' && window.location?.origin) {
+        return window.location.origin;
+      }
+      return '—';
+    });
+
+    const setMessage = (text, type = 'info') => {
+      message.value = text;
+      messageType.value = type;
+    };
+
+    /** Exclusive local vs external selection (replaces dual independent toggles). */
+    const selectMode = (mode) => {
+      if (!hasDesktopBridge.value) return;
+      useExternalBackend.value = mode === 'external';
+    };
+
+    const load = async () => {
+      const electron = getDesktopBridge();
+      hasDesktopBridge.value = Boolean(electron);
+      if (!electron) {
+        // Browser / non-desktop: show current page origin as the active host.
+        effective.value = {
+          useExternalBackend: false,
+          backendUrl: typeof window !== 'undefined' ? window.location.origin : '',
+          source: 'browser',
+          envOverrides: false,
+        };
+        return;
+      }
+      try {
+        const cfg = await electron.getConnectionConfig();
+        effective.value = {
+          useExternalBackend: Boolean(cfg.useExternalBackend),
+          backendUrl: cfg.backendUrl || '',
+          source: cfg.source || 'default',
+          envOverrides: Boolean(cfg.envOverrides),
+        };
+        const form = cfg.form || cfg.stored || {};
+        useExternalBackend.value = Boolean(form.useExternalBackend);
+        backendUrl.value = form.backendUrl || '';
+        initial.value = {
+          useExternalBackend: useExternalBackend.value,
+          backendUrl: backendUrl.value,
+        };
+      } catch (err) {
+        setMessage(err.message || 'Failed to load connection settings', 'error');
+      }
+    };
+
+    const testConnection = async () => {
+      const electron = getDesktopBridge();
+      if (!electron?.testConnection) return;
+      testing.value = true;
+      setMessage('');
+      try {
+        const url = useExternalBackend.value
+          ? (backendUrl.value || '').trim()
+          : effective.value.backendUrl;
+        const result = await electron.testConnection({ backendUrl: url });
+        if (result.ok) {
+          setMessage(`Health OK (${result.latencyMs ?? '?'} ms) — ${result.backendUrl}`, 'success');
+        } else {
+          setMessage(result.error || `Health check failed for ${result.backendUrl}`, 'error');
+        }
+      } catch (err) {
+        setMessage(err.message || 'Test failed', 'error');
+      } finally {
+        testing.value = false;
+      }
+    };
+
+    const saveSettings = async () => {
+      const electron = getDesktopBridge();
+      if (!electron?.setConnectionConfig) return;
+      saving.value = true;
+      setMessage('');
+      try {
+        const result = await electron.setConnectionConfig({
+          useExternalBackend: useExternalBackend.value,
+          backendUrl: (backendUrl.value || '').trim(),
+        });
+        if (!result.ok) {
+          setMessage(result.error || 'Save failed', 'error');
+          return;
+        }
+        initial.value = {
+          useExternalBackend: useExternalBackend.value,
+          backendUrl: (backendUrl.value || '').trim(),
+        };
+        setMessage(result.message || 'Saved. Restart AGNT to apply.', 'success');
+        await load();
+      } catch (err) {
+        setMessage(err.message || 'Save failed', 'error');
+      } finally {
+        saving.value = false;
+      }
+    };
+
+    const relaunch = async () => {
+      const electron = getDesktopBridge();
+      if (!electron?.relaunchApp) return;
+      if (dirty.value) {
+        setMessage('Save your changes before restarting.', 'error');
+        return;
+      }
+      relaunching.value = true;
+      try {
+        await electron.relaunchApp();
+      } catch (err) {
+        relaunching.value = false;
+        setMessage(err.message || 'Relaunch failed', 'error');
+      }
+    };
+
+    onMounted(load);
+
+    return {
+      hasDesktopBridge,
+      useExternalBackend,
+      backendUrl,
+      effective,
+      testing,
+      saving,
+      relaunching,
+      message,
+      messageType,
+      dirty,
+      canTest,
+      statusLabel,
+      statusClass,
+      displayBackendUrl,
+      selectMode,
+      testConnection,
+      saveSettings,
+      relaunch,
+    };
+  },
+};
+</script>
+
+<style scoped>
+.connection-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.settings-header h3 {
+  color: var(--color-text);
+  font-size: 1.3em;
+  font-weight: 600;
+  margin: 0 0 8px 0;
+}
+
+.settings-description {
+  color: var(--color-text-muted);
+  font-size: 0.95em;
+  margin: 0;
+  opacity: 0.85;
+}
+
+.status-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid var(--terminal-border-color);
+  background: rgba(var(--primary-rgb), 0.05);
+}
+
+/* Active runtime mode (local or external) uses the same emphasis color */
+.status-card.local,
+.status-card.external {
+  border-color: rgba(var(--primary-rgb), 0.45);
+  background: rgba(var(--primary-rgb), 0.1);
+}
+
+.status-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.status-row strong {
+  color: var(--color-text);
+  display: block;
+}
+
+.status-row p {
+  margin: 4px 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.9em;
+  word-break: break-all;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-top: 6px;
+  background: var(--color-green, #3dd68c);
+  box-shadow: 0 0 8px rgba(61, 214, 140, 0.5);
+  flex-shrink: 0;
+}
+
+.source-badge {
+  font-size: 0.75em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.connection-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.control-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  background: rgba(var(--primary-rgb), 0.03);
+  border: 1px solid var(--terminal-border-color);
+  border-radius: 8px;
+  gap: 20px;
+  flex-wrap: wrap;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+/* Only the selected mode row (local or external) is emphasized */
+.control-row.active {
+  border-color: rgba(var(--primary-rgb), 0.45);
+  background: rgba(var(--primary-rgb), 0.1);
+}
+
+.control-row.mode-row:not(.active) {
+  opacity: 0.85;
+}
+
+button.mode-card {
+  width: 100%;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+}
+
+button.mode-card:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+button.mode-card:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.radio-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid var(--color-text-muted);
+  flex-shrink: 0;
+  box-sizing: border-box;
+  position: relative;
+}
+
+.mode-card.active .radio-dot {
+  border-color: var(--color-primary);
+  box-shadow: inset 0 0 0 3px var(--color-primary);
+}
+
+.control-row.disabled {
+  opacity: 0.55;
+}
+
+.control-info {
+  flex: 1;
+  min-width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.control-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.control-label i {
+  color: var(--color-primary);
+  width: 18px;
+  text-align: center;
+}
+
+.control-description {
+  color: var(--color-text-muted);
+  font-size: 0.85em;
+  margin: 0;
+}
+
+.url-input {
+  flex: 1;
+  min-width: 240px;
+  max-width: 420px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--terminal-border-color);
+  background: var(--color-darker-0, rgba(0, 0, 0, 0.25));
+  color: var(--color-text);
+  font-family: var(--font-family-mono, ui-monospace, monospace);
+  font-size: 0.9em;
+}
+
+.url-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 52px;
+  height: 28px;
+  flex-shrink: 0;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background-color: rgba(127, 129, 147, 0.3);
+  transition: 0.3s;
+  border-radius: 28px;
+  border: 1px solid var(--terminal-border-color);
+}
+
+.slider:before {
+  position: absolute;
+  content: '';
+  height: 20px;
+  width: 20px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: 0.3s;
+  border-radius: 50%;
+}
+
+.toggle-switch input:checked + .slider {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.toggle-switch input:checked + .slider:before {
+  transform: translateX(24px);
+}
+
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.primary-btn,
+.secondary-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--terminal-border-color);
+  cursor: pointer;
+  font-size: 0.9em;
+  font-family: inherit;
+  transition: all 0.2s ease;
+}
+
+.primary-btn {
+  background: rgba(var(--primary-rgb), 0.2);
+  color: var(--color-primary);
+  border-color: rgba(var(--primary-rgb), 0.45);
+}
+
+.primary-btn:hover:not(:disabled) {
+  background: rgba(var(--primary-rgb), 0.35);
+}
+
+.secondary-btn {
+  background: transparent;
+  color: var(--color-text);
+}
+
+.secondary-btn:hover:not(:disabled) {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.primary-btn:disabled,
+.secondary-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.restart-btn {
+  margin-left: auto;
+}
+
+.notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--terminal-border-color);
+  color: var(--color-text);
+  font-size: 0.9em;
+  line-height: 1.4;
+}
+
+.notice.success {
+  border-color: rgba(61, 214, 140, 0.45);
+  background: rgba(61, 214, 140, 0.08);
+}
+
+.notice.error {
+  border-color: rgba(255, 99, 99, 0.45);
+  background: rgba(255, 99, 99, 0.08);
+}
+
+.notice.warn {
+  border-color: rgba(255, 196, 0, 0.45);
+  background: rgba(255, 196, 0, 0.08);
+}
+
+.notice.info {
+  background: rgba(var(--primary-rgb), 0.06);
+}
+
+.notice code,
+.info-content code {
+  font-family: var(--font-family-mono, ui-monospace, monospace);
+  font-size: 0.9em;
+}
+
+.info-card {
+  display: flex;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid var(--terminal-border-color);
+  background: rgba(var(--primary-rgb), 0.04);
+}
+
+.info-card > i {
+  color: var(--color-primary);
+  margin-top: 2px;
+}
+
+.info-content h4 {
+  margin: 0 0 8px;
+  color: var(--color-text);
+}
+
+.info-content ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--color-text-muted);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+</style>

--- a/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/ExternalModeBanner/ExternalModeBanner.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/ExternalModeBanner/ExternalModeBanner.vue
@@ -1,0 +1,116 @@
+<template>
+  <div v-if="isExternalMode" class="external-mode-banner" role="status">
+    <div class="banner-icon" aria-hidden="true">
+      <i class="fas fa-network-wired"></i>
+    </div>
+    <div class="banner-body">
+      <strong class="banner-title">External backend mode</strong>
+      <p class="banner-text">
+        <template v-if="!isAuthenticated">
+          Sign in to load agents and chat from the remote server
+          <span v-if="remoteHostLabel" class="remote-host"> ({{ remoteHostLabel }})</span>.
+          This desktop origin is separate from a browser tab on that host — your data was not wiped.
+        </template>
+        <template v-else>
+          Connected to remote
+          <span v-if="remoteHostLabel" class="remote-host">{{ remoteHostLabel }}</span>
+          <span v-else>backend</span>. Agents and history come from that server.
+        </template>
+      </p>
+      <button v-if="showConnectionLink" type="button" class="banner-link" @click="$emit('open-connection')">
+        Settings → Connection
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { useDesktopConnection } from '@/composables/useDesktopConnection.js';
+
+export default {
+  name: 'ExternalModeBanner',
+  props: {
+    isAuthenticated: {
+      type: Boolean,
+      default: false,
+    },
+    showConnectionLink: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  emits: ['open-connection'],
+  setup() {
+    const { isExternalMode, remoteHostLabel, backendUrl } = useDesktopConnection();
+    return { isExternalMode, remoteHostLabel, backendUrl };
+  },
+};
+</script>
+
+<style scoped>
+.external-mode-banner {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  width: 100%;
+  max-width: 420px;
+  margin: 0 auto 20px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(var(--primary-rgb), 0.4);
+  background: rgba(var(--primary-rgb), 0.1);
+  text-align: left;
+  box-sizing: border-box;
+}
+
+.banner-icon {
+  color: var(--color-primary);
+  font-size: 1.1rem;
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+
+.banner-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.banner-title {
+  display: block;
+  color: var(--color-text);
+  font-size: 0.95rem;
+  margin-bottom: 4px;
+}
+
+.banner-text {
+  margin: 0 0 8px;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
+.remote-host {
+  color: var(--color-primary);
+  font-family: var(--font-family-mono, ui-monospace, monospace);
+  font-size: 0.9em;
+  word-break: break-all;
+}
+
+.banner-link {
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  color: var(--color-primary);
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.banner-link:hover {
+  opacity: 0.9;
+}
+</style>

--- a/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue
@@ -11,11 +11,26 @@
     />
 
     <div v-if="!isAuthenticated" class="auth-content">
+      <ExternalModeBanner
+        :is-authenticated="false"
+        :show-connection-link="true"
+        @open-connection="openConnectionSettings"
+      />
+
       <!-- Email Login Form -->
       <div v-if="!showCodeModal">
         <header class="auth-header">
           <h2>Sign in to AGNT</h2>
-          <p class="auth-subtitle">Secure, passwordless access to your workspace.</p>
+          <p class="auth-subtitle">
+            <template v-if="isExternalMode && remoteHostLabel">
+              Sign in to load your workspace from
+              <span class="remote-host-inline">{{ remoteHostLabel }}</span>.
+            </template>
+            <template v-else-if="isExternalMode">
+              External backend mode — sign in to load agents and chat from the remote server.
+            </template>
+            <template v-else> Secure, passwordless access to your workspace. </template>
+          </p>
         </header>
 
         <div class="login-options">
@@ -107,18 +122,26 @@ import { useRouter } from 'vue-router';
 import axios from 'axios';
 import SvgIcon from '@/views/_components/common/SvgIcon.vue';
 import TermsPrivacyModal from '@/components/TermsPrivacyModal.vue';
+import ExternalModeBanner from '../ExternalModeBanner/ExternalModeBanner.vue';
 import { API_CONFIG } from '@/tt.config.js';
+import { useDesktopConnection } from '@/composables/useDesktopConnection.js';
 
 export default {
   name: 'AuthSection',
-  components: { SvgIcon, TermsPrivacyModal },
+  components: { SvgIcon, TermsPrivacyModal, ExternalModeBanner },
+  emits: ['login-success', 'open-connection'],
   setup(props, { emit }) {
     const store = useStore();
     const router = useRouter();
+    const { isExternalMode, remoteHostLabel } = useDesktopConnection();
 
     const isAuthenticated = computed(() => store.getters['userAuth/isAuthenticated']);
     const user = computed(() => store.state.userAuth.user);
     const displayPseudonym = computed(() => store.getters['userAuth/userPseudonym']);
+
+    const openConnectionSettings = () => {
+      emit('open-connection');
+    };
 
     // Email magic link state
     const email = ref('');
@@ -356,6 +379,9 @@ export default {
       isAuthenticated,
       user,
       displayPseudonym,
+      isExternalMode,
+      remoteHostLabel,
+      openConnectionSettings,
       email,
       isLoading,
       errorMessage,
@@ -470,6 +496,14 @@ body.dark .auth-section {
   font-size: 13px;
   color: var(--color-text-muted);
   opacity: 0.85;
+}
+
+.remote-host-inline {
+  color: var(--color-primary);
+  font-family: var(--font-family-mono, ui-monospace, monospace);
+  font-size: 0.95em;
+  -webkit-text-fill-color: var(--color-primary);
+  word-break: break-all;
 }
 
 .login-options {

--- a/frontend/src/views/Terminal/LeftPanel/types/SettingsPanel/SettingsPanel.vue
+++ b/frontend/src/views/Terminal/LeftPanel/types/SettingsPanel/SettingsPanel.vue
@@ -57,6 +57,15 @@
             <i class="fas fa-volume-up"></i>
             <span>Sounds</span>
           </button>
+          <button
+            class="nav-item"
+            :class="{ active: activeSection === 'connection' }"
+            @click="handleNavClick('connection')"
+            data-nav="connection"
+          >
+            <i class="fas fa-network-wired"></i>
+            <span>Connection</span>
+          </button>
           <button class="nav-item" :class="{ active: activeSection === 'tours' }" @click="handleNavClick('tours')" data-nav="tours">
             <i class="fas fa-route"></i>
             <span>Tours</span>
@@ -90,7 +99,7 @@
 </template>
 
 <script>
-import { ref, computed, toRefs } from 'vue';
+import { ref, toRefs } from 'vue';
 
 export default {
   name: 'SettingsPanel',

--- a/frontend/user.config.js
+++ b/frontend/user.config.js
@@ -53,14 +53,21 @@ export const AI_PROVIDERS_CONFIG = {
 // };
 
 // Semi Local Configuration
-// Dynamically detect backend URL based on how the frontend is served
-const isDevServer = typeof window !== 'undefined' && window.location.port === '5173';
-const backendBaseUrl = isDevServer
-  ? 'http://localhost:3333/api'
-  : `${typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3333'}/api`;
+// Co-located: origin/api. Vite dev (5173): localhost:3333/api.
+// Electron external mode: UI+proxy on 127.0.0.1:19333 — still origin/api (same-origin).
+function resolveBackendBaseUrl() {
+  const isDevServer = typeof window !== 'undefined' && window.location.port === '5173';
+  if (isDevServer) {
+    return 'http://localhost:3333/api';
+  }
+  const origin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3333';
+  return `${origin}/api`;
+}
 
 export const API_CONFIG = {
-  BASE_URL: backendBaseUrl, // dynamically set based on frontend port
+  get BASE_URL() {
+    return resolveBackendBaseUrl();
+  },
   FRONTEND_URL: 'http://localhost:5173', // local frontend url (dev server)
   WEBHOOK_URL: 'https://api.agnt.gg', // remote webhook url
   REMOTE_URL: 'https://api.agnt.gg', // remote url for sharing, login, app auths, and webhooks

--- a/main.js
+++ b/main.js
@@ -7,12 +7,32 @@ import { Readable } from 'stream';
 
 // DEBUG: Show which main.js is being loaded
 console.log('=== LOADING MAIN.JS FROM:', import.meta.url, '===');
-import http from 'http'; // Import http to poll the backend
 import https from 'https'; // Import https for update checks
 import dotenv from 'dotenv';
+import {
+  initDesktopConnection,
+  getUiLoadUrl,
+  prepareConnectionForLaunch,
+  waitForBackendReady,
+  recoverOnActivate,
+  stopDesktopConnection,
+} from './electron/desktop-connection.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+// Load root .env early so USE_EXTERNAL_BACKEND / BACKEND_URL work before boot.
+// Packaged builds still prefer userData desktop-connection.json from Settings.
+if (!app.isPackaged) {
+  const rootEnvPath = path.join(__dirname, '.env');
+  if (fs.existsSync(rootEnvPath)) {
+    try {
+      dotenv.config({ path: rootEnvPath });
+    } catch (err) {
+      console.warn('[connection] Could not load root .env:', err.message);
+    }
+  }
+}
 
 // ============================================================================
 // DIAGNOSTICS
@@ -125,6 +145,54 @@ protocol.registerSchemesAsPrivileged([
 
 let mainWindow;
 let backendProcess;
+let windowControlIpcRegistered = false;
+/** webContents ids that already have F11/Escape handlers */
+const chromeAttached = new Set();
+
+/**
+ * Wire F11 / Escape / title freeze once per BrowserWindow webContents.
+ */
+function attachMainWindowChrome() {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  const id = mainWindow.webContents.id;
+  if (chromeAttached.has(id)) return;
+  chromeAttached.add(id);
+  mainWindow.webContents.once('destroyed', () => chromeAttached.delete(id));
+
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (input.key === 'F11' && !input.alt && !input.control && !input.meta && !input.shift) {
+      const isFullScreen = mainWindow.isFullScreen();
+      mainWindow.setFullScreen(!isFullScreen);
+      event.preventDefault();
+    }
+    if (input.key === 'Escape' && mainWindow.isFullScreen()) {
+      mainWindow.setFullScreen(false);
+      event.preventDefault();
+    }
+  });
+  mainWindow.on('page-title-updated', (event) => {
+    event.preventDefault();
+  });
+}
+
+/** Register window control IPC once (createWindow may run multiple times). */
+function registerWindowControlIpc() {
+  if (windowControlIpcRegistered) return;
+  windowControlIpcRegistered = true;
+
+  ipcMain.on('minimize-window', () => {
+    if (mainWindow) mainWindow.minimize();
+  });
+  ipcMain.on('maximize-window', () => {
+    if (mainWindow) {
+      if (mainWindow.isMaximized()) mainWindow.unmaximize();
+      else mainWindow.maximize();
+    }
+  });
+  ipcMain.on('close-window', () => {
+    if (mainWindow) mainWindow.close();
+  });
+}
 
 // ============================================================================
 // BACKEND SUPERVISOR - sanctioned self-restart support
@@ -188,7 +256,8 @@ function handleBackendExit(code, signal, lastStderr, lastStdout) {
     // "restart yourself" doubles as credential hot-reload).
     setTimeout(() => {
       startBackend();
-      waitForBackend(() => {
+      waitForBackendReady().then((ok) => {
+        if (!ok) return;
         supervisor.state = 'running';
         console.log('Backend respawned and healthy.');
         notifyRenderer('backend:restarted');
@@ -832,9 +901,10 @@ function createWindow() {
     });
   });
 
-  // Load the URL that is serving your API and frontend.
-  const port = process.env.PORT || 3333;
-  mainWindow.loadURL(`http://localhost:${port}`);
+  // Load the UI (local co-located backend or external-mode local proxy origin).
+  const loadUrl = getUiLoadUrl();
+  console.log('[connection] Loading UI from:', loadUrl);
+  mainWindow.loadURL(loadUrl);
 
   mainWindow.center();
   mainWindow.show();
@@ -842,89 +912,19 @@ function createWindow() {
   mainWindow.on('closed', () => {
     mainWindow = null;
   });
-
-  // Add IPC listeners for window controls.
-  ipcMain.on('minimize-window', () => {
-    if (mainWindow) mainWindow.minimize();
-  });
-
-  ipcMain.on('maximize-window', () => {
-    if (mainWindow) {
-      if (mainWindow.isMaximized()) {
-        mainWindow.unmaximize();
-      } else {
-        mainWindow.maximize();
-      }
-    }
-  });
-
-  ipcMain.on('close-window', () => {
-    if (mainWindow) mainWindow.close();
-  });
-}
-
-// Polls the backend at localhost:3333 until it responds, then calls the callback.
-function waitForBackend(callback) {
-  const port = process.env.PORT || 3333;
-  const options = {
-    hostname: '127.0.0.1', // Use IP instead of localhost
-    port: parseInt(port),
-    path: '/api/health',
-    method: 'GET',
-    timeout: 30000, // 30s per request — backend may block the event loop during plugin/skill init
-  };
-
-  let isBackendReady = false;
-  let retryCount = 0;
-
-  // PRD-105 P2: flat fast polling. A refused localhost connection costs ~1ms,
-  // so there is no resource to protect with backoff — exponential delays were
-  // adding 2-4s of dead air AFTER the backend was already up (the backend
-  // routinely became ready inside the 4s gap between attempts 3 and 4).
-  const getRetryDelay = () => 250;
-
-  const attempt = () => {
-    console.log(`Attempting to connect to backend (attempt ${retryCount + 1})...`);
-    const req = http.request(options, (res) => {
-      let data = '';
-      res.on('data', (chunk) => {
-        data += chunk;
-      });
-      res.on('end', () => {
-        if (res.statusCode === 200 && !isBackendReady) {
-          console.log('Backend is ready');
-          isBackendReady = true;
-          callback();
-        } else if (!isBackendReady) {
-          retryCount++;
-          const delay = getRetryDelay();
-          console.log(`Backend not ready (status ${res.statusCode}). Retry ${retryCount} in ${delay}ms`);
-          setTimeout(attempt, delay);
-        }
-      });
-    });
-
-    req.on('error', (error) => {
-      retryCount++;
-      const delay = getRetryDelay();
-      console.log(`Backend connection error (${error.message}). Retry ${retryCount} in ${delay}ms`);
-      setTimeout(attempt, delay);
-    });
-
-    req.on('timeout', () => {
-      // Just destroy — the resulting 'error' event handles the retry, so this
-      // doesn't double-fire (was causing back-to-back "timed out" / "socket
-      // hang up" retry pairs).
-      req.destroy();
-    });
-
-    req.end();
-  };
-
-  attempt();
 }
 
 app.on('ready', () => {
+  initDesktopConnection({
+    app,
+    BrowserWindow,
+    dialog,
+    ipcMain,
+    dirname: __dirname,
+    getMainWindow: () => mainWindow,
+  });
+  registerWindowControlIpc();
+
   // Native minidumps (V8/native aborts never reach JS) plus the four Electron
   // death modes: render-process-gone, child-process-gone, gpu crash, and a
   // frozen window. Windows are auto-watched via 'browser-window-created', so
@@ -1023,36 +1023,13 @@ app.on('ready', () => {
     }
   });
 
-  // Start the backend process from within Electron.
-  startBackend();
-
-  // Instead of a fixed delay, poll until the backend is ready.
-  waitForBackend(() => {
+  // Hybrid connection: local Express OR external proxy UI + remote API.
+  prepareConnectionForLaunch({ startBackend }).then((ready) => {
+    if (!ready) return;
     supervisor.state = 'running';
     console.log('Backend is ready. Creating main window...');
     createWindow();
-
-    // Register local shortcuts after the window is created.
-    mainWindow.webContents.on('before-input-event', (event, input) => {
-      if (input.key === 'F11' && !input.alt && !input.control && !input.meta && !input.shift) {
-        const isFullScreen = mainWindow.isFullScreen();
-        mainWindow.setFullScreen(!isFullScreen);
-        event.preventDefault();
-      }
-      if (input.key === 'Escape' && mainWindow.isFullScreen()) {
-        mainWindow.setFullScreen(false);
-        event.preventDefault();
-      }
-    });
-
-    // Remove global shortcut registrations
-    // globalShortcut.register('F11', () => { ... });
-    // globalShortcut.register('Escape', () => { ... });
-
-    // Prevent default page title updates.
-    mainWindow.on('page-title-updated', (event) => {
-      event.preventDefault();
-    });
+    attachMainWindowChrome();
   });
 });
 
@@ -1063,9 +1040,15 @@ app.on('window-all-closed', () => {
 });
 
 app.on('activate', () => {
-  if (app.isReady() && BrowserWindow.getAllWindows().length === 0) {
-    createWindow();
-  }
+  if (!app.isReady() || BrowserWindow.getAllWindows().length > 0) return;
+  recoverOnActivate({
+    createWindow,
+    attachChrome: attachMainWindowChrome,
+  }).then(() => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      supervisor.state = 'running';
+    }
+  });
 });
 
 app.on('will-quit', () => {
@@ -1074,5 +1057,6 @@ app.on('will-quit', () => {
     console.log('Shutting down backend process...');
     backendProcess.kill();
   }
+  stopDesktopConnection();
   globalShortcut.unregisterAll();
 });

--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
     "files": [
       "main.js",
       "preload.js",
+      "electron/**/*",
       "assets/**/*",
       "backend/**/*",
       "docs/_API-DOCUMENTATION.md",

--- a/preload.js
+++ b/preload.js
@@ -1,5 +1,17 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
+// Sync snapshot for Settings/status. External mode uses same-origin proxy:
+// UI on 127.0.0.1:19333, so API is window.location.origin/api (no remote BASE_URL inject).
+const desktopRuntime = (() => {
+  try {
+    return ipcRenderer.sendSync('connection:get-desktop-runtime') || {};
+  } catch {
+    return {};
+  }
+})();
+
+contextBridge.exposeInMainWorld('__AGNT_DESKTOP__', desktopRuntime);
+
 contextBridge.exposeInMainWorld('electron', {
   send: (channel, data) => {
     let validChannels = ['minimize-window', 'maximize-window', 'close-window', 'open-download-page', 'open-external-url'];
@@ -15,6 +27,14 @@ contextBridge.exposeInMainWorld('electron', {
   // Update system - one-way messages
   openDownloadPage: () => ipcRenderer.send('open-download-page'),
   openExternalUrl: (url) => ipcRenderer.send('open-external-url', url),
+
+  // Hybrid / external backend connection (Settings → Connection).
+  getConnectionConfig: () => ipcRenderer.invoke('connection:get'),
+  setConnectionConfig: (config) => ipcRenderer.invoke('connection:set', config),
+  testConnection: (config) => ipcRenderer.invoke('connection:test', config),
+  relaunchApp: () => ipcRenderer.invoke('app:relaunch'),
+  quitApp: () => ipcRenderer.invoke('app:quit'),
+  getDesktopRuntime: () => desktopRuntime,
 
   // OS file manager bridge — used by the artifacts file tree right-click menu.
   // Renderer code should guard on `window.electron?.revealInFolder` so the menu

--- a/tests/unit/electron-connection-config.test.js
+++ b/tests/unit/electron-connection-config.test.js
@@ -1,0 +1,352 @@
+/**
+ * Unit tests for hybrid / external-backend connection config.
+ *
+ * Covers pure resolution logic used by Electron main + Settings IPC:
+ *   - normalize / validate URLs
+ *   - read/write desktop-connection.json
+ *   - env vs file vs default precedence
+ *   - invalid external URL falls back to local
+ *   - health probe against a tiny local server
+ *
+ * Run: npm test
+ *   or: npx vitest run tests/unit/electron-connection-config.test.js
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import http from 'http';
+
+import {
+  connectionConfigPath,
+  readStoredConnectionConfig,
+  writeStoredConnectionConfig,
+  normalizeBackendUrl,
+  validateBackendUrl,
+  resolveConnectionConfig,
+  probeBackendHealth,
+  waitUntilHealthy,
+} from '../../electron/connection-config.js';
+
+function makeTempUserData() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'agnt-conn-test-'));
+}
+
+function rmrf(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe('normalizeBackendUrl', () => {
+  it('returns empty for nullish / non-string', () => {
+    expect(normalizeBackendUrl('')).toBe('');
+    expect(normalizeBackendUrl(null)).toBe('');
+    expect(normalizeBackendUrl(undefined)).toBe('');
+    expect(normalizeBackendUrl(42)).toBe('');
+  });
+
+  it('trims whitespace and trailing slashes', () => {
+    expect(normalizeBackendUrl('  http://host:3333/  ')).toBe('http://host:3333');
+    expect(normalizeBackendUrl('http://host:3333///')).toBe('http://host:3333');
+  });
+
+  it('strips a trailing /api suffix', () => {
+    expect(normalizeBackendUrl('http://10.0.0.5:3333/api')).toBe('http://10.0.0.5:3333');
+    expect(normalizeBackendUrl('http://10.0.0.5:3333/api/')).toBe('http://10.0.0.5:3333');
+  });
+
+  it('does not strip /api mid-path', () => {
+    expect(normalizeBackendUrl('http://host/api/v1')).toBe('http://host/api/v1');
+  });
+});
+
+describe('validateBackendUrl', () => {
+  it('rejects empty', () => {
+    const r = validateBackendUrl('');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/required/i);
+  });
+
+  it('rejects non-absolute garbage', () => {
+    const r = validateBackendUrl('not a url');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/valid URL/i);
+  });
+
+  it('rejects non-http protocols', () => {
+    const r = validateBackendUrl('ftp://files.example.com');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/http/i);
+  });
+
+  it('accepts http and https and returns cleaned', () => {
+    const httpR = validateBackendUrl('http://192.168.1.10:3333/api/');
+    expect(httpR.ok).toBe(true);
+    expect(httpR.cleaned).toBe('http://192.168.1.10:3333');
+
+    const httpsR = validateBackendUrl('https://agnt.example.com');
+    expect(httpsR.ok).toBe(true);
+    expect(httpsR.cleaned).toBe('https://agnt.example.com');
+  });
+});
+
+describe('read/write desktop-connection.json', () => {
+  let userData;
+
+  beforeAll(() => {
+    userData = makeTempUserData();
+  });
+
+  afterAll(() => {
+    rmrf(userData);
+  });
+
+  it('defaults when file is missing', () => {
+    const stored = readStoredConnectionConfig(userData);
+    expect(stored).toEqual({ useExternalBackend: false, backendUrl: '' });
+    expect(connectionConfigPath(userData)).toBe(path.join(userData, 'desktop-connection.json'));
+  });
+
+  it('round-trips config and strips trailing slash on write', () => {
+    const written = writeStoredConnectionConfig(userData, {
+      useExternalBackend: true,
+      backendUrl: 'http://server:3333/',
+    });
+    expect(written.useExternalBackend).toBe(true);
+    expect(written.backendUrl).toBe('http://server:3333');
+
+    const stored = readStoredConnectionConfig(userData);
+    expect(stored.useExternalBackend).toBe(true);
+    expect(stored.backendUrl).toBe('http://server:3333');
+  });
+
+  it('recovers from corrupt JSON', () => {
+    fs.writeFileSync(connectionConfigPath(userData), '{not-json', 'utf8');
+    const stored = readStoredConnectionConfig(userData);
+    expect(stored).toEqual({ useExternalBackend: false, backendUrl: '' });
+  });
+});
+
+describe('resolveConnectionConfig', () => {
+  let userData;
+
+  beforeAll(() => {
+    userData = makeTempUserData();
+  });
+
+  afterAll(() => {
+    rmrf(userData);
+  });
+
+  it('defaults to local backend on 127.0.0.1:3333', () => {
+    const r = resolveConnectionConfig({ userDataPath: userData, env: {} });
+    expect(r.useExternalBackend).toBe(false);
+    expect(r.backendUrl).toBe('http://127.0.0.1:3333');
+    expect(r.loadUrl).toBe('http://127.0.0.1:3333');
+    expect(r.healthUrl).toBe('http://127.0.0.1:3333/api/health');
+    expect(r.source).toBe('default');
+    expect(r.envOverrides).toBe(false);
+  });
+
+  it('respects PORT for the local default', () => {
+    const r = resolveConnectionConfig({ userDataPath: userData, env: { PORT: '4444' } });
+    expect(r.backendUrl).toBe('http://127.0.0.1:4444');
+    expect(r.healthUrl).toBe('http://127.0.0.1:4444/api/health');
+  });
+
+  it('uses stored file when external is enabled', () => {
+    writeStoredConnectionConfig(userData, {
+      useExternalBackend: true,
+      backendUrl: 'http://10.0.0.9:3333/api',
+    });
+    const r = resolveConnectionConfig({ userDataPath: userData, env: {} });
+    expect(r.useExternalBackend).toBe(true);
+    expect(r.backendUrl).toBe('http://10.0.0.9:3333');
+    expect(r.healthUrl).toBe('http://10.0.0.9:3333/api/health');
+    expect(r.source).toBe('file');
+    expect(r.envOverrides).toBe(false);
+  });
+
+  it('env USE_EXTERNAL_BACKEND + BACKEND_URL override the file', () => {
+    writeStoredConnectionConfig(userData, {
+      useExternalBackend: true,
+      backendUrl: 'http://from-file:3333',
+    });
+    const r = resolveConnectionConfig({
+      userDataPath: userData,
+      env: {
+        USE_EXTERNAL_BACKEND: 'true',
+        BACKEND_URL: 'http://from-env:9999/api',
+      },
+    });
+    expect(r.useExternalBackend).toBe(true);
+    expect(r.backendUrl).toBe('http://from-env:9999');
+    expect(r.source).toBe('env');
+    expect(r.envOverrides).toBe(true);
+    expect(r.stored.backendUrl).toBe('http://from-file:3333');
+  });
+
+  it('BACKEND_URL alone enables external mode from env source', () => {
+    writeStoredConnectionConfig(userData, {
+      useExternalBackend: false,
+      backendUrl: '',
+    });
+    const r = resolveConnectionConfig({
+      userDataPath: userData,
+      env: { BACKEND_URL: 'https://remote.example.com' },
+    });
+    expect(r.useExternalBackend).toBe(true);
+    expect(r.backendUrl).toBe('https://remote.example.com');
+    expect(r.source).toBe('env');
+  });
+
+  it('USE_EXTERNAL_BACKEND=false forces local even if file says external', () => {
+    writeStoredConnectionConfig(userData, {
+      useExternalBackend: true,
+      backendUrl: 'http://should-not-use:3333',
+    });
+    const r = resolveConnectionConfig({
+      userDataPath: userData,
+      env: { USE_EXTERNAL_BACKEND: 'false' },
+    });
+    expect(r.useExternalBackend).toBe(false);
+    expect(r.backendUrl).toBe('http://127.0.0.1:3333');
+    expect(r.source).toBe('env');
+  });
+
+  it('falls back to local when external URL is invalid', () => {
+    writeStoredConnectionConfig(userData, {
+      useExternalBackend: true,
+      backendUrl: 'not-a-url',
+    });
+    const r = resolveConnectionConfig({ userDataPath: userData, env: {} });
+    expect(r.useExternalBackend).toBe(false);
+    expect(r.backendUrl).toBe('http://127.0.0.1:3333');
+    expect(r.source).toBe('default');
+  });
+
+  it('treats useExternalBackend false with only a stored URL as local', () => {
+    writeStoredConnectionConfig(userData, {
+      useExternalBackend: false,
+      backendUrl: 'http://ignored-when-local:3333',
+    });
+    const r = resolveConnectionConfig({ userDataPath: userData, env: {} });
+    expect(r.useExternalBackend).toBe(false);
+    expect(r.backendUrl).toBe('http://127.0.0.1:3333');
+    expect(r.source).toBe('file');
+  });
+});
+
+describe('probeBackendHealth', () => {
+  let server;
+  let baseUrl;
+  let statusCode = 200;
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      if (req.url === '/api/health') {
+        res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok' }));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  it('returns ok for a healthy backend', async () => {
+    statusCode = 200;
+    const result = await probeBackendHealth(baseUrl, 3000);
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(typeof result.latencyMs).toBe('number');
+  });
+
+  it('returns not ok for non-200 health', async () => {
+    statusCode = 503;
+    const result = await probeBackendHealth(baseUrl, 3000);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(503);
+    expect(result.error).toMatch(/503/);
+  });
+
+  it('rejects invalid URLs without opening a socket', async () => {
+    const result = await probeBackendHealth('ftp://nope', 1000);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/http/i);
+  });
+
+  it('reports connection errors for closed ports', async () => {
+    const result = await probeBackendHealth('http://127.0.0.1:1', 2000);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+});
+
+describe('waitUntilHealthy', () => {
+  let server;
+  let baseUrl;
+  let hits;
+
+  beforeAll(async () => {
+    hits = 0;
+    server = http.createServer((_req, res) => {
+      hits += 1;
+      // Fail first two probes, then succeed
+      if (hits < 3) {
+        res.writeHead(503);
+        res.end('not yet');
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok' }));
+    });
+    await new Promise((r) => server.listen(0, '127.0.0.1', r));
+    baseUrl = `http://127.0.0.1:${server.address().port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise((r) => server.close(r));
+  });
+
+  it('retries until health succeeds', async () => {
+    hits = 0;
+    const result = await waitUntilHealthy(baseUrl, {
+      maxAttempts: 5,
+      intervalMs: 10,
+      requestTimeoutMs: 2000,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toBeGreaterThanOrEqual(3);
+  });
+
+  it('stops after maxAttempts', async () => {
+    hits = 0;
+    // Force permanent 503 by restarting logic: first request after reset is 503
+    // Keep server always 503 for this test via a separate server
+    let alwaysDown;
+    alwaysDown = http.createServer((_req, res) => {
+      res.writeHead(503);
+      res.end('down');
+    });
+    await new Promise((r) => alwaysDown.listen(0, '127.0.0.1', r));
+    const url = `http://127.0.0.1:${alwaysDown.address().port}`;
+    try {
+      const result = await waitUntilHealthy(url, {
+        maxAttempts: 3,
+        intervalMs: 5,
+        requestTimeoutMs: 1000,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.attempts).toBe(3);
+    } finally {
+      await new Promise((r) => alwaysDown.close(r));
+    }
+  });
+});

--- a/tests/unit/electron-local-ui-server.test.js
+++ b/tests/unit/electron-local-ui-server.test.js
@@ -1,0 +1,319 @@
+/**
+ * Unit tests for the Electron local UI static server + reverse proxy.
+ *
+ * Covers:
+ *   - missing dist / index errors
+ *   - static file serving + SPA fallback
+ *   - path-escape protection
+ *   - /api and /socket.io proxy to a mock remote
+ *   - proxy 502 when remote is down
+ *   - fixed vs ephemeral ports
+ *   - resolveFrontendDistPath candidates
+ *
+ * Run: npx vitest run tests/unit/electron-local-ui-server.test.js
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import http from 'http';
+
+import {
+  startLocalUiServer,
+  resolveFrontendDistPath,
+  DEFAULT_LOCAL_UI_PORT,
+} from '../../electron/local-ui-server.js';
+
+function rmrf(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function makeFakeDist() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agnt-ui-dist-'));
+  fs.writeFileSync(path.join(dir, 'index.html'), '<!doctype html><title>AGNT UI</title><div id="app">ok</div>');
+  fs.writeFileSync(path.join(dir, 'app.js'), 'console.log("hi")');
+  fs.mkdirSync(path.join(dir, 'assets'));
+  fs.writeFileSync(path.join(dir, 'assets', 'style.css'), 'body{color:red}');
+  return dir;
+}
+
+function fetchText(url, options = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(url, { method: options.method || 'GET', headers: options.headers || {} }, (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        resolve({
+          status: res.statusCode,
+          headers: res.headers,
+          body: Buffer.concat(chunks).toString('utf8'),
+        });
+      });
+    });
+    req.on('error', reject);
+    if (options.body) req.write(options.body);
+    req.end();
+  });
+}
+
+describe('DEFAULT_LOCAL_UI_PORT', () => {
+  it('is the stable desktop UI port 19333', () => {
+    expect(DEFAULT_LOCAL_UI_PORT).toBe(19333);
+  });
+});
+
+describe('startLocalUiServer — validation', () => {
+  it('rejects when dist dir is missing', async () => {
+    await expect(startLocalUiServer('/tmp/agnt-no-such-dist-xyz', { port: 0 })).rejects.toThrow(/dist not found/i);
+  });
+
+  it('rejects when index.html is missing', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agnt-ui-empty-'));
+    try {
+      await expect(startLocalUiServer(dir, { port: 0 })).rejects.toThrow(/index\.html/i);
+    } finally {
+      rmrf(dir);
+    }
+  });
+
+  it('rejects invalid proxyTarget', async () => {
+    const dist = makeFakeDist();
+    try {
+      await expect(startLocalUiServer(dist, { port: 0, proxyTarget: 'not a url' })).rejects.toThrow(/Invalid proxy target/i);
+    } finally {
+      rmrf(dist);
+    }
+  });
+});
+
+describe('startLocalUiServer — static', () => {
+  let dist;
+  let handle;
+
+  beforeAll(async () => {
+    dist = makeFakeDist();
+    handle = await startLocalUiServer(dist, { port: 0 });
+  });
+
+  afterAll(async () => {
+    await new Promise((r) => handle.server.close(r));
+    rmrf(dist);
+  });
+
+  it('serves index.html at /', async () => {
+    const res = await fetchText(`${handle.origin}/`);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/html/);
+    expect(res.body).toContain('AGNT UI');
+  });
+
+  it('serves static assets with correct content-type', async () => {
+    const js = await fetchText(`${handle.origin}/app.js`);
+    expect(js.status).toBe(200);
+    expect(js.headers['content-type']).toMatch(/javascript/);
+    expect(js.body).toContain('console.log');
+
+    const css = await fetchText(`${handle.origin}/assets/style.css`);
+    expect(css.status).toBe(200);
+    expect(css.headers['content-type']).toMatch(/text\/css/);
+  });
+
+  it('SPA-fallbacks unknown routes to index.html', async () => {
+    const res = await fetchText(`${handle.origin}/settings/connection`);
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('AGNT UI');
+  });
+
+  it('blocks path traversal outside dist', async () => {
+    const res = await fetchText(`${handle.origin}/../../../../etc/passwd`);
+    // Either 403 Forbidden or SPA fallback to index (both avoid leaking files)
+    if (res.status === 403) {
+      expect(res.body).toMatch(/Forbidden/i);
+    } else {
+      expect(res.status).toBe(200);
+      expect(res.body).toContain('AGNT UI');
+      expect(res.body).not.toMatch(/^root:/);
+    }
+  });
+
+  it('uses an ephemeral port when port is 0', () => {
+    expect(handle.port).toBeGreaterThan(0);
+    expect(handle.origin).toBe(`http://127.0.0.1:${handle.port}`);
+  });
+});
+
+describe('startLocalUiServer — proxy', () => {
+  let dist;
+  let remote;
+  let remotePort;
+  let remoteHits;
+  let handle;
+
+  beforeAll(async () => {
+    dist = makeFakeDist();
+    remoteHits = [];
+
+    remote = http.createServer((req, res) => {
+      remoteHits.push({ method: req.method, url: req.url });
+      if (req.url === '/api/health' || req.url?.startsWith('/api/health')) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok', via: 'remote' }));
+        return;
+      }
+      if (req.url?.startsWith('/api/agents')) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify([{ id: 1, name: 'Test Agent' }]));
+        return;
+      }
+      if (req.url?.startsWith('/socket.io/')) {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('socket-io-ok');
+        return;
+      }
+      res.writeHead(404);
+      res.end('remote-miss');
+    });
+
+    await new Promise((r) => remote.listen(0, '127.0.0.1', r));
+    remotePort = remote.address().port;
+
+    handle = await startLocalUiServer(dist, {
+      port: 0,
+      proxyTarget: `http://127.0.0.1:${remotePort}`,
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise((r) => handle.server.close(r));
+    await new Promise((r) => remote.close(r));
+    rmrf(dist);
+  });
+
+  beforeEach(() => {
+    remoteHits.length = 0;
+  });
+
+  it('proxies /api/health to the remote backend', async () => {
+    const res = await fetchText(`${handle.origin}/api/health`);
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ status: 'ok', via: 'remote' });
+    expect(remoteHits.some((h) => h.url?.startsWith('/api/health'))).toBe(true);
+  });
+
+  it('proxies /api/agents (JSON)', async () => {
+    const res = await fetchText(`${handle.origin}/api/agents`);
+    expect(res.status).toBe(200);
+    const data = JSON.parse(res.body);
+    expect(data[0].name).toBe('Test Agent');
+  });
+
+  it('proxies /socket.io/ polling path', async () => {
+    const res = await fetchText(`${handle.origin}/socket.io/?EIO=4&transport=polling`);
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('socket-io-ok');
+  });
+
+  it('still serves local UI for non-api paths while proxy is enabled', async () => {
+    const res = await fetchText(`${handle.origin}/`);
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('AGNT UI');
+    expect(remoteHits.length).toBe(0);
+  });
+
+  it('returns 502 when proxy target is unreachable', async () => {
+    const deadDist = makeFakeDist();
+    let deadHandle;
+    try {
+      deadHandle = await startLocalUiServer(deadDist, {
+        port: 0,
+        proxyTarget: 'http://127.0.0.1:1',
+      });
+      const res = await fetchText(`${deadHandle.origin}/api/health`);
+      expect(res.status).toBe(502);
+      expect(res.body).toMatch(/Proxy|failed|error/i);
+    } finally {
+      if (deadHandle) await new Promise((r) => deadHandle.server.close(r));
+      rmrf(deadDist);
+    }
+  });
+});
+
+describe('startLocalUiServer — port fallback', () => {
+  it('falls back when preferred port is busy', async () => {
+    const dist = makeFakeDist();
+    const blocker = http.createServer((_req, res) => res.end('busy'));
+    let ui;
+    try {
+      await new Promise((r) => blocker.listen(0, '127.0.0.1', r));
+      const busyPort = blocker.address().port;
+
+      ui = await startLocalUiServer(dist, { port: busyPort });
+      // Should not fail; either same port stolen (unlikely) or ephemeral fallback
+      expect(ui.port).toBeGreaterThan(0);
+      const res = await fetchText(`${ui.origin}/`);
+      expect(res.status).toBe(200);
+      expect(res.body).toContain('AGNT UI');
+    } finally {
+      if (ui) await new Promise((r) => ui.server.close(r));
+      await new Promise((r) => blocker.close(r));
+      rmrf(dist);
+    }
+  });
+});
+
+describe('resolveFrontendDistPath', () => {
+  let tmp;
+  let withIndex;
+  let withoutIndex;
+
+  beforeAll(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agnt-resolve-'));
+    withIndex = path.join(tmp, 'frontend', 'dist');
+    fs.mkdirSync(withIndex, { recursive: true });
+    fs.writeFileSync(path.join(withIndex, 'index.html'), '<html></html>');
+
+    withoutIndex = path.join(tmp, 'empty', 'frontend', 'dist');
+    fs.mkdirSync(withoutIndex, { recursive: true });
+  });
+
+  afterAll(() => {
+    rmrf(tmp);
+  });
+
+  it('returns candidate that contains index.html', () => {
+    const found = resolveFrontendDistPath({
+      app: { isPackaged: false },
+      dirname: tmp,
+    });
+    expect(found).toBe(withIndex);
+  });
+
+  it('falls back to first candidate when none have index.html', () => {
+    const base = path.join(tmp, 'empty');
+    const found = resolveFrontendDistPath({
+      app: { isPackaged: false },
+      dirname: base,
+    });
+    expect(found).toBe(path.join(base, 'frontend', 'dist'));
+  });
+
+  it('checks packaged candidates when app.isPackaged', () => {
+    const resources = path.join(tmp, 'resources');
+    const asarDist = path.join(resources, 'app.asar', 'frontend', 'dist');
+    fs.mkdirSync(asarDist, { recursive: true });
+    fs.writeFileSync(path.join(asarDist, 'index.html'), '<html>packaged</html>');
+
+    const prev = process.resourcesPath;
+    process.resourcesPath = resources;
+    try {
+      const found = resolveFrontendDistPath({
+        app: { isPackaged: true },
+        dirname: path.join(tmp, 'nope'),
+      });
+      expect(found).toBe(asarDist);
+    } finally {
+      if (prev === undefined) delete process.resourcesPath;
+      else process.resourcesPath = prev;
+    }
+  });
+});

--- a/tests/unit/electron-local-ui-server.test.js
+++ b/tests/unit/electron-local-ui-server.test.js
@@ -22,6 +22,8 @@ import {
   startLocalUiServer,
   resolveFrontendDistPath,
   DEFAULT_LOCAL_UI_PORT,
+  pathnameToRelative,
+  shouldRejectUnauthorized,
 } from '../../electron/local-ui-server.js';
 
 function rmrf(dir) {
@@ -59,6 +61,39 @@ function fetchText(url, options = {}) {
 describe('DEFAULT_LOCAL_UI_PORT', () => {
   it('is the stable desktop UI port 19333', () => {
     expect(DEFAULT_LOCAL_UI_PORT).toBe(19333);
+  });
+});
+
+describe('pathnameToRelative', () => {
+  it('strips leading slashes so path.join keeps distDir', () => {
+    expect(pathnameToRelative('/app.js')).toBe('app.js');
+    expect(pathnameToRelative('///assets/x.css')).toBe('assets/x.css');
+    expect(pathnameToRelative('/')).toBe('index.html');
+    expect(pathnameToRelative('')).toBe('index.html');
+  });
+});
+
+describe('shouldRejectUnauthorized', () => {
+  const prevProxy = process.env.AGNT_PROXY_INSECURE_TLS;
+  const prevNode = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+
+  afterEach(() => {
+    if (prevProxy === undefined) delete process.env.AGNT_PROXY_INSECURE_TLS;
+    else process.env.AGNT_PROXY_INSECURE_TLS = prevProxy;
+    if (prevNode === undefined) delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    else process.env.NODE_TLS_REJECT_UNAUTHORIZED = prevNode;
+  });
+
+  it('verifies certificates by default', () => {
+    delete process.env.AGNT_PROXY_INSECURE_TLS;
+    delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    expect(shouldRejectUnauthorized()).toBe(true);
+  });
+
+  it('allows opt-out for self-signed LAN via AGNT_PROXY_INSECURE_TLS', () => {
+    process.env.AGNT_PROXY_INSECURE_TLS = '1';
+    delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    expect(shouldRejectUnauthorized()).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Enables hybrid desktop use against a remote AGNT API, and stops workflow workers from flooding the disk with crash dumps after broken-pipe errors.

### Added
- **Settings → Configuration → Connection** — toggle local vs external backend, URL, test, save, restart
- **External mode runtime** (`electron/`):
  - Skip local Express fork
  - Serve this package’s UI on fixed loopback **`http://127.0.0.1:19333`**
  - Reverse-proxy **`/api`** and **`/socket.io`** to `BACKEND_URL` (remote needs API only, not frontend)
- **Cold-start connection UI** when external health check fails at launch
- **macOS activate recovery** — reopen main window if remote is healthy; otherwise connection setup
- **External-mode login UX** — banner when signed out, remote host in copy, link to Connection without login
- **Env / packaging** — `.env.example` (`USE_EXTERNAL_BACKEND`, `BACKEND_URL`, `AGNT_UI_PORT`, `AGNT_FATAL_POLICY`); `electron/**/*` in builder `files`
- **Docs** — hybrid notes, sign-in origin, `docs/DIAGNOSTICS.md`, index/self-host/README links

### Changed
- Connection lifecycle extracted into `electron/desktop-connection.js`
- Single health path: `waitUntilHealthy` → `probeBackendHealth`
- Window control IPC and F11 chrome registered once
- Backend CORS allows loopback origins (Vite + tooling; desktop external is same-origin via proxy)

### Fixed
- **Connection missing** when external loaded remote UI — always use local packaged UI
- **Empty agents/history** after external switch — fixed origin + proxy + login messaging
- **Workflow crash-file storms** after EPIPE/broken pipe (benign pipe handling, dump dedupe, workflow `fatalPolicy=exit`, IPC clean exit)

### Tests
```bash
npx vitest run \
  tests/unit/electron-connection-config.test.js \
  tests/unit/electron-local-ui-server.test.js \
  backend/src/diagnostics/diagnostics.test.js
```

Test plan
• [ x] Local mode: Express on :3333, agents as before
• [ x] External mode: UI on :19333, Connection always visible
• [ x] Wrong remote URL → setup UI; fix → restart → OK
• [ x] Signed out external → banner + host + Connection link; login → remote agents
• [ x] macOS dock activate with healthy remote reopens main window
• [ x] Unit tests above pass
• [ x] (Optional) No crash-file storm under diagnostics/crashes after parent/worker pipe close EOF

