### PR TITLE
fix: include electron/ assets in packaged Mac/Windows builds

### DIFF
--- a/electron/mainWiring.test.js
+++ b/electron/mainWiring.test.js
@@ -117,3 +117,14 @@ describe('connection error page', () => {
     expect(html).toMatch(/relaunch/);
   });
 });
+
+describe('electron-builder packaging', () => {
+  // main.js imports ./electron/connectionConfig.js and loadFiles connection-error.html.
+  // electron-builder uses an explicit allowlist (build.files) — if electron/ is missing,
+  // the packaged app throws ERR_MODULE_NOT_FOUND at launch.
+  it('includes the electron/ directory in build.files', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+    const files = pkg.build?.files || [];
+    expect(files).toEqual(expect.arrayContaining(['electron/**/*']));
+  });
+});

--- a/electron/mainWiring.test.js
+++ b/electron/mainWiring.test.js
@@ -119,7 +119,7 @@ describe('connection error page', () => {
 });
 
 describe('electron-builder packaging', () => {
-  // main.js imports ./electron/connectionConfig.js and loadFiles connection-error.html.
+  // main.js imports ./electron/connectionConfig.js and loadFile() for connection-error.html.
   // electron-builder uses an explicit allowlist (build.files) — if electron/ is missing,
   // the packaged app throws ERR_MODULE_NOT_FOUND at launch.
   it('includes the electron/ directory in build.files', () => {

--- a/package.json
+++ b/package.json
@@ -217,6 +217,8 @@
     "files": [
       "main.js",
       "preload.js",
+      "electron/**/*",
+      "!electron/**/*.test.js",
       "assets/**/*",
       "backend/**/*",
       "docs/_API-DOCUMENTATION.md",


### PR DESCRIPTION
main.js imports electron/connectionConfig.js and loads connection-error.html, but electron-builder's files allowlist omitted the electron/ directory, so packaged apps crashed at launch with ERR_MODULE_NOT_FOUND.