### PR TITLE
fix(diagnostics): dedupe crash dumps and skip EPIPE storms

### DIFF
--- a/backend/src/diagnostics/bootstrap.js
+++ b/backend/src/diagnostics/bootstrap.js
@@ -28,7 +28,13 @@ const fatalPolicy = process.env.AGNT_FATAL_POLICY === 'exit' ? 'exit' : 'stay';
 
 /** Cheap, high-signal state for crash records. Must never throw. */
 function getState() {
-  const state = { proc, argv1: process.argv[1] };
+  const state = {
+    proc,
+    argv1: process.argv[1],
+    // Helps distinguish parent-gone vs app bugs in crash JSON when dumps do occur
+    connected: process.connected,
+    ppid: process.ppid,
+  };
   try {
     state.cwd = process.cwd();
   } catch {

--- a/backend/src/diagnostics/diagnostics.test.js
+++ b/backend/src/diagnostics/diagnostics.test.js
@@ -9,6 +9,14 @@ import { installConsoleBridge } from './consoleBridge.js';
 import { withContext } from './context.js';
 import { sweep, purgeLegacyLogs } from './retention.js';
 import { readRecords, readCrashes } from './read.js';
+import {
+  isBenignPipeError,
+  shouldDumpCrash,
+  shouldExitForParentGone,
+  isWorkflowChildProcess,
+  EXIT_PARENT_GONE,
+  _resetDiagnosticsInstallForTests,
+} from './install.js';
 
 let DIR;
 
@@ -29,6 +37,57 @@ beforeEach(() => {
 afterEach(() => {
   fs.rmSync(DIR, { recursive: true, force: true });
   vi.restoreAllMocks();
+  _resetDiagnosticsInstallForTests();
+  delete process.env.IS_WORKFLOW_PROCESS;
+});
+
+/* ------------------------------------------------------------------ *
+ * Fatal handling — EPIPE / dump storms (scoped: no fatalPolicy flips)
+ * ------------------------------------------------------------------ */
+describe('fatal pipe / crash dedupe', () => {
+  it('treats EPIPE / broken pipe / destroyed stream / closed IPC as benign', () => {
+    expect(isBenignPipeError(Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))).toBe(true);
+    expect(isBenignPipeError(Object.assign(new Error('x'), { code: 'ERR_STREAM_DESTROYED' }))).toBe(true);
+    expect(isBenignPipeError(Object.assign(new Error('x'), { code: 'ERR_IPC_CHANNEL_CLOSED' }))).toBe(true);
+    expect(isBenignPipeError(new Error('write broken pipe after parent exit'))).toBe(true);
+    expect(isBenignPipeError(new Error('something else blew up'))).toBe(false);
+    expect(isBenignPipeError(Object.assign(new Error('x'), { code: 'ENOENT' }))).toBe(false);
+  });
+
+  it('dedupes identical crash dumps within the window', () => {
+    _resetDiagnosticsInstallForTests();
+    const boom = new Error('kaboom');
+    expect(shouldDumpCrash('uncaughtException', boom, 1000)).toBe(true);
+    expect(shouldDumpCrash('uncaughtException', boom, 2000)).toBe(false);
+    expect(shouldDumpCrash('uncaughtException', boom, 3000)).toBe(false);
+    // After window elapses, dump again
+    expect(shouldDumpCrash('uncaughtException', boom, 1000 + 60_000 + 1)).toBe(true);
+  });
+
+  it('does not dedupe different errors', () => {
+    _resetDiagnosticsInstallForTests();
+    expect(shouldDumpCrash('uncaughtException', new Error('a'), 1)).toBe(true);
+    expect(shouldDumpCrash('uncaughtException', new Error('b'), 2)).toBe(true);
+  });
+
+  it('uses a distinct nonzero exit code for parent-gone (not 0 or 1)', () => {
+    expect(EXIT_PARENT_GONE).toBe(74);
+    expect(EXIT_PARENT_GONE).not.toBe(0);
+    expect(EXIT_PARENT_GONE).not.toBe(1);
+  });
+
+  it('exits only for workflow children when parent/IPC is gone', () => {
+    delete process.env.IS_WORKFLOW_PROCESS;
+    expect(isWorkflowChildProcess()).toBe(false);
+    expect(shouldExitForParentGone(Object.assign(new Error('EPIPE'), { code: 'EPIPE' }))).toBe(false);
+
+    process.env.IS_WORKFLOW_PROCESS = 'true';
+    expect(isWorkflowChildProcess()).toBe(true);
+    // ERR_IPC_CHANNEL_CLOSED always means parent side is gone
+    expect(
+      shouldExitForParentGone(Object.assign(new Error('channel closed'), { code: 'ERR_IPC_CHANNEL_CLOSED' }))
+    ).toBe(true);
+  });
 });
 
 /* ------------------------------------------------------------------ *

--- a/backend/src/diagnostics/diagnostics.test.js
+++ b/backend/src/diagnostics/diagnostics.test.js
@@ -52,6 +52,8 @@ describe('fatal pipe / crash dedupe', () => {
     expect(isBenignPipeError(new Error('write broken pipe after parent exit'))).toBe(true);
     expect(isBenignPipeError(new Error('something else blew up'))).toBe(false);
     expect(isBenignPipeError(Object.assign(new Error('x'), { code: 'ENOENT' }))).toBe(false);
+    // EIO is generic (disk/FS/etc.) — must still dump for diagnostics
+    expect(isBenignPipeError(Object.assign(new Error('read EIO'), { code: 'EIO' }))).toBe(false);
   });
 
   it('dedupes identical crash dumps within the window', () => {

--- a/backend/src/diagnostics/install.js
+++ b/backend/src/diagnostics/install.js
@@ -4,15 +4,16 @@
  * One call at the top of each process wires up: the recorder, the console
  * bridge, process-level fatal handlers, and a final flush on exit.
  *
- * `fatalPolicy` differs by process on purpose:
- *   backend  — 'exit': a process in an undefined state must not keep serving.
- *              The supervisor in main.js respawns it. Today this is 'stay',
- *              which produces a zombie backend that looks alive and isn't.
+ * `fatalPolicy` (default for all processes: 'stay'; opt into 'exit' via
+ * AGNT_FATAL_POLICY=exit or an explicit installDiagnostics option):
+ *   backend  — default 'stay' for compatibility with today's restart semantics.
+ *              Preferred long-term is 'exit' so a process in an undefined state
+ *              does not keep serving (main.js can respawn it). Flipping the
+ *              default is intentional and separate from this module's dumps.
  *   workflow — 'stay': the parent bridge owns restart, and an in-flight
- *              workflow is often still salvageable.
+ *              workflow is often still salvageable. (Override with AGNT_FATAL_POLICY.)
  *   main     — 'stay': quitting is decided by Electron lifecycle code.
  *
- * Default fatal policy remains 'stay' (opt into exit via AGNT_FATAL_POLICY).
  * This module also:
  *   - skips full crash dumps for benign pipe/stream errors (EPIPE storms)
  *   - dedupes identical crash dumps within a short window
@@ -43,11 +44,11 @@ export const EXIT_PARENT_GONE = 74;
 export function isBenignPipeError(err) {
   if (!err) return false;
   const code = err.code || err.errno;
+  // Do not treat generic EIO as benign — it can be real disk/FS failure.
   if (
     code === 'EPIPE' ||
     code === 'ERR_STREAM_DESTROYED' ||
-    code === 'ERR_IPC_CHANNEL_CLOSED' ||
-    code === 'EIO'
+    code === 'ERR_IPC_CHANNEL_CLOSED'
   ) {
     return true;
   }

--- a/backend/src/diagnostics/install.js
+++ b/backend/src/diagnostics/install.js
@@ -11,6 +11,12 @@
  *   workflow — 'stay': the parent bridge owns restart, and an in-flight
  *              workflow is often still salvageable.
  *   main     — 'stay': quitting is decided by Electron lifecycle code.
+ *
+ * Default fatal policy remains 'stay' (opt into exit via AGNT_FATAL_POLICY).
+ * This module also:
+ *   - skips full crash dumps for benign pipe/stream errors (EPIPE storms)
+ *   - dedupes identical crash dumps within a short window
+ *   - exits workflow children with a distinct nonzero code when the parent/IPC is gone
  */
 import path from 'path';
 import { randomUUID } from 'crypto';
@@ -18,6 +24,105 @@ import { Recorder } from './Recorder.js';
 import { installConsoleBridge } from './consoleBridge.js';
 
 let installed = null;
+
+/** @type {{ key: string, at: number, count: number } | null} */
+let lastCrashDedupe = null;
+
+const DEDUPE_WINDOW_MS = 60_000;
+
+/**
+ * sysexits-style: "input/output error" — parent/IPC channel is gone.
+ * Distinct from exit(0) (clean) and exit(1) (app fatal under fatalPolicy=exit).
+ */
+export const EXIT_PARENT_GONE = 74;
+
+/**
+ * Errors that mean "the other end of stdout/stderr/IPC is gone" — not app bugs.
+ * Dumping a large crash per throw under fatalPolicy=stay = crash-file storms.
+ */
+export function isBenignPipeError(err) {
+  if (!err) return false;
+  const code = err.code || err.errno;
+  if (
+    code === 'EPIPE' ||
+    code === 'ERR_STREAM_DESTROYED' ||
+    code === 'ERR_IPC_CHANNEL_CLOSED' ||
+    code === 'EIO'
+  ) {
+    return true;
+  }
+  const msg = String(err.message || err);
+  if (/broken pipe/i.test(msg) || /EPIPE/i.test(msg) || /IPC channel closed/i.test(msg)) {
+    return true;
+  }
+  return false;
+}
+
+function crashDedupeKey(reason, err) {
+  return `${reason}|${err?.code || ''}|${String(err?.message || '').slice(0, 200)}`;
+}
+
+/**
+ * @returns {boolean} true if this crash should be dumped (first in window)
+ */
+export function shouldDumpCrash(reason, err, now = Date.now()) {
+  const key = crashDedupeKey(reason, err);
+  if (lastCrashDedupe && lastCrashDedupe.key === key && now - lastCrashDedupe.at < DEDUPE_WINDOW_MS) {
+    lastCrashDedupe.count += 1;
+    return false;
+  }
+  lastCrashDedupe = { key, at: now, count: 1 };
+  return true;
+}
+
+/** True when this process is a workflow (or similar) child of a bridge. */
+export function isWorkflowChildProcess() {
+  return process.env.IS_WORKFLOW_PROCESS === 'true';
+}
+
+/**
+ * Parent is gone / IPC closed — worker should stop (nonzero, not 0).
+ * If still connected, a pipe hiccup alone is not a reason to exit under stay policy.
+ */
+export function shouldExitForParentGone(err) {
+  if (!isWorkflowChildProcess()) return false;
+  if (typeof process.connected === 'boolean' && !process.connected) return true;
+  const code = err?.code || err?.errno;
+  if (code === 'ERR_IPC_CHANNEL_CLOSED') return true;
+  return false;
+}
+
+/** Test helper — reset module state between tests. */
+export function _resetDiagnosticsInstallForTests() {
+  if (installed) {
+    try {
+      installed.uninstall();
+    } catch {
+      /* ignore */
+    }
+  }
+  installed = null;
+  lastCrashDedupe = null;
+}
+
+function attachStdioPipeGuards() {
+  const swallowPipe = (stream) => {
+    if (!stream || typeof stream.on !== 'function') return;
+    // Avoid stacking handlers if install is somehow re-entered after reset
+    if (stream.__agntPipeGuard) return;
+    stream.__agntPipeGuard = true;
+    stream.on('error', (err) => {
+      if (isBenignPipeError(err)) return;
+      try {
+        process.stderr.write(`[diagnostics] stdio error: ${err?.message || err}\n`);
+      } catch {
+        /* ignore */
+      }
+    });
+  };
+  swallowPipe(process.stdout);
+  swallowPipe(process.stderr);
+}
 
 /**
  * @param {object}   opts
@@ -46,6 +151,8 @@ export function installDiagnostics({
   const recorder = new Recorder({ dir, proc, bootId: resolvedBoot, level });
   const uninstallBridge = bridgeConsole ? installConsoleBridge(recorder) : () => {};
 
+  attachStdioPipeGuards();
+
   const safeState = () => {
     try {
       return getState() || {};
@@ -54,16 +161,61 @@ export function installDiagnostics({
     }
   };
 
+  const quietExit = (code) => {
+    try {
+      recorder.close();
+    } catch {
+      /* ignore */
+    }
+    process.exitCode = code;
+    setTimeout(() => process.exit(code), 50).unref?.();
+  };
+
   const onFatal = (reason) => (errOrReason) => {
     const err = errOrReason instanceof Error ? errOrReason : new Error(String(errOrReason));
+
+    // Parent closed the pipe / IPC — not an app bug. Skip multi-hundred-KB dumps.
+    if (isBenignPipeError(err)) {
+      try {
+        process.stderr.write(
+          `[diagnostics] ${proc} ${reason}: benign pipe/stream error (${err.code || err.message}) — not dumping crash\n`
+        );
+      } catch {
+        /* stderr may be the broken pipe */
+      }
+      // Workflow child + parent/IPC gone → exit with distinct nonzero code (not 0).
+      // Still-connected pipe hiccup → stay (default fatalPolicy); no dump storm.
+      if (shouldExitForParentGone(err)) {
+        quietExit(EXIT_PARENT_GONE);
+      }
+      return;
+    }
+
+    if (!shouldDumpCrash(reason, err)) {
+      const n = lastCrashDedupe?.count || 0;
+      try {
+        process.stderr.write(
+          `[diagnostics] ${proc} ${reason}: suppressed duplicate crash dump (×${n} in ${DEDUPE_WINDOW_MS / 1000}s): ${err.message}\n`
+        );
+      } catch {
+        /* ignore */
+      }
+      if (fatalPolicy === 'exit') {
+        quietExit(1);
+      }
+      return;
+    }
+
     const file = recorder.dumpCrash(reason, err, safeState());
     // Bypass the bridge so this reaches the terminal even mid-teardown.
-    process.stderr.write(`[diagnostics] ${proc} ${reason}: ${err.message}\n  crash record: ${file}\n`);
+    try {
+      process.stderr.write(`[diagnostics] ${proc} ${reason}: ${err.message}\n  crash record: ${file}\n`);
+    } catch {
+      /* ignore */
+    }
 
     if (fatalPolicy === 'exit') {
-      recorder.close();
-      process.exitCode = 1;
-      setTimeout(() => process.exit(1), 250).unref?.();
+      quietExit(1);
     }
   };
 
@@ -82,6 +234,7 @@ export function installDiagnostics({
     recorder,
     bootId: resolvedBoot,
     dir,
+    fatalPolicy,
     uninstall() {
       uninstallBridge();
       process.off('uncaughtException', handlers.uncaughtException);


### PR DESCRIPTION
## Summary

Scoped **diagnostics-only** fix per Annie’s close note on #51 — no Electron hybrid, no CORS, no fatal-policy default flips, no WorkflowProcess riders.

When a workflow parent dies, workers often throw **EPIPE** / closed-IPC. Under `fatalPolicy=stay`, each throw used to write a large crash JSON → **dump storms**. This PR:

1. **Skips** full crash dumps for benign pipe/IPC errors (`EPIPE`, `ERR_STREAM_DESTROYED`, `ERR_IPC_CHANNEL_CLOSED`, “broken pipe”).
2. **Dedupes** identical crash dumps within a 60s window (stderr note for suppressed copies).
3. Exits workflow children with a **distinct nonzero code `74`** (`EXIT_PARENT_GONE` / EX_IOERR) when parent/IPC is gone — **not** `exit(0)` — so field logs distinguish parent-gone from clean shutdown.
4. Still-connected pipe hiccups: **no dump**, **stay** (default policy unchanged).
5. Real fatals: still dump; exit only if `AGNT_FATAL_POLICY=exit` (opt-in, same as today).

## Files

- `backend/src/diagnostics/install.js` — core behaviour
- `backend/src/diagnostics/bootstrap.js` — crash state adds `connected` / `ppid` only; **default policy remains stay**
- `backend/src/diagnostics/diagnostics.test.js` — coverage for benign pipes, dedupe, exit code

## Test plan

- [x] `npx vitest run backend/src/diagnostics/diagnostics.test.js` (35 passed)
- [ ] Optional: run a workflow, kill the parent bridge, confirm no dump storm and worker exit code is `74` when IPC is closed

## Out of scope (intentionally)

- Desktop external-backend / local UI proxy (#51)
- CORS changes on `server.js`
- Changing workflow/backend default `fatalPolicy` to `exit`
- `WorkflowProcess.js` IPC `exit(0)` rewrites

Refs: #51 (closed; Annie asked for this slice only)