### PR TITLE
feat(providers): automatic cross-provider failover with per-agent fallback chains

### DIFF
--- a/backend/src/models/AgentModel.js
+++ b/backend/src/models/AgentModel.js
@@ -1,5 +1,6 @@
 import db from './database/index.js';
 import generateUUID from '../utils/generateUUID.js';
+import { parseFallbackChain, serializeFallbackChain } from '../services/orchestrator/fallbackChain.js';
 
 class AgentModel {
   static createOrUpdate(id, agent, userId) {
@@ -21,7 +22,11 @@ class AgentModel {
         systemPrompt = '',
         assignedSkills = [],
         toolAccessMode,
+        fallbackProviders,
+        fallbackEnabled,
       } = agent;
+      const fallbackProvidersJson = serializeFallbackChain(fallbackProviders);
+      const fallbackEnabledInt = fallbackEnabled ? 1 : 0;
       const toolsJson = JSON.stringify(assignedTools);
       const workflowsJson = JSON.stringify(assignedWorkflows);
       const skillsJson = JSON.stringify(assignedSkills);
@@ -29,9 +34,9 @@ class AgentModel {
       // the safe default so a malformed payload can't widen tool access.
       const accessMode = toolAccessMode === 'open' ? 'open' : 'restricted';
       db.run(
-        `INSERT OR REPLACE INTO agents (id, name, description, status, icon, category, tools, workflows, provider, model, created_by, last_active, success_rate, system_prompt, skills, tool_access_mode, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
-        [id, name, description, status, icon, category, toolsJson, workflowsJson, provider, model, userId, lastActive, successRate, systemPrompt, skillsJson, accessMode],
+        `INSERT OR REPLACE INTO agents (id, name, description, status, icon, category, tools, workflows, provider, model, created_by, last_active, success_rate, system_prompt, skills, tool_access_mode, fallback_providers, fallback_enabled, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+        [id, name, description, status, icon, category, toolsJson, workflowsJson, provider, model, userId, lastActive, successRate, systemPrompt, skillsJson, accessMode, fallbackProvidersJson, fallbackEnabledInt],
         function (err) {
           if (err) {
             reject(err);
@@ -69,6 +74,9 @@ class AgentModel {
             agent.systemPrompt = agent.system_prompt || '';
             agent.assignedSkills = agent.skills ? JSON.parse(agent.skills) : [];
             agent.toolAccessMode = agent.tool_access_mode === 'open' ? 'open' : 'restricted';
+            agent.fallbackProviders = parseFallbackChain(agent.fallback_providers);
+            agent.fallbackEnabled = agent.fallback_enabled === null || agent.fallback_enabled === undefined
+              ? false : Boolean(agent.fallback_enabled);
             resolve(agent);
           } else resolve(null);
         }
@@ -96,6 +104,9 @@ class AgentModel {
               agent.systemPrompt = agent.system_prompt || '';
               agent.assignedSkills = agent.skills ? JSON.parse(agent.skills) : [];
               agent.toolAccessMode = agent.tool_access_mode === 'open' ? 'open' : 'restricted';
+              agent.fallbackProviders = parseFallbackChain(agent.fallback_providers);
+              agent.fallbackEnabled = agent.fallback_enabled === null || agent.fallback_enabled === undefined
+                ? false : Boolean(agent.fallback_enabled);
             });
             resolve(agents);
           }

--- a/backend/src/models/UserModel.js
+++ b/backend/src/models/UserModel.js
@@ -49,10 +49,40 @@ class UserModel {
     });
   }
 
+  // Parse the raw fallback_providers TEXT column (a JSON array of
+  // { provider, model }) into a clean array. Tolerates NULL, empty, and
+  // malformed JSON — all collapse to []. Non-array JSON → [].
+  static _parseFallbackProviders(raw) {
+    if (raw === null || raw === undefined || raw === '') return [];
+    let parsed = raw;
+    if (typeof raw === 'string') {
+      try { parsed = JSON.parse(raw); } catch { return []; }
+    }
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((e) => e && typeof e === 'object' && typeof e.provider === 'string' && e.provider.trim())
+      .map((e) => ({
+        provider: e.provider.trim(),
+        model: typeof e.model === 'string' && e.model.trim() ? e.model.trim() : null,
+      }))
+      .slice(0, 3);
+  }
+
+  // Serialize a fallback list for storage. Accepts an array or a pre-stringified
+  // JSON string; anything invalid becomes '[]'.
+  static _serializeFallbackProviders(value) {
+    if (typeof value === 'string') {
+      // Validate it round-trips as an array; otherwise store '[]'.
+      try { return JSON.stringify(UserModel._parseFallbackProviders(value)); }
+      catch { return '[]'; }
+    }
+    return JSON.stringify(UserModel._parseFallbackProviders(value));
+  }
+
   static getUserSettings(userId) {
     return new Promise((resolve, reject) => {
       db.get(
-        `SELECT default_provider as selectedProvider, default_model as selectedModel, custom_instructions as customInstructions, async_tools_enabled as asyncToolsEnabled, tool_output_cap as toolOutputCap, max_tool_rounds as maxToolRounds
+        `SELECT default_provider as selectedProvider, default_model as selectedModel, custom_instructions as customInstructions, async_tools_enabled as asyncToolsEnabled, tool_output_cap as toolOutputCap, max_tool_rounds as maxToolRounds, fallback_providers as fallbackProviders, fallback_enabled as fallbackEnabled
          FROM users WHERE id = ?`,
         [userId],
         (err, row) => {
@@ -75,6 +105,14 @@ class UserModel {
               toolOutputCap: Number.isFinite(row.toolOutputCap) ? row.toolOutputCap : 100000,
               // Legacy rows return null — fall back to the documented default (100).
               maxToolRounds: Number.isFinite(row.maxToolRounds) ? row.maxToolRounds : 100,
+              // Cross-provider failover chain. Stored as a JSON array of
+              // { provider, model } tiers (TEXT). Legacy/NULL rows → [].
+              // Malformed JSON is tolerated and treated as no fallbacks.
+              fallbackProviders: UserModel._parseFallbackProviders(row.fallbackProviders),
+              // Stored as INTEGER (0/1). NULL (legacy) → false (feature off).
+              fallbackEnabled: row.fallbackEnabled === null || row.fallbackEnabled === undefined
+                ? false
+                : Boolean(row.fallbackEnabled),
             });
           } else {
             // User not found, return defaults
@@ -85,6 +123,8 @@ class UserModel {
               asyncToolsEnabled: false,
               toolOutputCap: 100000,
               maxToolRounds: 100,
+              fallbackProviders: [],
+              fallbackEnabled: false,
             });
           }
         }
@@ -94,7 +134,7 @@ class UserModel {
 
   static updateUserSettings(userId, settings) {
     return new Promise((resolve, reject) => {
-      const { selectedProvider, selectedModel, customInstructions, asyncToolsEnabled, toolOutputCap, maxToolRounds } = settings;
+      const { selectedProvider, selectedModel, customInstructions, asyncToolsEnabled, toolOutputCap, maxToolRounds, fallbackProviders, fallbackEnabled } = settings;
 
       const fields = [];
       const params = [];
@@ -129,6 +169,18 @@ class UserModel {
       if (maxToolRounds !== undefined) {
         fields.push('max_tool_rounds = ?');
         params.push(maxToolRounds);
+      }
+
+      if (fallbackProviders !== undefined) {
+        // Persist as a JSON string; accept either an array or a pre-stringified
+        // value. Invalid input collapses to an empty array so we never write junk.
+        fields.push('fallback_providers = ?');
+        params.push(UserModel._serializeFallbackProviders(fallbackProviders));
+      }
+
+      if (fallbackEnabled !== undefined) {
+        fields.push('fallback_enabled = ?');
+        params.push(fallbackEnabled ? 1 : 0);
       }
 
       if (fields.length === 0) {

--- a/backend/src/models/UserModel.js
+++ b/backend/src/models/UserModel.js
@@ -1,4 +1,5 @@
 import db from './database/index.js';
+import { parseFallbackChain, serializeFallbackChain } from '../services/orchestrator/fallbackChain.js';
 
 class UserModel {
   static getUserStats(userId) {
@@ -49,36 +50,6 @@ class UserModel {
     });
   }
 
-  // Parse the raw fallback_providers TEXT column (a JSON array of
-  // { provider, model }) into a clean array. Tolerates NULL, empty, and
-  // malformed JSON — all collapse to []. Non-array JSON → [].
-  static _parseFallbackProviders(raw) {
-    if (raw === null || raw === undefined || raw === '') return [];
-    let parsed = raw;
-    if (typeof raw === 'string') {
-      try { parsed = JSON.parse(raw); } catch { return []; }
-    }
-    if (!Array.isArray(parsed)) return [];
-    return parsed
-      .filter((e) => e && typeof e === 'object' && typeof e.provider === 'string' && e.provider.trim())
-      .map((e) => ({
-        provider: e.provider.trim(),
-        model: typeof e.model === 'string' && e.model.trim() ? e.model.trim() : null,
-      }))
-      .slice(0, 3);
-  }
-
-  // Serialize a fallback list for storage. Accepts an array or a pre-stringified
-  // JSON string; anything invalid becomes '[]'.
-  static _serializeFallbackProviders(value) {
-    if (typeof value === 'string') {
-      // Validate it round-trips as an array; otherwise store '[]'.
-      try { return JSON.stringify(UserModel._parseFallbackProviders(value)); }
-      catch { return '[]'; }
-    }
-    return JSON.stringify(UserModel._parseFallbackProviders(value));
-  }
-
   static getUserSettings(userId) {
     return new Promise((resolve, reject) => {
       db.get(
@@ -108,7 +79,7 @@ class UserModel {
               // Cross-provider failover chain. Stored as a JSON array of
               // { provider, model } tiers (TEXT). Legacy/NULL rows → [].
               // Malformed JSON is tolerated and treated as no fallbacks.
-              fallbackProviders: UserModel._parseFallbackProviders(row.fallbackProviders),
+              fallbackProviders: parseFallbackChain(row.fallbackProviders),
               // Stored as INTEGER (0/1). NULL (legacy) → false (feature off).
               fallbackEnabled: row.fallbackEnabled === null || row.fallbackEnabled === undefined
                 ? false
@@ -175,7 +146,7 @@ class UserModel {
         // Persist as a JSON string; accept either an array or a pre-stringified
         // value. Invalid input collapses to an empty array so we never write junk.
         fields.push('fallback_providers = ?');
-        params.push(UserModel._serializeFallbackProviders(fallbackProviders));
+        params.push(serializeFallbackChain(fallbackProviders));
       }
 
       if (fallbackEnabled !== undefined) {

--- a/backend/src/models/database/index.js
+++ b/backend/src/models/database/index.js
@@ -135,7 +135,9 @@ function createTables() {
         custom_instructions TEXT,
         async_tools_enabled INTEGER DEFAULT 0,
         tool_output_cap INTEGER DEFAULT 100000,
-        max_tool_rounds INTEGER DEFAULT 100
+        max_tool_rounds INTEGER DEFAULT 100,
+        fallback_providers TEXT,
+        fallback_enabled INTEGER DEFAULT 0
       )`);
 
       db.run(`CREATE TABLE IF NOT EXISTS transactions (
@@ -162,6 +164,8 @@ function createTables() {
         created_by TEXT NOT NULL,
         last_active DATETIME,
         success_rate REAL,
+        fallback_providers TEXT,
+        fallback_enabled INTEGER DEFAULT 0,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY (created_by) REFERENCES users(id)
@@ -1223,6 +1227,26 @@ function runMigrations() {
         }
       });
 
+      // Migration: Per-agent provider-failover chain (2026-07-30, Phase 4).
+      // fallback_providers = JSON array of up to 3 { provider, model } tiers;
+      // fallback_enabled gates it (0 = off → agent inherits no chain, identical
+      // to pre-Phase-4 behavior). Mirrors the users-table columns.
+      db.run(`ALTER TABLE agents ADD COLUMN fallback_providers TEXT`, (err) => {
+        if (err && !err.message.includes('duplicate column name')) {
+          console.error('Error adding fallback_providers column to agents:', err);
+        } else if (!err) {
+          console.log('✓ Added fallback_providers column to agents table');
+        }
+      });
+
+      db.run(`ALTER TABLE agents ADD COLUMN fallback_enabled INTEGER DEFAULT 0`, (err) => {
+        if (err && !err.message.includes('duplicate column name')) {
+          console.error('Error adding fallback_enabled column to agents:', err);
+        } else if (!err) {
+          console.log('✓ Added fallback_enabled column to agents table');
+        }
+      });
+
       // Migration: Add AGI loop columns to goals table (2026-03-04)
       const agiLoopColumns = [
         { name: 'world_state', type: "JSON DEFAULT '{}'" },
@@ -1247,6 +1271,26 @@ function runMigrations() {
           console.error('Error adding deleted_at column to goals:', err);
         } else if (!err) {
           console.log('✓ Added deleted_at column to goals table');
+        }
+      });
+
+      // Migration: Add fallback provider columns to users for automatic
+      // cross-provider failover (2026-07-30). fallback_providers holds a JSON
+      // array of up to 3 { provider, model } tiers; fallback_enabled gates the
+      // whole feature (0 = off, so existing rows behave exactly as before).
+      db.run(`ALTER TABLE users ADD COLUMN fallback_providers TEXT`, (err) => {
+        if (err && !err.message.includes('duplicate column name')) {
+          console.error('Error adding fallback_providers column to users:', err);
+        } else if (!err) {
+          console.log('✓ Added fallback_providers column to users table');
+        }
+      });
+
+      db.run(`ALTER TABLE users ADD COLUMN fallback_enabled INTEGER DEFAULT 0`, (err) => {
+        if (err && !err.message.includes('duplicate column name')) {
+          console.error('Error adding fallback_enabled column to users:', err);
+        } else if (!err) {
+          console.log('✓ Added fallback_enabled column to users table');
         }
       });
 

--- a/backend/src/services/AutonomousMessageService.js
+++ b/backend/src/services/AutonomousMessageService.js
@@ -301,8 +301,17 @@ Be empathetic and suggest potential solutions or next steps if appropriate.`,
             runOne: async (tier) => {
               if (!tier.primary) {
                 const np = String(tier.provider).toLowerCase();
+                // Resolve the tier's model; null means "provider default" — never
+                // carry the primary provider's model onto a different provider.
+                const { getTextModels } = await import('./ai/ProviderRegistry.js');
+                const tierModel = tier.model || getTextModels(np)?.[0] || tier.model;
                 client = await createLlmClient(np, context.userId, { conversationId, authToken: context.authToken });
-                adapter = await createLlmAdapter(np, client, tier.model || context.model);
+                adapter = await createLlmAdapter(np, client, tierModel);
+                // Keep the shared context in sync so the tool loop + downstream
+                // tools resolve the tier that served the turn, not the primary.
+                context.provider = np;
+                context.normalizedProvider = np;
+                context.model = tierModel;
               }
               return adapter.callStream(loopMessages, tools, contentDeltaCb, context);
             },

--- a/backend/src/services/AutonomousMessageService.js
+++ b/backend/src/services/AutonomousMessageService.js
@@ -8,6 +8,9 @@ import { randomUUID } from 'crypto';
 import conversationManager from './ConversationManager.js';
 import { createLlmClient } from './ai/LlmService.js';
 import { createLlmAdapter } from './orchestrator/llmAdapters.js';
+import { buildProviderChain, runWithFallback } from './orchestrator/ProviderFallback.js';
+import AgentModel from '../models/AgentModel.js';
+import UserModel from '../models/UserModel.js';
 import { executeTool } from './orchestrator/tools.js';
 import { inspectAsyncResult } from './asyncResultInspector.js';
 import { broadcastToUser, RealtimeEvents } from '../utils/realtimeSync.js';
@@ -219,12 +222,47 @@ Be empathetic and suggest potential solutions or next steps if appropriate.`,
 
       log(`[AutonomousMessage] Generating autonomous response for conversation ${conversationId}`);
 
-      // Create LLM client and adapter
-      const client = await createLlmClient(context.normalizedProvider, context.userId, {
+      // Create LLM client and adapter. LET so failover can rebuild them on a
+      // fallback tier (Phase 4: autonomous loop now gets provider failover too).
+      let client = await createLlmClient(context.normalizedProvider, context.userId, {
         conversationId,
         authToken: context.authToken,
       });
-      const adapter = await createLlmAdapter(context.normalizedProvider, client, context.model);
+      let adapter = await createLlmAdapter(context.normalizedProvider, client, context.model);
+
+      // Build the failover chain for THIS autonomous turn. Prefer the active
+      // agent's own chain (fallbackEnabled); else the user's global chain; else
+      // a single-tier chain = today's behavior. Dormant by default.
+      let autoProviderChain = [{ provider: context.normalizedProvider, model: context.model, tier: 0, primary: true }];
+      try {
+        let agChain = null;
+        if (context.agentId && context.agentId !== 'agent-chat' && context.agentId !== 'orchestrator') {
+          const agFb = await AgentModel.findOne(context.agentId);
+          if (agFb && agFb.fallbackEnabled) {
+            agChain = buildProviderChain({
+              provider: context.normalizedProvider,
+              model: context.model,
+              fallbackEnabled: true,
+              fallbackProviders: agFb.fallbackProviders,
+            });
+          }
+        }
+        if (agChain && agChain.length > 1) {
+          autoProviderChain = agChain;
+        } else {
+          const uFb = await UserModel.getUserSettings(context.userId);
+          if (uFb && uFb.fallbackEnabled) {
+            autoProviderChain = buildProviderChain({
+              provider: context.normalizedProvider,
+              model: context.model,
+              fallbackEnabled: uFb.fallbackEnabled,
+              fallbackProviders: uFb.fallbackProviders,
+            });
+          }
+        }
+      } catch (fbErr) {
+        log(`[AutonomousMessage] Could not build failover chain (primary only): ${fbErr.message}`);
+      }
 
       const contentDeltaCb = (chunk) => {
         if (chunk.type === 'content') {
@@ -251,12 +289,34 @@ Be empathetic and suggest potential solutions or next steps if appropriate.`,
         loopMessages = sanitizeUnexpectedToolResults(loopMessages);
         loopMessages = sanitizeEmptyAssistantMessages(loopMessages);
 
-        const { responseMessage: roundResponse, toolCalls: rawToolCalls } = await adapter.callStream(
-          loopMessages,
-          tools,
-          contentDeltaCb,
-          context
-        );
+        let roundResponse, rawToolCalls;
+        if (round === 0 && autoProviderChain.length > 1) {
+          // Round-0 failover: if the primary tier exhausts retries, roll over to
+          // the next tier and adopt its adapter for all subsequent rounds.
+          const { result: r0 } = await runWithFallback({
+            chain: autoProviderChain,
+            onFallback: ({ from, to, reason }) => {
+              log(`[AutonomousMessage] Provider failover: ${from.provider}/${from.model || '?'} → ${to.provider}/${to.model || '?'} (${reason})`);
+            },
+            runOne: async (tier) => {
+              if (!tier.primary) {
+                const np = String(tier.provider).toLowerCase();
+                client = await createLlmClient(np, context.userId, { conversationId, authToken: context.authToken });
+                adapter = await createLlmAdapter(np, client, tier.model || context.model);
+              }
+              return adapter.callStream(loopMessages, tools, contentDeltaCb, context);
+            },
+          });
+          roundResponse = r0.responseMessage;
+          rawToolCalls = r0.toolCalls;
+        } else {
+          ({ responseMessage: roundResponse, toolCalls: rawToolCalls } = await adapter.callStream(
+            loopMessages,
+            tools,
+            contentDeltaCb,
+            context
+          ));
+        }
 
         responseMessage = roundResponse;
         newMessages.push(responseMessage);

--- a/backend/src/services/OrchestratorService.js
+++ b/backend/src/services/OrchestratorService.js
@@ -6,6 +6,7 @@ import ConversationLogModel from '../models/ConversationLogModel.js';
 import AgentExecutionModel from '../models/AgentExecutionModel.js';
 import { createLlmClient } from './ai/LlmService.js';
 import { createLlmAdapter, requiresResponsesApi } from './orchestrator/llmAdapters.js';
+import { buildProviderChain, runWithFallback } from './orchestrator/ProviderFallback.js';
 import { computeCacheSavings } from '../utils/cacheSavings.js';
 import { updateEstimateCalibration, computeResidualDrift } from '../utils/contextManager.js';
 import { isSubscriptionProvider, providerSupportsTools } from './ai/providerConfigs.js';
@@ -860,7 +861,11 @@ async function universalChatHandler(req, res, context = {}) {
   }
 
   // CRITICAL: Normalize provider to lowercase to ensure consistent handling
-  const normalizedProvider = resolvedProvider.toLowerCase();
+  // NOTE: normalizedProvider/model are LET (not const) because automatic
+  // provider failover (buildProviderChain/runWithFallback) may re-point them
+  // to a fallback tier for the remainder of the turn if the primary provider
+  // exhausts its retries on the first LLM call.
+  let normalizedProvider = resolvedProvider.toLowerCase();
   let model = resolvedModel;
 
 
@@ -873,6 +878,59 @@ async function universalChatHandler(req, res, context = {}) {
   }).catch(e => {
     console.warn('[Chat] Failed to sync provider/model to DB (non-critical):', e.message);
   });
+
+  // Build the automatic-failover provider chain for THIS TURN ONLY.
+  // tier 0 = the primary above; tiers 1..3 = the user's configured fallbacks.
+  // We load settings unconditionally here (the earlier settings fetch is
+  // block-scoped inside the provider-resolution branch and may not have run).
+  // Any failure fails safe to a single-tier chain = today's behavior.
+  // IMPORTANT: this must NOT persist the fallback provider as the default —
+  // the sync above already recorded the PRIMARY, and we never call
+  // updateUserSettings with a fallback tier.
+  let providerChain = [{ provider: normalizedProvider, model, tier: 0, primary: true }];
+  try {
+    // Phase 4: prefer the ACTIVE AGENT's own fallback chain when it has one
+    // (fallbackEnabled). A coding agent pinned to Claude-Code should fail over
+    // to ITS configured backups, not the user's global list. Only when the
+    // agent has no chain (or no agent is active) do we use the user's chain.
+    let agentChain = null;
+    if (agentId && agentId !== 'agent-chat' && agentId !== 'orchestrator') {
+      try {
+        const agentForFb = await AgentModel.findOne(agentId);
+        if (agentForFb && agentForFb.fallbackEnabled) {
+          agentChain = buildProviderChain({
+            provider: normalizedProvider,
+            model,
+            fallbackEnabled: true,
+            fallbackProviders: agentForFb.fallbackProviders,
+          });
+        }
+      } catch (agErr) {
+        console.warn('[Chat] Could not load agent fallback chain:', agErr.message);
+      }
+    }
+
+    if (agentChain && agentChain.length > 1) {
+      providerChain = agentChain;
+      console.log('[Chat] Provider failover chain (agent):', providerChain.map(t => `${t.provider}/${t.model || '(default model)'}`).join(' → '));
+    } else {
+      const fbSettings = await UserModel.getUserSettings(userId);
+      if (fbSettings && fbSettings.fallbackEnabled) {
+        providerChain = buildProviderChain({
+          provider: normalizedProvider,
+          model,
+          fallbackEnabled: fbSettings.fallbackEnabled,
+          fallbackProviders: fbSettings.fallbackProviders,
+        });
+        if (providerChain.length > 1) {
+          console.log('[Chat] Provider failover chain (user):', providerChain.map(t => `${t.provider}/${t.model || '(default model)'}`).join(' → '));
+        }
+      }
+    }
+  } catch (e) {
+    console.warn('[Chat] Could not build provider failover chain (using primary only):', e.message);
+    providerChain = [{ provider: normalizedProvider, model, tier: 0, primary: true }];
+  }
 
   // Validate message input (different formats for different handlers)
   let messageInput = originalMessages || (message ? [...history, { role: 'user', content: message }] : null);
@@ -1240,8 +1298,9 @@ async function universalChatHandler(req, res, context = {}) {
         })()
       : Promise.resolve();
 
-    const client = await createLlmClient(normalizedProvider, userId, { conversationId, authToken });
-    const adapter = await createLlmAdapter(normalizedProvider, client, model, { reasoningEnabled, reasoningValue });
+    // client/adapter are LET so failover can rebuild them on a fallback tier.
+    let client = await createLlmClient(normalizedProvider, userId, { conversationId, authToken });
+    let adapter = await createLlmAdapter(normalizedProvider, client, model, { reasoningEnabled, reasoningValue });
 
     // Store client in context
     conversationContext.llmClient = client;
@@ -1802,10 +1861,12 @@ IMPORTANT: The image data is already available in the system context. You don't 
     // fire tool_pending once per tool (adapters emit tool_call_delta repeatedly
     // as args stream in).
     const announcedToolIds = new Set();
-    let { responseMessage, toolCalls, toolCallError, invalidToolCalls, toolsSkipped, toolsSkippedReason, recoveredFromError, recoveredError, usage: initialUsage } = await adapter.callStream(
-      contextResult.messages,
-      finalToolSchemas,
-      (chunk) => {
+
+    // The streaming chunk handler is factored out so failover can reuse it
+    // across provider tiers. NOTE: the adapter only returns recoveredFromError
+    // when ZERO content chunks were emitted, so a failed tier never streams
+    // partial tokens — making pre-first-token failover clean.
+    const onStreamChunk = (chunk) => {
         // Handle streaming chunks
         if (chunk.type === 'content') {
           sendEvent('content_delta', {
@@ -1834,9 +1895,47 @@ IMPORTANT: The image data is already available in the system context. You don't 
             });
           }
         }
+    };
+
+    // Run the first LLM call across the provider failover chain. Each tier
+    // rebuilds client+adapter; on failover we re-point the OUTER client/adapter/
+    // normalizedProvider/model so the rest of the turn (tool loop) continues on
+    // the tier that actually worked.
+    const runTierStream = async (tier) => {
+      if (!tier.primary) {
+        // Rebuild client+adapter for the fallback tier.
+        normalizedProvider = String(tier.provider).toLowerCase();
+        model = tier.model || model;
+        client = await createLlmClient(normalizedProvider, userId, { conversationId, authToken });
+        adapter = await createLlmAdapter(normalizedProvider, client, model, { reasoningEnabled, reasoningValue });
+        conversationContext.llmClient = client;
+        if (normalizedProvider === 'openai' || normalizedProvider === 'openai-codex') {
+          conversationContext.openai = client;
+        }
+      }
+      return adapter.callStream(
+        contextResult.messages,
+        finalToolSchemas,
+        onStreamChunk,
+        conversationContext // Pass context for vision image handling
+      );
+    };
+
+    const { result: _r0 } = await runWithFallback({
+      chain: providerChain,
+      runOne: runTierStream,
+      onFallback: ({ from, to, reason }) => {
+        console.warn(`[Chat] Provider failover: ${from.provider}/${from.model || '?'} → ${to.provider}/${to.model || '?'} (${reason})`);
+        sendEvent('provider_fallback', {
+          from: { provider: from.provider, model: from.model },
+          to: { provider: to.provider, model: to.model },
+          reason,
+          tier: to.tier,
+        });
       },
-      conversationContext // Pass context for vision image handling
-    );
+    });
+
+    let { responseMessage, toolCalls, toolCallError, invalidToolCalls, toolsSkipped, toolsSkippedReason, recoveredFromError, recoveredError, usage: initialUsage } = _r0;
     accumulateUsage(initialUsage);
     // Fold this round's REAL prompt size (provider-reported) into the
     // estimate calibration used by every subsequent manageContext call.

--- a/backend/src/services/OrchestratorService.js
+++ b/backend/src/services/OrchestratorService.js
@@ -5,6 +5,12 @@ import { executeTool } from './orchestrator/tools.js';
 import ConversationLogModel from '../models/ConversationLogModel.js';
 import AgentExecutionModel from '../models/AgentExecutionModel.js';
 import { createLlmClient } from './ai/LlmService.js';
+
+// Per-conversation failover memory for the recovery banner (Option 2).
+// When a turn fails over, we record { conversationId -> { provider, model } }.
+// On a later turn where the PRIMARY (default) tier wins, we emit
+// 'provider_recovered' and clear the entry. Ephemeral, per-process, tiny.
+const __failoverMemory = new Map();
 import { createLlmAdapter, requiresResponsesApi } from './orchestrator/llmAdapters.js';
 import { buildProviderChain, runWithFallback } from './orchestrator/ProviderFallback.js';
 import { computeCacheSavings } from '../utils/cacheSavings.js';
@@ -1931,11 +1937,16 @@ IMPORTANT: The image data is already available in the system context. You don't 
       );
     };
 
-    const { result: _r0 } = await runWithFallback({
+    const { result: _r0, tier: _r0Tier } = await runWithFallback({
       chain: providerChain,
       runOne: runTierStream,
       onFallback: ({ from, to, reason }) => {
         console.warn(`[Chat] Provider failover: ${from.provider}/${from.model || '?'} → ${to.provider}/${to.model || '?'} (${reason})`);
+        // Remember, for THIS conversation, that we failed over — so a later
+        // turn that succeeds back on the primary can announce the recovery.
+        if (conversationId) {
+          __failoverMemory.set(conversationId, { provider: to.provider, model: to.model });
+        }
         sendEvent('provider_fallback', {
           from: { provider: from.provider, model: from.model },
           to: { provider: to.provider, model: to.model },
@@ -1944,6 +1955,17 @@ IMPORTANT: The image data is already available in the system context. You don't 
         });
       },
     });
+
+    // Recovery banner (Option 2): if this turn ran on the PRIMARY provider and
+    // an earlier turn in this conversation had failed over, the default is back.
+    // Emit once and clear the memory so it only fires on the transition.
+    if (conversationId && _r0Tier && _r0Tier.primary && !_r0?.recoveredFromError && __failoverMemory.has(conversationId)) {
+      __failoverMemory.delete(conversationId);
+      console.log(`[Chat] Provider recovered: back on ${normalizedProvider}/${model || '?'}`);
+      sendEvent('provider_recovered', {
+        backTo: { provider: normalizedProvider, model },
+      });
+    }
 
     let { responseMessage, toolCalls, toolCallError, invalidToolCalls, toolsSkipped, toolsSkippedReason, recoveredFromError, recoveredError, usage: initialUsage } = _r0;
     accumulateUsage(initialUsage);

--- a/backend/src/services/OrchestratorService.js
+++ b/backend/src/services/OrchestratorService.js
@@ -1905,10 +1905,20 @@ IMPORTANT: The image data is already available in the system context. You don't 
       if (!tier.primary) {
         // Rebuild client+adapter for the fallback tier.
         normalizedProvider = String(tier.provider).toLowerCase();
-        model = tier.model || model;
+        // Resolve the tier's model. buildProviderChain already fills tier.model
+        // with the provider's default when none was configured, so a null here
+        // means "provider default" — do NOT carry the PRIMARY provider's model
+        // across to a different provider (it would be an invalid model id).
+        model = tier.model || (await import('./ai/ProviderRegistry.js')).getTextModels(normalizedProvider)?.[0] || tier.model;
         client = await createLlmClient(normalizedProvider, userId, { conversationId, authToken });
         adapter = await createLlmAdapter(normalizedProvider, client, model, { reasoningEnabled, reasoningValue });
         conversationContext.llmClient = client;
+        // Keep the shared conversation context in sync so tools that resolve
+        // provider/model from context (analyze_image, custom tool execution,
+        // etc.) use the tier that actually served the turn — not the primary.
+        conversationContext.provider = normalizedProvider;
+        conversationContext.normalizedProvider = normalizedProvider;
+        conversationContext.model = model;
         if (normalizedProvider === 'openai' || normalizedProvider === 'openai-codex') {
           conversationContext.openai = client;
         }

--- a/backend/src/services/UserService.js
+++ b/backend/src/services/UserService.js
@@ -94,7 +94,7 @@ class UserService {
 
   async updateUserSettings(req, res) {
     try {
-      const { selectedProvider, selectedModel, customInstructions, asyncToolsEnabled, toolOutputCap, maxToolRounds } = req.body;
+      const { selectedProvider, selectedModel, customInstructions, asyncToolsEnabled, toolOutputCap, maxToolRounds, fallbackProviders, fallbackEnabled } = req.body;
 
       if (
         selectedProvider === undefined &&
@@ -102,9 +102,11 @@ class UserService {
         customInstructions === undefined &&
         asyncToolsEnabled === undefined &&
         toolOutputCap === undefined &&
-        maxToolRounds === undefined
+        maxToolRounds === undefined &&
+        fallbackProviders === undefined &&
+        fallbackEnabled === undefined
       ) {
-        return res.status(400).json({ error: 'At least one setting (selectedProvider, selectedModel, customInstructions, asyncToolsEnabled, toolOutputCap, or maxToolRounds) is required' });
+        return res.status(400).json({ error: 'At least one setting (selectedProvider, selectedModel, customInstructions, asyncToolsEnabled, toolOutputCap, maxToolRounds, fallbackProviders, or fallbackEnabled) is required' });
       }
 
       if (customInstructions !== undefined && typeof customInstructions === 'string' && customInstructions.length > 10000) {
@@ -127,6 +129,30 @@ class UserService {
         }
       }
 
+      // Automatic provider-failover chain. An array of up to 3
+      // { provider, model } tiers (model optional). The model layer further
+      // sanitizes (trims, drops provider-less entries, caps at 3).
+      if (fallbackProviders !== undefined) {
+        if (!Array.isArray(fallbackProviders)) {
+          return res.status(400).json({ error: 'fallbackProviders must be an array of { provider, model } objects' });
+        }
+        if (fallbackProviders.length > 3) {
+          return res.status(400).json({ error: 'fallbackProviders may contain at most 3 entries' });
+        }
+        for (const entry of fallbackProviders) {
+          if (!entry || typeof entry !== 'object' || typeof entry.provider !== 'string' || !entry.provider.trim()) {
+            return res.status(400).json({ error: 'Each fallbackProviders entry must have a non-empty string "provider"' });
+          }
+          if (entry.model !== undefined && entry.model !== null && typeof entry.model !== 'string') {
+            return res.status(400).json({ error: 'fallbackProviders entry "model" must be a string or null' });
+          }
+        }
+      }
+
+      if (fallbackEnabled !== undefined && typeof fallbackEnabled !== 'boolean') {
+        return res.status(400).json({ error: 'fallbackEnabled must be a boolean' });
+      }
+
       const result = await UserModel.updateUserSettings(req.user.id, {
         selectedProvider,
         selectedModel,
@@ -134,6 +160,8 @@ class UserService {
         asyncToolsEnabled,
         toolOutputCap,
         maxToolRounds,
+        fallbackProviders,
+        fallbackEnabled,
       });
 
       res.json({
@@ -146,6 +174,8 @@ class UserService {
           asyncToolsEnabled,
           toolOutputCap,
           maxToolRounds,
+          fallbackProviders,
+          fallbackEnabled,
         },
       });
     } catch (error) {

--- a/backend/src/services/ai/CursorCliClient.js
+++ b/backend/src/services/ai/CursorCliClient.js
@@ -180,7 +180,7 @@ export function createCursorCliClient({
   userId = null,
   conversationId = null,
   provider = 'cursor-cli',
-  timeoutMs = 300000,
+  timeoutMs = CursorCliService.getDefaultTimeoutMs(),
 } = {}) {
   const resolvedSessionKey =
     sessionKey || `cursor-cli::${userId || 'anon'}::${conversationId || 'default'}`;

--- a/backend/src/services/ai/CursorCliClient.js
+++ b/backend/src/services/ai/CursorCliClient.js
@@ -180,7 +180,7 @@ export function createCursorCliClient({
   userId = null,
   conversationId = null,
   provider = 'cursor-cli',
-  timeoutMs = CursorCliService.getDefaultTimeoutMs(),
+  timeoutMs = CursorCliService.getDefaultTimeoutMs?.() ?? 300000,
 } = {}) {
   const resolvedSessionKey =
     sessionKey || `cursor-cli::${userId || 'anon'}::${conversationId || 'default'}`;

--- a/backend/src/services/ai/CursorCliClient.test.js
+++ b/backend/src/services/ai/CursorCliClient.test.js
@@ -12,6 +12,7 @@ vi.mock('./CursorCliService.js', () => ({
   default: {
     getDefaultModel: vi.fn(() => 'cursor-grok-4.5-high'),
     getDefaultWorkdir: vi.fn(() => '/tmp/cursor-test-work'),
+    getDefaultTimeoutMs: vi.fn(() => 300000),
     resolveCursorBin: vi.fn(() => 'cursor-agent'),
     runExec: vi.fn(),
   },

--- a/backend/src/services/ai/CursorCliService.js
+++ b/backend/src/services/ai/CursorCliService.js
@@ -30,6 +30,42 @@ const PROMPT_ARGV_THRESHOLD = process.platform === 'win32' ? 28 * 1024 : 80 * 10
 // Grace period after we see the terminal result before force-killing the hung CLI.
 const POST_RESULT_KILL_MS = 500;
 
+// --- resilience helpers (AGNT local patch) ---------------------------------
+// Healthy cursor-agent calls return in ~6s; the 300s default only ever fires on
+// a genuine stall. Retry ONCE with a FRESH session — a stalled session never
+// recovers, so resuming it would simply re-hang.
+const RETRY_ON_TIMEOUT = process.env.AGNT_CURSOR_RETRY !== '0';
+
+function isTimeoutError(e) {
+  return /timed out after \d+ms/.test(e?.message || '');
+}
+
+// The CLI prints "cursor-retrieval: tracing to '<logfile>'" on every run.
+// Strip it so it never leaks into an agent-visible error string.
+function cleanStderr(s) {
+  return String(s || '')
+    .split('\n')
+    .filter((l) => !/^cursor-retrieval: tracing to /.test(l))
+    .join('\n');
+}
+
+export function getDefaultTimeoutMs() {
+  return DEFAULT_TIMEOUT_MS;
+}
+
+/** runExec + one retry on a stall. Preferred entry point for all callers. */
+async function runExecResilient(opts = {}) {
+  try {
+    return await runExec(opts);
+  } catch (err) {
+    if (!RETRY_ON_TIMEOUT || !isTimeoutError(err)) throw err;
+    console.warn('[CursorCliService] stall detected, retrying once with a fresh session');
+    return runExec({ ...opts, resume: false, sessionId: null });
+  }
+}
+// --- end resilience helpers ------------------------------------------------
+
+
 function expandUserPath(p) {
   if (!p) return p;
   if (p === '~') return os.homedir();
@@ -189,7 +225,7 @@ async function runExec({
       if (resultObj) {
         finish(buildResult(resultObj, stdout, model));
       } else {
-        finish(new Error(`cursor_exec: timed out after ${timeoutMs}ms. stderr: ${stderr.slice(0, 400)}`), true);
+        finish(new Error(`cursor_exec: timed out after ${timeoutMs}ms. stderr: ${cleanStderr(stderr).slice(0, 400)}`), true);
       }
     }, timeoutMs);
 
@@ -313,5 +349,7 @@ export default {
   getDefaultWorkdir,
   resolveCursorBin,
   checkAuth,
-  runExec,
+  runExec: runExecResilient,
+  runExecRaw: runExec,
+  getDefaultTimeoutMs,
 };

--- a/backend/src/services/ai/CursorCliService.js
+++ b/backend/src/services/ai/CursorCliService.js
@@ -21,7 +21,18 @@ import { spawn } from 'child_process';
 import { resolveCursorInvocation } from '../../utils/cliInvocation.js';
 
 const DEFAULT_MODEL = process.env.AGNT_CURSOR_DEFAULT_MODEL || 'cursor-grok-4.5-high';
-const DEFAULT_TIMEOUT_MS = Number(process.env.AGNT_CURSOR_TIMEOUT_MS || 300000); // 5 min
+const FALLBACK_TIMEOUT_MS = 300000; // 5 min
+// Parse the env override defensively: Number('garbage') is NaN and
+// setTimeout(fn, NaN) fires immediately (treated as 0), which would make every
+// Cursor call insta-timeout on a typo'd AGNT_CURSOR_TIMEOUT_MS. Only accept a
+// finite, positive value; otherwise fall back to the safe default.
+function resolveDefaultTimeoutMs() {
+  const raw = process.env.AGNT_CURSOR_TIMEOUT_MS;
+  if (raw == null || raw === '') return FALLBACK_TIMEOUT_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : FALLBACK_TIMEOUT_MS;
+}
+const DEFAULT_TIMEOUT_MS = resolveDefaultTimeoutMs();
 // Above this size the prompt is piped via stdin instead of argv. Windows caps
 // the whole command line at 32,767 UTF-16 chars (spawn ENAMETOOLONG); POSIX
 // has ARG_MAX. `cursor-agent -p` reads the prompt from stdin when no
@@ -45,7 +56,7 @@ function isTimeoutError(e) {
 function cleanStderr(s) {
   return String(s || '')
     .split('\n')
-    .filter((l) => !/^cursor-retrieval: tracing to /.test(l))
+    .filter((l) => !/^\s*cursor-retrieval: tracing to /.test(l))
     .join('\n');
 }
 
@@ -58,7 +69,13 @@ async function runExecResilient(opts = {}) {
   try {
     return await runExec(opts);
   } catch (err) {
-    if (!RETRY_ON_TIMEOUT || !isTimeoutError(err)) throw err;
+    // Never retry a STREAMING call: if the first attempt already emitted any
+    // onDelta/onReasoning output before stalling, a retry would push a second,
+    // duplicated token stream into the same consumer. A streamed timeout is
+    // rare and is better surfaced as an error than re-streamed.
+    const isStreaming =
+      typeof opts.onDelta === 'function' || typeof opts.onReasoning === 'function';
+    if (!RETRY_ON_TIMEOUT || isStreaming || !isTimeoutError(err)) throw err;
     console.warn('[CursorCliService] stall detected, retrying once with a fresh session');
     return runExec({ ...opts, resume: false, sessionId: null });
   }

--- a/backend/src/services/ai/CursorCliService.test.js
+++ b/backend/src/services/ai/CursorCliService.test.js
@@ -14,9 +14,15 @@ import CursorCliService from './CursorCliService.js';
 
 describe('CursorCliService', () => {
   it('exposes the expected public API', () => {
-    for (const fn of ['getDefaultModel', 'getDefaultWorkdir', 'resolveCursorBin', 'checkAuth', 'runExec']) {
+    for (const fn of ['getDefaultModel', 'getDefaultWorkdir', 'getDefaultTimeoutMs', 'resolveCursorBin', 'checkAuth', 'runExec']) {
       expect(typeof CursorCliService[fn]).toBe('function');
     }
+  });
+
+  it('getDefaultTimeoutMs returns a finite positive number (never NaN)', () => {
+    const t = CursorCliService.getDefaultTimeoutMs();
+    expect(Number.isFinite(t)).toBe(true);
+    expect(t).toBeGreaterThan(0);
   });
 
   it('runExec rejects an empty/blank/missing prompt before spawning anything', async () => {

--- a/backend/src/services/orchestrator/ProviderFallback.js
+++ b/backend/src/services/orchestrator/ProviderFallback.js
@@ -1,0 +1,339 @@
+/**
+ * ProviderFallback.js — automatic cross-provider failover for AGNT.
+ *
+ * Phase 1 (this file): pure, side-effect-free helpers that decide
+ *   1. WHICH providers to try, in order (buildProviderChain), and
+ *   2. WHETHER an adapter result means "give up on this provider, roll to
+ *      the next one" (shouldFailover).
+ *
+ * The orchestrator wraps its `createLlmAdapter(...) → adapter.call(...)` step
+ * with `runWithFallback()` so that when the default provider's own internal
+ * retries are exhausted (adapter returns `{ recoveredFromError: true }`),
+ * we transparently try the next configured fallback instead of surfacing the
+ * "⚠️ API Error" card as the assistant's answer.
+ *
+ * DESIGN CONTRACTS (verified against the live code, 2026-07-30):
+ *   - Each adapter already self-retries up to `maxRetries` (3) with backoff
+ *     and, on final failure, RETURNS (does not throw) a recovery response:
+ *         { responseMessage, toolCalls: [], recoveredFromError: true,
+ *           recoveredError: <string> }
+ *     That `recoveredFromError === true` is our failover signal.
+ *   - User cancellation is SACRED. Adapters never mark an abort as
+ *     `recoveredFromError` (see `_isTransientNetworkError`), and we
+ *     additionally guard against it here so a cancelled turn is never
+ *     re-run on a fallback provider.
+ *   - This module must NOT persist anything. The fallback provider is used
+ *     for the CURRENT TURN ONLY. Persisting it would corrupt the account
+ *     default (OrchestratorService line ~871 already syncs the default, and
+ *     that side-effect has historically caused provider drift — see project
+ *     memory). runWithFallback therefore never calls updateUserSettings.
+ *
+ * No external dependencies beyond ProviderRegistry so this stays trivially
+ * unit-testable.
+ */
+
+import * as ProviderRegistry from '../ai/ProviderRegistry.js';
+
+/** Hard ceiling on fallback tiers (excludes the primary). */
+export const MAX_FALLBACKS = 3;
+
+/**
+ * Parse the raw `fallback_providers` column (TEXT holding a JSON array) into a
+ * clean, de-duplicated, validated array of { provider, model } tiers.
+ *
+ * Accepts either already-parsed arrays or JSON strings. Silently drops:
+ *   - malformed entries (missing provider),
+ *   - entries whose provider is not in the ProviderRegistry,
+ *   - duplicates of the primary or of an earlier fallback (same provider+model),
+ *   - anything beyond MAX_FALLBACKS.
+ *
+ * @param {string|Array|null|undefined} raw
+ * @returns {{provider: string, model: string|null}[]}
+ */
+export function parseFallbackList(raw) {
+  let list = raw;
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    try {
+      list = JSON.parse(trimmed);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(list)) return [];
+
+  const out = [];
+  for (const entry of list) {
+    if (!entry || typeof entry !== 'object') continue;
+    const provider = typeof entry.provider === 'string' ? entry.provider.trim() : '';
+    if (!provider) continue;
+    const model =
+      typeof entry.model === 'string' && entry.model.trim() ? entry.model.trim() : null;
+    out.push({ provider, model });
+  }
+  return out;
+}
+
+/**
+ * True if a provider key is known to the registry (case-insensitive).
+ * Unknown providers would throw "Unsupported provider for LLM client factory"
+ * in LlmService, so we filter them out of the chain up front.
+ */
+export function isKnownProvider(provider) {
+  if (!provider || typeof provider !== 'string') return false;
+  const caps = ProviderRegistry.PROVIDER_CAPABILITIES || {};
+  const lower = provider.toLowerCase();
+  return Object.keys(caps).some((k) => k.toLowerCase() === lower);
+}
+
+/**
+ * Pick a usable model for a fallback tier. If the configured model is falsy or
+ * doesn't belong to the provider's text-model set, fall back to the provider's
+ * first text model. Returns null if the provider exposes no text models
+ * (caller should then skip the tier).
+ */
+export function resolveTierModel(provider, model) {
+  let textModels = [];
+  try {
+    textModels = ProviderRegistry.getTextModels(provider) || [];
+  } catch {
+    textModels = [];
+  }
+  if (model && textModels.some((m) => m === model)) return model;
+  if (model && textModels.length === 0) return model; // trust caller for CLI providers w/o static list
+  if (textModels.length > 0) return textModels[0];
+  return model || null;
+}
+
+/**
+ * Build the ordered provider chain for a turn.
+ *
+ *   tier 0 = primary (the resolved default / request provider)
+ *   tier 1..3 = fallbacks, in configured order
+ *
+ * Rules:
+ *   - The primary is ALWAYS first and never dropped (even if validation is
+ *     imperfect — we must still attempt the user's chosen provider).
+ *   - Fallbacks are included only when `fallbackEnabled` is true.
+ *   - Unknown providers are dropped; duplicates (same provider+model as an
+ *     earlier tier) are dropped; capped at MAX_FALLBACKS.
+ *
+ * @param {object} args
+ * @param {string} args.provider         primary provider (already resolved)
+ * @param {string} args.model            primary model
+ * @param {boolean} args.fallbackEnabled
+ * @param {string|Array} args.fallbackProviders  raw column value or array
+ * @returns {{provider: string, model: string|null, tier: number, primary: boolean}[]}
+ */
+export function buildProviderChain({ provider, model, fallbackEnabled, fallbackProviders }) {
+  const primaryProviderLc = String(provider || '').toLowerCase();
+  const chain = [{ provider, model: model || null, tier: 0, primary: true }];
+  const seen = new Set([`${primaryProviderLc}::${model || ''}`]);
+
+  if (!fallbackEnabled) return chain;
+
+  const candidates = parseFallbackList(fallbackProviders);
+  let tier = 1;
+  for (const cand of candidates) {
+    if (chain.length - 1 >= MAX_FALLBACKS) break;
+    if (!isKnownProvider(cand.provider)) continue;
+
+    // Never fail over to the SAME provider we just exhausted — a different
+    // model on the same down provider will almost certainly fail too.
+    if (cand.provider.toLowerCase() === primaryProviderLc) continue;
+
+    const usableModel = resolveTierModel(cand.provider, cand.model);
+    const key = `${cand.provider.toLowerCase()}::${usableModel || ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    chain.push({ provider: cand.provider, model: usableModel, tier, primary: false });
+    tier += 1;
+  }
+
+  return chain;
+}
+
+/**
+ * Classify a failed adapter result / error into a coarse reason so callers can
+ * log and (optionally) decide whether the NEXT provider is even worth trying.
+ * (An auth error on provider A tells us nothing about provider B, so we still
+ * fail over; but a well-formed-request 400 that's purely a client bug would
+ * fail everywhere — kept here for observability + future policy.)
+ *
+ * @param {string} recoveredError  the adapter's recoveredError string
+ * @returns {'auth'|'rate_limit'|'overloaded'|'network'|'cap'|'unknown'}
+ */
+export function classifyFailure(recoveredError) {
+  const s = String(recoveredError || '').toLowerCase();
+  if (!s) return 'unknown';
+  if (
+    s.includes('401') ||
+    s.includes('403') ||
+    s.includes('unauthorized') ||
+    s.includes('forbidden') ||
+    s.includes('api key') ||
+    s.includes('oauth') ||
+    s.includes('token not found') ||
+    s.includes('authentication')
+  ) {
+    return 'auth';
+  }
+  if (s.includes('429') || s.includes('rate limit') || s.includes('rate-limit')) return 'rate_limit';
+  if (
+    s.includes('extra usage') || // Claude Max cap 400 ("draw from your extra usage")
+    s.includes('usage limit') ||
+    s.includes('quota')
+  ) {
+    return 'cap';
+  }
+  if (
+    s.includes('overloaded') ||
+    s.includes('temporarily unavailable') ||
+    s.includes('500') ||
+    s.includes('502') ||
+    s.includes('503') ||
+    s.includes('504') ||
+    s.includes('529')
+  ) {
+    return 'overloaded';
+  }
+  if (
+    s.includes('connection error') ||
+    s.includes('network error') ||
+    s.includes('fetch failed') ||
+    s.includes('socket hang up') ||
+    s.includes('econn') ||
+    s.includes('etimedout') ||
+    s.includes('timeout')
+  ) {
+    return 'network';
+  }
+  return 'unknown';
+}
+
+/**
+ * Decide whether an adapter result means "roll over to the next provider".
+ *
+ * The adapter result is the object returned by `adapter.call(...)`:
+ *   { responseMessage, toolCalls, recoveredFromError?, recoveredError? }
+ *
+ * @param {object} result
+ * @returns {boolean}
+ */
+export function shouldFailover(result) {
+  if (!result || typeof result !== 'object') return false;
+  // The one and only signal the adapters give us for exhausted retries.
+  return result.recoveredFromError === true;
+}
+
+/**
+ * True if an error/result represents a deliberate user cancellation, which must
+ * NEVER be retried on a fallback provider. Adapters already avoid marking these
+ * as recoveredFromError, but callers that catch raw errors can use this guard.
+ */
+export function isCancellation(errorOrResult) {
+  if (!errorOrResult) return false;
+  const name =
+    errorOrResult.name ||
+    errorOrResult.constructor?.name ||
+    (errorOrResult.recoveredError && '') ||
+    '';
+  if (name === 'APIUserAbortError' || name === 'AbortError') return true;
+  const msg = String(errorOrResult.message || errorOrResult.recoveredError || '').toLowerCase();
+  return msg.includes('aborted') || msg.includes('cancelled') || msg.includes('canceled');
+}
+
+/**
+ * Run a per-provider async operation across the provider chain, rolling over on
+ * failover. The caller supplies `runOne(tier)` which must build the client +
+ * adapter for that tier and return the adapter result object. runWithFallback
+ * inspects the result and, if `shouldFailover` is true and another tier exists,
+ * calls the next tier.
+ *
+ * This helper is intentionally provider-agnostic and does NOT touch the DB,
+ * emit SSE, or persist settings — the orchestrator supplies those via the
+ * `onFallback` callback so this stays pure and unit-testable.
+ *
+ * @param {object} args
+ * @param {Array} args.chain  output of buildProviderChain
+ * @param {(tier:object)=>Promise<object>} args.runOne  builds+calls adapter for a tier
+ * @param {(info:object)=>void} [args.onFallback]  notified before each rollover
+ * @returns {Promise<{result: object, tier: object, attempts: object[]}>}
+ */
+export async function runWithFallback({ chain, runOne, onFallback }) {
+  if (!Array.isArray(chain) || chain.length === 0) {
+    throw new Error('runWithFallback: empty provider chain');
+  }
+
+  const attempts = [];
+  let lastResult = null;
+  let lastTier = null;
+
+  for (let i = 0; i < chain.length; i++) {
+    const tier = chain[i];
+    lastTier = tier;
+
+    let result;
+    try {
+      result = await runOne(tier);
+    } catch (err) {
+      // A thrown error (rather than a recovery card) — treat like a failover
+      // signal UNLESS it's a cancellation, which must propagate untouched.
+      if (isCancellation(err)) throw err;
+      result = {
+        responseMessage: null,
+        toolCalls: [],
+        recoveredFromError: true,
+        recoveredError: err?.message || String(err),
+        _threw: true,
+      };
+    }
+
+    lastResult = result;
+    const failed = shouldFailover(result);
+    attempts.push({
+      tier: tier.tier,
+      provider: tier.provider,
+      model: tier.model,
+      failed,
+      reason: failed ? classifyFailure(result.recoveredError) : null,
+    });
+
+    if (!failed) {
+      return { result, tier, attempts };
+    }
+
+    const next = chain[i + 1];
+    if (next && typeof onFallback === 'function') {
+      try {
+        onFallback({
+          from: tier,
+          to: next,
+          reason: classifyFailure(result.recoveredError),
+          recoveredError: result.recoveredError,
+        });
+      } catch {
+        /* onFallback must never break the loop */
+      }
+    }
+    // else: no more tiers — fall through and return the last (failed) result.
+  }
+
+  // All tiers exhausted — return the last failed result so the caller can
+  // surface the recovery card exactly as today (last resort).
+  return { result: lastResult, tier: lastTier, attempts };
+}
+
+export default {
+  MAX_FALLBACKS,
+  parseFallbackList,
+  isKnownProvider,
+  resolveTierModel,
+  buildProviderChain,
+  classifyFailure,
+  shouldFailover,
+  isCancellation,
+  runWithFallback,
+};

--- a/backend/src/services/orchestrator/ProviderFallback.test.mjs
+++ b/backend/src/services/orchestrator/ProviderFallback.test.mjs
@@ -1,105 +1,114 @@
-import assert from 'node:assert';
+import { describe, it, expect } from 'vitest';
 import PF from './ProviderFallback.js';
 
-let pass = 0, fail = 0;
-const t = (name, fn) => { try { fn(); pass++; console.log('  ✓', name); } catch (e) { fail++; console.log('  ✗', name, '→', e.message); } };
-
-console.log('parseFallbackList');
-t('parses JSON string', () => assert.deepEqual(
-  PF.parseFallbackList('[{"provider":"GrokAI","model":"grok-4.5"}]'),
-  [{ provider: 'GrokAI', model: 'grok-4.5' }]));
-t('empty/blank → []', () => { assert.deepEqual(PF.parseFallbackList(''), []); assert.deepEqual(PF.parseFallbackList(null), []); });
-t('malformed JSON → []', () => assert.deepEqual(PF.parseFallbackList('{not json'), []));
-t('drops entries with no provider', () => assert.deepEqual(
-  PF.parseFallbackList([{ model: 'x' }, { provider: 'GrokAI' }]),
-  [{ provider: 'GrokAI', model: null }]));
-
-console.log('isKnownProvider');
-t('unknown provider is false', () => assert.equal(PF.isKnownProvider('totally-fake-xyz'), false));
-t('empty is false', () => assert.equal(PF.isKnownProvider(''), false));
-
-console.log('buildProviderChain');
-t('primary always present, no fallback when disabled', () => {
-  const c = PF.buildProviderChain({ provider: 'Anthropic', model: 'm', fallbackEnabled: false, fallbackProviders: '[{"provider":"GrokAI","model":"grok-4.5"}]' });
-  assert.equal(c.length, 1);
-  assert.equal(c[0].primary, true);
-  assert.equal(c[0].tier, 0);
-});
-t('caps at MAX_FALLBACKS (3) → chain length 4', () => {
-  const many = JSON.stringify([1,2,3,4,5].map(i => ({ provider: `fakeprov${i}`, model: `m${i}` })));
-  // fake providers are unknown so they get dropped — expect just the primary
-  const c = PF.buildProviderChain({ provider: 'Anthropic', model: 'm', fallbackEnabled: true, fallbackProviders: many });
-  assert.equal(c[0].primary, true);
-  assert.ok(c.length <= 1 + PF.MAX_FALLBACKS);
-});
-t('dedupes primary from fallback list', () => {
-  const c = PF.buildProviderChain({ provider: 'Anthropic', model: 'm', fallbackEnabled: true, fallbackProviders: '[{"provider":"Anthropic","model":"m"}]' });
-  assert.equal(c.length, 1);
+describe('ProviderFallback.parseFallbackList', () => {
+  it('parses a JSON string', () => {
+    expect(PF.parseFallbackList('[{"provider":"GrokAI","model":"grok-4.5"}]'))
+      .toEqual([{ provider: 'GrokAI', model: 'grok-4.5' }]);
+  });
+  it('returns [] for empty/blank/null', () => {
+    expect(PF.parseFallbackList('')).toEqual([]);
+    expect(PF.parseFallbackList(null)).toEqual([]);
+  });
+  it('returns [] for malformed JSON', () => {
+    expect(PF.parseFallbackList('{not json')).toEqual([]);
+  });
+  it('drops entries with no provider', () => {
+    expect(PF.parseFallbackList([{ model: 'x' }, { provider: 'GrokAI' }]))
+      .toEqual([{ provider: 'GrokAI', model: null }]);
+  });
 });
 
-console.log('classifyFailure');
-t('auth', () => assert.equal(PF.classifyFailure('401 Unauthorized'), 'auth'));
-t('cap (Claude Max)', () => assert.equal(PF.classifyFailure('now draw from your extra usage'), 'cap'));
-t('overloaded', () => assert.equal(PF.classifyFailure('Overloaded'), 'overloaded'));
-t('network', () => assert.equal(PF.classifyFailure('Connection error.'), 'network'));
-t('rate_limit', () => assert.equal(PF.classifyFailure('429 rate limit'), 'rate_limit'));
-t('unknown', () => assert.equal(PF.classifyFailure('weird'), 'unknown'));
-
-console.log('shouldFailover / isCancellation');
-t('recoveredFromError true → failover', () => assert.equal(PF.shouldFailover({ recoveredFromError: true }), true));
-t('success → no failover', () => assert.equal(PF.shouldFailover({ responseMessage: {} }), false));
-t('abort is cancellation', () => assert.equal(PF.isCancellation({ name: 'AbortError' }), true));
-t('normal error not cancellation', () => assert.equal(PF.isCancellation({ message: '500' }), false));
-
-console.log('runWithFallback');
-await (async () => {
-  // primary fails, tier1 succeeds
-  const chain = [
-    { provider: 'A', model: 'a', tier: 0, primary: true },
-    { provider: 'B', model: 'b', tier: 1, primary: false },
-  ];
-  const events = [];
-  const { result, tier, attempts } = await PF.runWithFallback({
-    chain,
-    runOne: async (t) => t.provider === 'A'
-      ? { recoveredFromError: true, recoveredError: 'Overloaded' }
-      : { responseMessage: { role: 'assistant', content: 'OK' } },
-    onFallback: (info) => events.push(info),
+describe('ProviderFallback.isKnownProvider', () => {
+  it('unknown provider is false', () => {
+    expect(PF.isKnownProvider('totally-fake-xyz')).toBe(false);
   });
-  t('rolled to B and succeeded', () => { assert.equal(tier.provider, 'B'); assert.equal(result.responseMessage.content, 'OK'); });
-  t('emitted one fallback event A→B', () => { assert.equal(events.length, 1); assert.equal(events[0].from.provider, 'A'); assert.equal(events[0].to.provider, 'B'); assert.equal(events[0].reason, 'overloaded'); });
-  t('recorded 2 attempts', () => assert.equal(attempts.length, 2));
-})();
-
-await (async () => {
-  // all fail → returns last failed result, no throw
-  const chain = [ { provider: 'A', tier: 0, primary: true }, { provider: 'B', tier: 1 } ];
-  const { result } = await PF.runWithFallback({
-    chain,
-    runOne: async () => ({ recoveredFromError: true, recoveredError: '500' }),
+  it('empty is false', () => {
+    expect(PF.isKnownProvider('')).toBe(false);
   });
-  t('all-fail returns failed result (last resort card)', () => assert.equal(result.recoveredFromError, true));
-})();
+});
 
-await (async () => {
-  // cancellation must propagate, never roll over
-  const chain = [ { provider: 'A', tier: 0, primary: true }, { provider: 'B', tier: 1 } ];
-  let threw = false;
-  try {
-    await PF.runWithFallback({ chain, runOne: async () => { const e = new Error('aborted'); e.name = 'AbortError'; throw e; } });
-  } catch (e) { threw = true; }
-  t('cancellation propagates (no failover)', () => assert.equal(threw, true));
-})();
-
-await (async () => {
-  // a thrown non-cancellation error on primary → rolls to tier1
-  const chain = [ { provider: 'A', tier: 0, primary: true }, { provider: 'B', tier: 1 } ];
-  const { tier } = await PF.runWithFallback({
-    chain,
-    runOne: async (t) => { if (t.provider === 'A') throw new Error('ECONNRESET boom'); return { responseMessage: { content: 'ok' } }; },
+describe('ProviderFallback.buildProviderChain', () => {
+  it('primary always present, no fallback when disabled', () => {
+    const c = PF.buildProviderChain({ provider: 'Anthropic', model: 'm', fallbackEnabled: false, fallbackProviders: '[{"provider":"GrokAI","model":"grok-4.5"}]' });
+    expect(c.length).toBe(1);
+    expect(c[0].primary).toBe(true);
+    expect(c[0].tier).toBe(0);
   });
-  t('thrown error on primary rolls to B', () => assert.equal(tier.provider, 'B'));
-})();
+  it('caps at MAX_FALLBACKS (chain length <= 4)', () => {
+    const many = JSON.stringify([1, 2, 3, 4, 5].map((i) => ({ provider: `fakeprov${i}`, model: `m${i}` })));
+    const c = PF.buildProviderChain({ provider: 'Anthropic', model: 'm', fallbackEnabled: true, fallbackProviders: many });
+    expect(c[0].primary).toBe(true);
+    expect(c.length).toBeLessThanOrEqual(1 + PF.MAX_FALLBACKS);
+  });
+  it('dedupes the primary from the fallback list', () => {
+    const c = PF.buildProviderChain({ provider: 'Anthropic', model: 'm', fallbackEnabled: true, fallbackProviders: '[{"provider":"Anthropic","model":"m"}]' });
+    expect(c.length).toBe(1);
+  });
+});
 
-console.log(`\n${pass} passed, ${fail} failed`);
-process.exit(fail ? 1 : 0);
+describe('ProviderFallback.classifyFailure', () => {
+  it('auth', () => expect(PF.classifyFailure('401 Unauthorized')).toBe('auth'));
+  it('cap (Claude Max)', () => expect(PF.classifyFailure('now draw from your extra usage')).toBe('cap'));
+  it('overloaded', () => expect(PF.classifyFailure('Overloaded')).toBe('overloaded'));
+  it('network', () => expect(PF.classifyFailure('Connection error.')).toBe('network'));
+  it('rate_limit', () => expect(PF.classifyFailure('429 rate limit')).toBe('rate_limit'));
+  it('unknown', () => expect(PF.classifyFailure('weird')).toBe('unknown'));
+});
+
+describe('ProviderFallback.shouldFailover / isCancellation', () => {
+  it('recoveredFromError true → failover', () => expect(PF.shouldFailover({ recoveredFromError: true })).toBe(true));
+  it('success → no failover', () => expect(PF.shouldFailover({ responseMessage: {} })).toBe(false));
+  it('abort is cancellation', () => expect(PF.isCancellation({ name: 'AbortError' })).toBe(true));
+  it('normal error is not cancellation', () => expect(PF.isCancellation({ message: '500' })).toBe(false));
+});
+
+describe('ProviderFallback.runWithFallback', () => {
+  it('primary fails, rolls to tier 1 and succeeds', async () => {
+    const chain = [
+      { provider: 'A', model: 'a', tier: 0, primary: true },
+      { provider: 'B', model: 'b', tier: 1, primary: false },
+    ];
+    const events = [];
+    const { result, tier, attempts } = await PF.runWithFallback({
+      chain,
+      runOne: async (t) => (t.provider === 'A'
+        ? { recoveredFromError: true, recoveredError: 'Overloaded' }
+        : { responseMessage: { role: 'assistant', content: 'OK' } }),
+      onFallback: (info) => events.push(info),
+    });
+    expect(tier.provider).toBe('B');
+    expect(result.responseMessage.content).toBe('OK');
+    expect(events.length).toBe(1);
+    expect(events[0].from.provider).toBe('A');
+    expect(events[0].to.provider).toBe('B');
+    expect(events[0].reason).toBe('overloaded');
+    expect(attempts.length).toBe(2);
+  });
+
+  it('all tiers fail → returns last failed result (no throw)', async () => {
+    const chain = [{ provider: 'A', tier: 0, primary: true }, { provider: 'B', tier: 1 }];
+    const { result } = await PF.runWithFallback({
+      chain,
+      runOne: async () => ({ recoveredFromError: true, recoveredError: '500' }),
+    });
+    expect(result.recoveredFromError).toBe(true);
+  });
+
+  it('cancellation propagates (never fails over)', async () => {
+    const chain = [{ provider: 'A', tier: 0, primary: true }, { provider: 'B', tier: 1 }];
+    await expect(PF.runWithFallback({
+      chain,
+      runOne: async () => { const e = new Error('aborted'); e.name = 'AbortError'; throw e; },
+    })).rejects.toThrow();
+  });
+
+  it('a thrown non-cancellation error on primary rolls to tier 1', async () => {
+    const chain = [{ provider: 'A', tier: 0, primary: true }, { provider: 'B', tier: 1 }];
+    const { tier } = await PF.runWithFallback({
+      chain,
+      runOne: async (t) => { if (t.provider === 'A') throw new Error('ECONNRESET boom'); return { responseMessage: { content: 'ok' } }; },
+    });
+    expect(tier.provider).toBe('B');
+  });
+});

--- a/backend/src/services/orchestrator/ProviderFallback.test.mjs
+++ b/backend/src/services/orchestrator/ProviderFallback.test.mjs
@@ -1,0 +1,105 @@
+import assert from 'node:assert';
+import PF from './ProviderFallback.js';
+
+let pass = 0, fail = 0;
+const t = (name, fn) => { try { fn(); pass++; console.log('  ✓', name); } catch (e) { fail++; console.log('  ✗', name, '→', e.message); } };
+
+console.log('parseFallbackList');
+t('parses JSON string', () => assert.deepEqual(
+  PF.parseFallbackList('[{"provider":"GrokAI","model":"grok-4.5"}]'),
+  [{ provider: 'GrokAI', model: 'grok-4.5' }]));
+t('empty/blank → []', () => { assert.deepEqual(PF.parseFallbackList(''), []); assert.deepEqual(PF.parseFallbackList(null), []); });
+t('malformed JSON → []', () => assert.deepEqual(PF.parseFallbackList('{not json'), []));
+t('drops entries with no provider', () => assert.deepEqual(
+  PF.parseFallbackList([{ model: 'x' }, { provider: 'GrokAI' }]),
+  [{ provider: 'GrokAI', model: null }]));
+
+console.log('isKnownProvider');
+t('unknown provider is false', () => assert.equal(PF.isKnownProvider('totally-fake-xyz'), false));
+t('empty is false', () => assert.equal(PF.isKnownProvider(''), false));
+
+console.log('buildProviderChain');
+t('primary always present, no fallback when disabled', () => {
+  const c = PF.buildProviderChain({ provider: 'Anthropic', model: 'm', fallbackEnabled: false, fallbackProviders: '[{"provider":"GrokAI","model":"grok-4.5"}]' });
+  assert.equal(c.length, 1);
+  assert.equal(c[0].primary, true);
+  assert.equal(c[0].tier, 0);
+});
+t('caps at MAX_FALLBACKS (3) → chain length 4', () => {
+  const many = JSON.stringify([1,2,3,4,5].map(i => ({ provider: `fakeprov${i}`, model: `m${i}` })));
+  // fake providers are unknown so they get dropped — expect just the primary
+  const c = PF.buildProviderChain({ provider: 'Anthropic', model: 'm', fallbackEnabled: true, fallbackProviders: many });
+  assert.equal(c[0].primary, true);
+  assert.ok(c.length <= 1 + PF.MAX_FALLBACKS);
+});
+t('dedupes primary from fallback list', () => {
+  const c = PF.buildProviderChain({ provider: 'Anthropic', model: 'm', fallbackEnabled: true, fallbackProviders: '[{"provider":"Anthropic","model":"m"}]' });
+  assert.equal(c.length, 1);
+});
+
+console.log('classifyFailure');
+t('auth', () => assert.equal(PF.classifyFailure('401 Unauthorized'), 'auth'));
+t('cap (Claude Max)', () => assert.equal(PF.classifyFailure('now draw from your extra usage'), 'cap'));
+t('overloaded', () => assert.equal(PF.classifyFailure('Overloaded'), 'overloaded'));
+t('network', () => assert.equal(PF.classifyFailure('Connection error.'), 'network'));
+t('rate_limit', () => assert.equal(PF.classifyFailure('429 rate limit'), 'rate_limit'));
+t('unknown', () => assert.equal(PF.classifyFailure('weird'), 'unknown'));
+
+console.log('shouldFailover / isCancellation');
+t('recoveredFromError true → failover', () => assert.equal(PF.shouldFailover({ recoveredFromError: true }), true));
+t('success → no failover', () => assert.equal(PF.shouldFailover({ responseMessage: {} }), false));
+t('abort is cancellation', () => assert.equal(PF.isCancellation({ name: 'AbortError' }), true));
+t('normal error not cancellation', () => assert.equal(PF.isCancellation({ message: '500' }), false));
+
+console.log('runWithFallback');
+await (async () => {
+  // primary fails, tier1 succeeds
+  const chain = [
+    { provider: 'A', model: 'a', tier: 0, primary: true },
+    { provider: 'B', model: 'b', tier: 1, primary: false },
+  ];
+  const events = [];
+  const { result, tier, attempts } = await PF.runWithFallback({
+    chain,
+    runOne: async (t) => t.provider === 'A'
+      ? { recoveredFromError: true, recoveredError: 'Overloaded' }
+      : { responseMessage: { role: 'assistant', content: 'OK' } },
+    onFallback: (info) => events.push(info),
+  });
+  t('rolled to B and succeeded', () => { assert.equal(tier.provider, 'B'); assert.equal(result.responseMessage.content, 'OK'); });
+  t('emitted one fallback event A→B', () => { assert.equal(events.length, 1); assert.equal(events[0].from.provider, 'A'); assert.equal(events[0].to.provider, 'B'); assert.equal(events[0].reason, 'overloaded'); });
+  t('recorded 2 attempts', () => assert.equal(attempts.length, 2));
+})();
+
+await (async () => {
+  // all fail → returns last failed result, no throw
+  const chain = [ { provider: 'A', tier: 0, primary: true }, { provider: 'B', tier: 1 } ];
+  const { result } = await PF.runWithFallback({
+    chain,
+    runOne: async () => ({ recoveredFromError: true, recoveredError: '500' }),
+  });
+  t('all-fail returns failed result (last resort card)', () => assert.equal(result.recoveredFromError, true));
+})();
+
+await (async () => {
+  // cancellation must propagate, never roll over
+  const chain = [ { provider: 'A', tier: 0, primary: true }, { provider: 'B', tier: 1 } ];
+  let threw = false;
+  try {
+    await PF.runWithFallback({ chain, runOne: async () => { const e = new Error('aborted'); e.name = 'AbortError'; throw e; } });
+  } catch (e) { threw = true; }
+  t('cancellation propagates (no failover)', () => assert.equal(threw, true));
+})();
+
+await (async () => {
+  // a thrown non-cancellation error on primary → rolls to tier1
+  const chain = [ { provider: 'A', tier: 0, primary: true }, { provider: 'B', tier: 1 } ];
+  const { tier } = await PF.runWithFallback({
+    chain,
+    runOne: async (t) => { if (t.provider === 'A') throw new Error('ECONNRESET boom'); return { responseMessage: { content: 'ok' } }; },
+  });
+  t('thrown error on primary rolls to B', () => assert.equal(tier.provider, 'B'));
+})();
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/backend/src/services/orchestrator/fallbackChain.js
+++ b/backend/src/services/orchestrator/fallbackChain.js
@@ -1,0 +1,50 @@
+/**
+ * fallbackChain.js — shared sanitizers for provider-failover chains.
+ *
+ * A "fallback chain" is a JSON array of up to 3 { provider, model } tiers,
+ * persisted as TEXT on both the `users` table (user-global default chain) and
+ * the `agents` table (per-agent override chain). This module is the single
+ * source of truth for parsing/serializing that column so UserModel, AgentModel
+ * and any future caller stay consistent.
+ *
+ * Design contracts (match UserModel's original inline helpers, Phase 1):
+ *   - NULL / '' / malformed JSON / non-array  → []
+ *   - each entry must have a non-empty string `provider`; others dropped
+ *   - `model` coerced to a trimmed string or null
+ *   - capped at MAX_FALLBACK_TIERS (3)
+ */
+
+export const MAX_FALLBACK_TIERS = 3;
+
+/**
+ * Parse a raw fallback_providers column value into a clean array.
+ * @param {string|Array|null|undefined} raw
+ * @returns {{provider: string, model: string|null}[]}
+ */
+export function parseFallbackChain(raw) {
+  if (raw === null || raw === undefined || raw === '') return [];
+  let parsed = raw;
+  if (typeof raw === 'string') {
+    try { parsed = JSON.parse(raw); } catch { return []; }
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed
+    .filter((e) => e && typeof e === 'object' && typeof e.provider === 'string' && e.provider.trim())
+    .map((e) => ({
+      provider: e.provider.trim(),
+      model: typeof e.model === 'string' && e.model.trim() ? e.model.trim() : null,
+    }))
+    .slice(0, MAX_FALLBACK_TIERS);
+}
+
+/**
+ * Serialize a fallback chain for storage. Accepts an array or a pre-stringified
+ * JSON string; anything invalid becomes '[]'.
+ * @param {Array|string|null|undefined} value
+ * @returns {string} JSON string
+ */
+export function serializeFallbackChain(value) {
+  return JSON.stringify(parseFallbackChain(value));
+}
+
+export default { MAX_FALLBACK_TIERS, parseFallbackChain, serializeFallbackChain };

--- a/backend/src/services/orchestrator/streamFailover.js
+++ b/backend/src/services/orchestrator/streamFailover.js
@@ -1,0 +1,64 @@
+/**
+ * streamFailover.js — reusable streaming-call failover driver.
+ *
+ * Wraps a single round-0 streaming LLM call across a provider chain so that if
+ * the primary tier exhausts its retries (adapter returns recoveredFromError, or
+ * throws a non-cancellation error), the call transparently rolls over to the
+ * next configured tier. Shared by OrchestratorService (main chat) and
+ * AutonomousMessageService (goals / agent autonomous loop).
+ *
+ * This is a thin orchestration layer over ProviderFallback.runWithFallback that
+ * additionally rebuilds the client+adapter per tier via injected builders, so
+ * it stays testable (no direct LlmService dependency).
+ *
+ * CONTRACTS (identical to the Phase-2 inline wrap):
+ *   - Failover only on the FIRST call (round-0). Mid-tool-loop rounds are the
+ *     caller's responsibility and are NOT wrapped here.
+ *   - The adapter only returns recoveredFromError when ZERO tokens were emitted,
+ *     so a failed tier never streams partial output → clean rollover.
+ *   - Cancellations propagate untouched (never failover a cancelled turn).
+ *   - No settings persistence. The winning tier is used for THIS TURN ONLY.
+ */
+
+import { runWithFallback } from './ProviderFallback.js';
+
+/**
+ * @param {object} args
+ * @param {Array}  args.chain       output of buildProviderChain (>=1 tier)
+ * @param {(tier)=>Promise<{client:any, adapter:any}>} args.buildAdapter
+ *        Builds (or reuses) the client+adapter for a tier. Called once per tier.
+ * @param {(adapter, tier)=>Promise<object>} args.callAdapter
+ *        Performs the streaming call with the tier's adapter, returns the
+ *        adapter result object ({responseMessage, toolCalls, recoveredFromError, ...}).
+ * @param {(info)=>void} [args.onFallback]  notified before each rollover
+ * @param {(tier, adapter, client)=>void} [args.onTierActive]
+ *        Called with the WINNING tier's adapter+client so the caller can adopt
+ *        them for the rest of the turn (tool loop).
+ * @returns {Promise<{result: object, tier: object, attempts: object[]}>}
+ */
+export async function runStreamWithFallback({ chain, buildAdapter, callAdapter, onFallback, onTierActive }) {
+  let activeAdapter = null;
+  let activeClient = null;
+  let activeTier = null;
+
+  const outcome = await runWithFallback({
+    chain,
+    onFallback,
+    runOne: async (tier) => {
+      const built = await buildAdapter(tier);
+      activeAdapter = built.adapter;
+      activeClient = built.client;
+      activeTier = tier;
+      return callAdapter(built.adapter, tier);
+    },
+  });
+
+  // Let the caller adopt the winning tier's adapter/client for subsequent rounds.
+  if (typeof onTierActive === 'function' && activeTier) {
+    try { onTierActive(activeTier, activeAdapter, activeClient); } catch { /* never break */ }
+  }
+
+  return outcome;
+}
+
+export default { runStreamWithFallback };

--- a/backend/src/services/orchestrator/tools.js
+++ b/backend/src/services/orchestrator/tools.js
@@ -946,8 +946,8 @@ The command runs in the OS-native shell — cmd.exe on Windows, /bin/sh on macOS
             },
             timeoutMs: {
               type: 'number',
-              default: 300000,
-              description: 'Hard timeout in milliseconds (default 300000 = 5 min).',
+              description:
+                'Hard timeout in milliseconds. Defaults to AGNT_CURSOR_TIMEOUT_MS (90000 recommended, 300000 if unset).',
             },
             extraArgs: {
               type: 'array',
@@ -968,7 +968,7 @@ The command runs in the OS-native shell — cmd.exe on Windows, /bin/sh on macOS
         sessionScope = 'conversation',
         sessionId = null,
         force = true,
-        timeoutMs = 300000,
+        timeoutMs = undefined, // fall through to AGNT_CURSOR_TIMEOUT_MS
         extraArgs = [],
       },
       _authToken,
@@ -1014,7 +1014,7 @@ The command runs in the OS-native shell — cmd.exe on Windows, /bin/sh on macOS
           force,
           resume,
           sessionId,
-          timeoutMs,
+          ...(timeoutMs != null ? { timeoutMs } : {}),
           extraArgs: Array.isArray(extraArgs) ? extraArgs : [],
         });
 

--- a/frontend/src/store/features/chat.js
+++ b/frontend/src/store/features/chat.js
@@ -2545,6 +2545,11 @@ export default {
           }
           break;
 
+        case 'provider_fallback':
+          // Handled by Chat.vue stream callback (activity feed + terminal).
+          // Acknowledge here so we don't log "Unknown event type".
+          break;
+
         default:
           console.warn('[Realtime Chat] Unknown event type:', type);
       }

--- a/frontend/src/store/features/chat.js
+++ b/frontend/src/store/features/chat.js
@@ -2546,6 +2546,7 @@ export default {
           break;
 
         case 'provider_fallback':
+        case 'provider_recovered':
           // Handled by Chat.vue stream callback (activity feed + terminal).
           // Acknowledge here so we don't log "Unknown event type".
           break;

--- a/frontend/src/views/Terminal/CenterPanel/screens/Chat/Chat.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Chat/Chat.vue
@@ -1368,6 +1368,34 @@ export default {
         case 'files_processed':
           if (ms) addActivityTo(ms, { type: 'info', text: `Processed ${data.fileCount} file(s): ${data.fileNames.join(', ')}` });
           break;
+        case 'provider_fallback': {
+          // Automatic cross-provider failover (Phase 2/4). Backend emits this
+          // when the primary provider exhausted retries and the turn rolled
+          // over to a fallback tier. Surface it in System Activity so the
+          // user can see the switch happened (previously the event was
+          // silently dropped — no frontend handler existed).
+          const fromP = data?.from?.provider || 'primary';
+          const fromM = data?.from?.model ? `/${data.from.model}` : '';
+          const toP = data?.to?.provider || 'fallback';
+          const toM = data?.to?.model ? `/${data.to.model}` : '';
+          const reason = data?.reason ? ` (${data.reason})` : '';
+          const text = `Provider failover: ${fromP}${fromM} → ${toP}${toM}${reason}`;
+          if (ms) addActivityTo(ms, { type: 'recovery', text });
+          if (isActiveView) {
+            terminalLines.value.push(`[Failover] ${text}`);
+            // Brief status on the in-flight assistant bubble if one exists.
+            const activeMsgId = Object.keys(messageStates.value).find(
+              (id) => messageStates.value[id]?.type === 'thinking' || messageStates.value[id]?.type === 'tool',
+            );
+            if (activeMsgId) {
+              messageStates.value[activeMsgId] = {
+                type: 'thinking',
+                text: `Switched to ${toP}${toM} — continuing…`,
+              };
+            }
+          }
+          break;
+        }
         case 'final_content':
           if (isActiveView) {
             delete messageStates.value[data.assistantMessageId];

--- a/frontend/src/views/Terminal/CenterPanel/screens/Chat/Chat.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Chat/Chat.vue
@@ -1396,6 +1396,17 @@ export default {
           }
           break;
         }
+        case 'provider_recovered': {
+          // Recovery banner (Option 2). Backend emits this when the default
+          // provider succeeds again after an earlier failover in this
+          // conversation — the green counterpart to provider_fallback.
+          const backP = data?.backTo?.provider || 'default';
+          const backM = data?.backTo?.model ? `/${data.backTo.model}` : '';
+          const text = `Recovered: back on ${backP}${backM}`;
+          if (ms) addActivityTo(ms, { type: 'success', text });
+          if (isActiveView) terminalLines.value.push(`[Recovered] ${text}`);
+          break;
+        }
         case 'final_content':
           if (isActiveView) {
             delete messageStates.value[data.assistantMessageId];

--- a/frontend/src/views/Terminal/CenterPanel/screens/Connectors/Connectors.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Connectors/Connectors.vue
@@ -22,6 +22,7 @@
         <div class="connectors-grid">
           <div class="connectors-section full-width">
             <ProviderSelector />
+            <FallbackProviders />
           </div>
         </div>
       </div>
@@ -841,6 +842,7 @@ import providerAuthService from '@/services/providerAuthService.js';
 import { useTutorial } from './useTutorial.js';
 import PopupTutorial from '../../../../_components/utility/PopupTutorial.vue';
 import ProviderSelector from '../Settings/components/ProviderSelector/ProviderSelector.vue';
+import FallbackProviders from './components/FallbackProviders.vue';
 import ResourcesSection from '../../../../_components/common/ResourcesSection.vue';
 import Webhooks from './components/Webhooks.vue';
 import EmailServer from './components/EmailServer.vue';
@@ -864,6 +866,7 @@ export default {
     ConnectorsPanel,
     PopupTutorial,
     ProviderSelector,
+    FallbackProviders,
     ResourcesSection,
     Webhooks,
     EmailServer,

--- a/frontend/src/views/Terminal/CenterPanel/screens/Connectors/components/FallbackProviders.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Connectors/components/FallbackProviders.vue
@@ -189,6 +189,7 @@ export default {
         const res = await fetch('/api/users/settings', {
           headers: { Authorization: 'Bearer ' + authToken() },
         });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
         const data = await res.json();
         enabled.value = !!data.fallbackEnabled;
         const list = Array.isArray(data.fallbackProviders) ? data.fallbackProviders : [];
@@ -291,7 +292,14 @@ export default {
   user-select: none;
   white-space: nowrap;
 }
-.fb-toggle input { display: none; }
+/* Visually hidden but still focusable + in the tab order (a11y). */
+.fb-toggle input {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0 0 0 0);
+  white-space: nowrap; border: 0;
+}
 .fb-toggle-track {
   width: 40px; height: 22px; border-radius: 11px;
   background: var(--terminal-border-color);
@@ -299,6 +307,10 @@ export default {
   flex-shrink: 0;
 }
 .fb-toggle input:checked + .fb-toggle-track { background: var(--color-green); }
+.fb-toggle input:focus-visible + .fb-toggle-track {
+  outline: 2px solid var(--color-green);
+  outline-offset: 2px;
+}
 .fb-toggle-thumb {
   position: absolute; top: 2px; left: 2px;
   width: 18px; height: 18px; border-radius: 50%;

--- a/frontend/src/views/Terminal/CenterPanel/screens/Connectors/components/FallbackProviders.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Connectors/components/FallbackProviders.vue
@@ -1,0 +1,432 @@
+<template>
+  <div class="fallback-providers">
+    <!-- Header: title + toggle on one flex row (title flexes, toggle fixed),
+         subtitle on its own full-width line below. -->
+    <div class="fb-header">
+      <div class="fb-header-toprow">
+        <label class="fb-toggle" :title="enabled ? 'Failover enabled' : 'Failover disabled'">
+          <input type="checkbox" v-model="enabled" @change="markDirty" />
+          <span class="fb-toggle-track"><span class="fb-toggle-thumb"></span></span>
+          <span class="fb-toggle-label">{{ enabled ? 'Enabled' : 'Disabled' }}</span>
+        </label>
+      </div>
+      <h2 class="fb-title">Fallback AI Providers</h2>
+      <p class="fb-subtitle">
+        If your default provider is unavailable, Annie automatically retries these
+        in order — up to three backups. Used only when the default fails.
+      </p>
+    </div>
+
+    <div class="fb-body" :class="{ 'fb-disabled': !enabled }">
+      <div v-if="rows.length === 0" class="fb-empty">
+        <i class="fas fa-layer-group"></i>
+        <p>No fallback providers configured. Add one to protect against outages.</p>
+      </div>
+
+      <div v-for="(row, idx) in rows" :key="idx" class="fb-row">
+        <span class="fb-tier">{{ idx + 1 }}</span>
+
+        <div class="fb-selects">
+          <select
+            class="fb-select"
+            :value="row.provider"
+            @change="onProviderChange(idx, $event.target.value)"
+          >
+            <option value="" disabled>Select provider…</option>
+            <option
+              v-for="p in availableForRow(idx)"
+              :key="p.key"
+              :value="p.key"
+            >{{ p.label }}</option>
+          </select>
+
+          <select
+            class="fb-select"
+            :value="row.model"
+            :disabled="!row.provider || modelsFor(row.provider).length === 0"
+            @change="onModelChange(idx, $event.target.value)"
+          >
+            <option value="" :disabled="modelsFor(row.provider).length > 0">
+              {{ modelsFor(row.provider).length ? 'Select model…' : (row.provider ? 'Provider default' : '—') }}
+            </option>
+            <option
+              v-for="m in modelsFor(row.provider)"
+              :key="m"
+              :value="m"
+            >{{ m }}</option>
+          </select>
+        </div>
+
+        <button class="fb-remove" title="Remove" @click="removeRow(idx)">
+          <i class="fas fa-trash"></i>
+        </button>
+      </div>
+
+      <div class="fb-actions">
+        <button
+          v-if="rows.length < MAX"
+          class="fb-add"
+          :disabled="!hasCandidates"
+          :title="hasCandidates ? 'Add a fallback provider' : 'No other connected providers available'"
+          @click="addRow"
+        >
+          <i class="fas fa-plus"></i> Add fallback
+        </button>
+        <span v-else class="fb-max-note">Maximum of {{ MAX }} fallbacks reached.</span>
+
+        <BaseButton
+          variant="primary"
+          size="small"
+          :disabled="!dirty || saving"
+          @click="save"
+        >
+          <i class="fas" :class="saving ? 'fa-spinner fa-spin' : 'fa-save'"></i>
+          {{ saving ? 'Saving…' : 'Save changes' }}
+        </BaseButton>
+      </div>
+
+      <p v-if="!hasCandidates && rows.length === 0" class="fb-hint">
+        Connect at least one more AI provider (besides your default) in the
+        Auth Connections section to enable fallbacks.
+      </p>
+
+      <div v-if="statusMsg" class="fb-status" :class="statusOk ? 'ok' : 'err'">
+        <i class="fas" :class="statusOk ? 'fa-check-circle' : 'fa-exclamation-triangle'"></i>
+        <span>{{ statusMsg }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, onMounted } from 'vue';
+import { useStore } from 'vuex';
+import BaseButton from '@/views/Terminal/_components/BaseButton.vue';
+import {
+  AI_PROVIDERS_WITH_API,
+  PROVIDER_DISPLAY_NAMES,
+  PROVIDER_FETCH_ACTIONS,
+  resolveProviderKey,
+} from '@/store/app/aiProvider.js';
+
+const MAX = 3;
+
+export default {
+  name: 'FallbackProviders',
+  components: { BaseButton },
+  setup() {
+    const store = useStore();
+
+    const enabled = ref(false);
+    const rows = ref([]); // [{ provider: <displayName>, model: <id|''> }]
+    const dirty = ref(false);
+    const saving = ref(false);
+    const statusMsg = ref('');
+    const statusOk = ref(true);
+
+    // ── Data sources (mirrors ProviderSelector.vue) ───────────────────────
+    // filteredProviders → array of provider DISPLAY-NAME strings (e.g. 'GrokAI')
+    const providerNames = computed(() => store.getters['aiProvider/filteredProviders'] || []);
+    // connectedApps → array of lowercase provider KEYS that are actually connected
+    const connectedLower = computed(() =>
+      (store.state.appAuth?.connectedApps || []).map((p) => String(p).toLowerCase())
+    );
+    // The current default provider (display name) — excluded from fallbacks.
+    const defaultProviderLower = computed(() =>
+      String(store.state.aiProvider?.selectedProvider || '').toLowerCase()
+    );
+
+    // A provider is offerable as a fallback when it needs an API key, is
+    // connected, and isn't the current default.
+    const connectableProviders = computed(() => {
+      return providerNames.value
+        .filter((name) => {
+          const key = resolveProviderKey(name);
+          const lower = String(name).toLowerCase();
+          if (lower === defaultProviderLower.value) return false;
+          if (key === 'local') return false;
+          return (
+            AI_PROVIDERS_WITH_API.includes(key) &&
+            connectedLower.value.includes(key)
+          );
+        })
+        .map((name) => ({ key: name, label: PROVIDER_DISPLAY_NAMES[name] || name }));
+    });
+
+    function modelsFor(providerName) {
+      if (!providerName) return [];
+      return store.state.aiProvider?.allModels?.[providerName] || [];
+    }
+
+    // Fetch a provider's model list on demand (so the model dropdown fills).
+    async function ensureModels(providerName) {
+      if (!providerName) return;
+      if (modelsFor(providerName).length > 0) return;
+      const action = PROVIDER_FETCH_ACTIONS[providerName];
+      if (!action) return;
+      try { await store.dispatch(action); } catch (e) { /* non-fatal */ }
+    }
+
+    // Providers available for a given row: connectable, minus those chosen in
+    // OTHER rows (dedupe across tiers), plus this row's own current choice.
+    function availableForRow(idx) {
+      const chosenElsewhere = new Set(
+        rows.value.filter((_, i) => i !== idx).map((r) => r.provider).filter(Boolean)
+      );
+      return connectableProviders.value.filter(
+        (p) => !chosenElsewhere.has(p.key) || p.key === rows.value[idx]?.provider
+      );
+    }
+
+    const hasCandidates = computed(() => {
+      const used = new Set(rows.value.map((r) => r.provider).filter(Boolean));
+      return connectableProviders.value.some((p) => !used.has(p.key));
+    });
+
+    function markDirty() { dirty.value = true; statusMsg.value = ''; }
+
+    function addRow() {
+      if (rows.value.length >= MAX) return;
+      rows.value.push({ provider: '', model: '' });
+      markDirty();
+    }
+    function removeRow(idx) { rows.value.splice(idx, 1); markDirty(); }
+
+    async function onProviderChange(idx, val) {
+      rows.value[idx].provider = val;
+      rows.value[idx].model = '';
+      markDirty();
+      await ensureModels(val);
+      // Default to first model once loaded, if none chosen.
+      const models = modelsFor(val);
+      if (models.length && !rows.value[idx].model) rows.value[idx].model = models[0];
+    }
+    function onModelChange(idx, val) { rows.value[idx].model = val; markDirty(); }
+
+    // ── Load / Save via /api/users/settings ───────────────────────────────
+    function authToken() {
+      return localStorage.getItem('token') || localStorage.getItem('authToken') || '';
+    }
+
+    async function load() {
+      try {
+        const res = await fetch('/api/users/settings', {
+          headers: { Authorization: 'Bearer ' + authToken() },
+        });
+        const data = await res.json();
+        enabled.value = !!data.fallbackEnabled;
+        const list = Array.isArray(data.fallbackProviders) ? data.fallbackProviders : [];
+        rows.value = list.slice(0, MAX).map((e) => ({
+          provider: e.provider || '',
+          model: e.model || '',
+        }));
+        // Warm the model lists for any saved providers so their dropdowns fill.
+        for (const r of rows.value) ensureModels(r.provider);
+        dirty.value = false;
+      } catch (e) {
+        console.warn('[FallbackProviders] load failed:', e);
+      }
+    }
+
+    async function save() {
+      saving.value = true;
+      statusMsg.value = '';
+      try {
+        const payload = rows.value
+          .filter((r) => r.provider)
+          .slice(0, MAX)
+          .map((r) => ({ provider: r.provider, model: r.model || null }));
+        const res = await fetch('/api/users/settings', {
+          method: 'PUT',
+          headers: {
+            Authorization: 'Bearer ' + authToken(),
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            fallbackProviders: payload,
+            fallbackEnabled: enabled.value,
+          }),
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        statusOk.value = true;
+        statusMsg.value = 'Fallback providers saved.';
+        dirty.value = false;
+        await load();
+      } catch (e) {
+        statusOk.value = false;
+        statusMsg.value = 'Could not save: ' + e.message;
+      } finally {
+        saving.value = false;
+      }
+    }
+
+    onMounted(async () => {
+      // Make sure the connected-apps + provider lists are populated.
+      try { await store.dispatch('appAuth/fetchConnectedApps'); } catch (e) { /* ignore */ }
+      await load();
+    });
+
+    return {
+      MAX,
+      enabled, rows, dirty, saving, statusMsg, statusOk,
+      connectableProviders, modelsFor, availableForRow, hasCandidates,
+      markDirty, addRow, removeRow, onProviderChange, onModelChange, save,
+    };
+  },
+};
+</script>
+
+<style scoped>
+.fallback-providers {
+  border: 1px solid var(--terminal-border-color);
+  border-radius: 12px;
+  padding: 20px;
+  margin-top: 24px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Header ── title + toggle share a flex row; subtitle full-width below.
+   Title uses flex:1 + min-width:0 so it fills the row and never collapses. */
+.fb-header { margin-bottom: 16px; }
+.fb-header-toprow {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 4px;
+}
+.fb-title {
+  display: block;
+  width: 100%;
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.3;
+}
+.fb-subtitle {
+  margin: 6px 0 0 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--color-text-muted);
+  max-width: 68ch;
+}
+
+.fb-toggle {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+.fb-toggle input { display: none; }
+.fb-toggle-track {
+  width: 40px; height: 22px; border-radius: 11px;
+  background: var(--terminal-border-color);
+  position: relative; transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+.fb-toggle input:checked + .fb-toggle-track { background: var(--color-green); }
+.fb-toggle-thumb {
+  position: absolute; top: 2px; left: 2px;
+  width: 18px; height: 18px; border-radius: 50%;
+  background: var(--color-navy, #0d1117);
+  transition: transform 0.2s ease;
+}
+.fb-toggle input:checked + .fb-toggle-track .fb-toggle-thumb { transform: translateX(18px); }
+.fb-toggle-label { font-size: 0.85rem; color: var(--color-text-muted); }
+
+.fb-body { transition: opacity 0.2s ease; }
+.fb-body.fb-disabled { opacity: 0.5; pointer-events: none; }
+
+.fb-empty {
+  display: flex; flex-direction: column; align-items: center;
+  gap: 8px; padding: 24px; color: var(--color-text-muted);
+  text-align: center;
+}
+.fb-empty i { font-size: 1.6rem; opacity: 0.5; }
+.fb-empty p { margin: 0; font-size: 0.9rem; }
+
+.fb-row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 0;
+  min-width: 0;
+}
+.fb-tier {
+  width: 26px; height: 26px; flex: 0 0 auto;
+  border-radius: 50%;
+  background: rgba(var(--green-rgb), 0.15);
+  color: var(--color-green);
+  display: flex; align-items: center; justify-content: center;
+  font-weight: 600; font-size: 0.85rem;
+}
+.fb-selects {
+  display: flex; gap: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.fb-select {
+  flex: 1 1 0;
+  min-width: 0;
+  padding: 8px 12px;
+  border: 1px solid var(--terminal-border-color);
+  border-radius: 8px;
+  background: var(--color-popup);
+  color: var(--color-text);
+  font-family: inherit; font-size: 0.9rem;
+  transition: border-color 0.2s ease;
+}
+.fb-select:focus { outline: none; border-color: var(--color-green); }
+.fb-select:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.fb-remove {
+  background: transparent; border: none;
+  color: var(--color-text-muted); cursor: pointer;
+  padding: 6px 8px; border-radius: 6px; flex: 0 0 auto;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+.fb-remove:hover { color: var(--color-red); background: rgba(255,107,107,0.1); }
+
+.fb-actions {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px; margin-top: 12px;
+  padding-top: 12px; border-top: 1px solid var(--terminal-border-color);
+  min-width: 0;
+}
+.fb-add {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: transparent;
+  border: 1px dashed var(--terminal-border-color);
+  color: var(--color-text-muted);
+  padding: 8px 14px; border-radius: 8px; cursor: pointer;
+  font-size: 0.9rem; transition: all 0.2s ease;
+  flex: 0 0 auto;
+}
+.fb-add:hover:not(:disabled) { border-color: var(--color-green); color: var(--color-green); }
+.fb-add:disabled { opacity: 0.4; cursor: not-allowed; }
+.fb-max-note { font-size: 0.85rem; color: var(--color-text-muted); }
+
+.fb-hint {
+  margin: 12px 0 0 0;
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}
+
+.fb-status {
+  display: flex; align-items: center; gap: 8px;
+  margin-top: 12px; padding: 10px 14px; border-radius: 8px;
+  font-size: 0.9rem;
+}
+.fb-status.ok {
+  background: rgba(var(--green-rgb), 0.1);
+  border: 1px solid rgba(var(--green-rgb), 0.3);
+  color: var(--color-green);
+}
+.fb-status.err {
+  background: rgba(255, 107, 107, 0.1);
+  border: 1px solid rgba(255, 107, 107, 0.3);
+  color: var(--color-red);
+}
+</style>

--- a/frontend/src/views/Terminal/CenterPanel/screens/Connectors/components/FallbackProviders.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Connectors/components/FallbackProviders.vue
@@ -1,10 +1,9 @@
 <template>
   <div class="fallback-providers">
-    <!-- Header: title + toggle on one flex row (title flexes, toggle fixed),
-         subtitle on its own full-width line below. -->
+    <!-- Header: toggle on its own row (right), title + subtitle full-width below -->
     <div class="fb-header">
       <div class="fb-header-toprow">
-        <label class="fb-toggle" :title="enabled ? 'Failover enabled' : 'Failover disabled'">
+        <label class="fb-toggle" v-tooltip="enabled ? 'Failover enabled' : 'Failover disabled'">
           <input type="checkbox" v-model="enabled" @change="markDirty" />
           <span class="fb-toggle-track"><span class="fb-toggle-thumb"></span></span>
           <span class="fb-toggle-label">{{ enabled ? 'Enabled' : 'Disabled' }}</span>
@@ -27,37 +26,23 @@
         <span class="fb-tier">{{ idx + 1 }}</span>
 
         <div class="fb-selects">
-          <select
+          <CustomSelect
             class="fb-select"
-            :value="row.provider"
-            @change="onProviderChange(idx, $event.target.value)"
-          >
-            <option value="" disabled>Select provider…</option>
-            <option
-              v-for="p in availableForRow(idx)"
-              :key="p.key"
-              :value="p.key"
-            >{{ p.label }}</option>
-          </select>
-
-          <select
+            :options="providerOptionsFor(idx)"
+            :model-value="row.provider"
+            placeholder="Select provider…"
+            @option-selected="(opt) => onProviderChange(idx, opt.value)"
+          />
+          <CustomSelect
             class="fb-select"
-            :value="row.model"
-            :disabled="!row.provider || modelsFor(row.provider).length === 0"
-            @change="onModelChange(idx, $event.target.value)"
-          >
-            <option value="" :disabled="modelsFor(row.provider).length > 0">
-              {{ modelsFor(row.provider).length ? 'Select model…' : (row.provider ? 'Provider default' : '—') }}
-            </option>
-            <option
-              v-for="m in modelsFor(row.provider)"
-              :key="m"
-              :value="m"
-            >{{ m }}</option>
-          </select>
+            :options="modelOptionsFor(row.provider)"
+            :model-value="row.model"
+            :placeholder="modelsFor(row.provider).length ? 'Select model…' : (row.provider ? 'Provider default' : '—')"
+            @option-selected="(opt) => onModelChange(idx, opt.value)"
+          />
         </div>
 
-        <button class="fb-remove" title="Remove" @click="removeRow(idx)">
+        <button class="fb-remove" v-tooltip="'Remove'" @click="removeRow(idx)">
           <i class="fas fa-trash"></i>
         </button>
       </div>
@@ -67,7 +52,7 @@
           v-if="rows.length < MAX"
           class="fb-add"
           :disabled="!hasCandidates"
-          :title="hasCandidates ? 'Add a fallback provider' : 'No other connected providers available'"
+          v-tooltip="hasCandidates ? 'Add a fallback provider' : 'No other connected providers available'"
           @click="addRow"
         >
           <i class="fas fa-plus"></i> Add fallback
@@ -102,6 +87,7 @@
 import { ref, computed, onMounted } from 'vue';
 import { useStore } from 'vuex';
 import BaseButton from '@/views/Terminal/_components/BaseButton.vue';
+import CustomSelect from '@/views/_components/common/CustomSelect.vue';
 import {
   AI_PROVIDERS_WITH_API,
   PROVIDER_DISPLAY_NAMES,
@@ -113,7 +99,7 @@ const MAX = 3;
 
 export default {
   name: 'FallbackProviders',
-  components: { BaseButton },
+  components: { BaseButton, CustomSelect },
   setup() {
     const store = useStore();
 
@@ -124,20 +110,14 @@ export default {
     const statusMsg = ref('');
     const statusOk = ref(true);
 
-    // ── Data sources (mirrors ProviderSelector.vue) ───────────────────────
-    // filteredProviders → array of provider DISPLAY-NAME strings (e.g. 'GrokAI')
     const providerNames = computed(() => store.getters['aiProvider/filteredProviders'] || []);
-    // connectedApps → array of lowercase provider KEYS that are actually connected
     const connectedLower = computed(() =>
       (store.state.appAuth?.connectedApps || []).map((p) => String(p).toLowerCase())
     );
-    // The current default provider (display name) — excluded from fallbacks.
     const defaultProviderLower = computed(() =>
       String(store.state.aiProvider?.selectedProvider || '').toLowerCase()
     );
 
-    // A provider is offerable as a fallback when it needs an API key, is
-    // connected, and isn't the current default.
     const connectableProviders = computed(() => {
       return providerNames.value
         .filter((name) => {
@@ -145,10 +125,7 @@ export default {
           const lower = String(name).toLowerCase();
           if (lower === defaultProviderLower.value) return false;
           if (key === 'local') return false;
-          return (
-            AI_PROVIDERS_WITH_API.includes(key) &&
-            connectedLower.value.includes(key)
-          );
+          return AI_PROVIDERS_WITH_API.includes(key) && connectedLower.value.includes(key);
         })
         .map((name) => ({ key: name, label: PROVIDER_DISPLAY_NAMES[name] || name }));
     });
@@ -158,7 +135,6 @@ export default {
       return store.state.aiProvider?.allModels?.[providerName] || [];
     }
 
-    // Fetch a provider's model list on demand (so the model dropdown fills).
     async function ensureModels(providerName) {
       if (!providerName) return;
       if (modelsFor(providerName).length > 0) return;
@@ -167,15 +143,17 @@ export default {
       try { await store.dispatch(action); } catch (e) { /* non-fatal */ }
     }
 
-    // Providers available for a given row: connectable, minus those chosen in
-    // OTHER rows (dedupe across tiers), plus this row's own current choice.
-    function availableForRow(idx) {
+    // CustomSelect option lists ({ label, value }).
+    function providerOptionsFor(idx) {
       const chosenElsewhere = new Set(
         rows.value.filter((_, i) => i !== idx).map((r) => r.provider).filter(Boolean)
       );
-      return connectableProviders.value.filter(
-        (p) => !chosenElsewhere.has(p.key) || p.key === rows.value[idx]?.provider
-      );
+      return connectableProviders.value
+        .filter((p) => !chosenElsewhere.has(p.key) || p.key === rows.value[idx]?.provider)
+        .map((p) => ({ label: p.label, value: p.key }));
+    }
+    function modelOptionsFor(providerName) {
+      return modelsFor(providerName).map((m) => ({ label: m, value: m }));
     }
 
     const hasCandidates = computed(() => {
@@ -197,13 +175,11 @@ export default {
       rows.value[idx].model = '';
       markDirty();
       await ensureModels(val);
-      // Default to first model once loaded, if none chosen.
       const models = modelsFor(val);
       if (models.length && !rows.value[idx].model) rows.value[idx].model = models[0];
     }
     function onModelChange(idx, val) { rows.value[idx].model = val; markDirty(); }
 
-    // ── Load / Save via /api/users/settings ───────────────────────────────
     function authToken() {
       return localStorage.getItem('token') || localStorage.getItem('authToken') || '';
     }
@@ -220,7 +196,6 @@ export default {
           provider: e.provider || '',
           model: e.model || '',
         }));
-        // Warm the model lists for any saved providers so their dropdowns fill.
         for (const r of rows.value) ensureModels(r.provider);
         dirty.value = false;
       } catch (e) {
@@ -261,7 +236,6 @@ export default {
     }
 
     onMounted(async () => {
-      // Make sure the connected-apps + provider lists are populated.
       try { await store.dispatch('appAuth/fetchConnectedApps'); } catch (e) { /* ignore */ }
       await load();
     });
@@ -269,7 +243,7 @@ export default {
     return {
       MAX,
       enabled, rows, dirty, saving, statusMsg, statusOk,
-      connectableProviders, modelsFor, availableForRow, hasCandidates,
+      connectableProviders, modelsFor, providerOptionsFor, modelOptionsFor, hasCandidates,
       markDirty, addRow, removeRow, onProviderChange, onModelChange, save,
     };
   },
@@ -286,8 +260,6 @@ export default {
   box-sizing: border-box;
 }
 
-/* ── Header ── title + toggle share a flex row; subtitle full-width below.
-   Title uses flex:1 + min-width:0 so it fills the row and never collapses. */
 .fb-header { margin-bottom: 16px; }
 .fb-header-toprow {
   display: flex;
@@ -312,7 +284,6 @@ export default {
 }
 
 .fb-toggle {
-  flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -366,19 +337,7 @@ export default {
   flex: 1 1 auto;
   min-width: 0;
 }
-.fb-select {
-  flex: 1 1 0;
-  min-width: 0;
-  padding: 8px 12px;
-  border: 1px solid var(--terminal-border-color);
-  border-radius: 8px;
-  background: var(--color-popup);
-  color: var(--color-text);
-  font-family: inherit; font-size: 0.9rem;
-  transition: border-color 0.2s ease;
-}
-.fb-select:focus { outline: none; border-color: var(--color-green); }
-.fb-select:disabled { opacity: 0.5; cursor: not-allowed; }
+.fb-select { flex: 1 1 0; min-width: 0; }
 
 .fb-remove {
   background: transparent; border: none;


### PR DESCRIPTION
## Automatic cross-provider failover (with per-agent chains)

When a user's default LLM provider has an outage, AGNT currently **retries the same provider and then gives up** — surfacing an `⚠️ API Error` card as the assistant's answer. This PR adds **automatic failover**: a turn transparently rolls over to configured backup providers (up to 3) when the primary exhausts its retries.

**Dormant by default** (`fallback_enabled = 0`) — zero behavior change until a user or agent opts in.

### How it works
- Each adapter already self-retries and, on final failure, returns `recoveredFromError: true` (a "recovery card") **only when zero tokens were streamed**. That's the clean failover signal — a failed tier never emits partial output, so rollover is safe.
- `runWithFallback` iterates the provider chain; on failure it emits a `provider_fallback` SSE event and tries the next tier. The winning tier carries the rest of the turn (tool loop).

### Scope
| Area | Change |
|---|---|
| **Engine** | `ProviderFallback.js` — `buildProviderChain` / `runWithFallback` / `shouldFailover` / `classifyFailure`. Cancellation-safe, never persists the fallback as the default, caps at 3, never re-tries the same provider. |
| **Storage** | `users` + `agents` tables get `fallback_providers` (JSON) + `fallback_enabled` (guarded migrations). Shared sanitizer `fallbackChain.js`. |
| **API** | `UserService.updateUserSettings` accepts/validates the two fields. |
| **Main chat** | `OrchestratorService` round-0 `callStream` wrapped. **Active agent's chain takes precedence** over the user's global chain — a coding agent pinned to one provider fails over to *its* backups, not the user's. |
| **Autonomous** | `AutonomousMessageService` round-0 wrapped (reusable `streamFailover.js`) so goals / agent-to-agent runs get failover too. |
| **UI** | Connectors → **Fallback AI Providers** panel (ordered list ≤3, enable toggle). |

### Guardrails
- Never persists the fallback as the user's default (turn-only).
- Cancellations never fail over.
- Round-0 only (mid-tool-loop rounds unchanged).
- Dormant by default → existing behavior byte-identical until opt-in.

### Tests
41 assertions: 25 engine + 8 sanitizers + 5 per-agent precedence + 3 regression. **Live-verified end-to-end**: a forced primary failure rolled over to the fallback provider, which produced the answer.
