### PR TITLE
fix(workspaces): keep the AI provider popover opaque over custom backgrounds

### DIFF
--- a/frontend/src/views/Terminal/CenterPanel/screens/Workspace/Workspace.spec.js
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Workspace/Workspace.spec.js
@@ -2045,6 +2045,18 @@ describe('chat parity + the right-panel inspector (source guards)', () => {
     expect(styles).toMatch(/body\.custom-bg \.ws-root\s*\{\s*background:\s*transparent;/);
   });
 
+  it('keeps the Workspace AI popover opaque under custom-bg', () => {
+    // theme.js sets --color-background: transparent when a wallpaper is on.
+    // Floating chrome that still uses that token becomes a see-through sheet
+    // over Memory/chat widgets — labels unreadable. Same invariant as .ws-palette.
+    const ws = read('Workspace.vue');
+    const styles = ws.slice(ws.indexOf('<style'));
+    const pop = styles.slice(styles.indexOf('.ws-ai-popover {'));
+    const body = pop.slice(0, pop.indexOf('}'));
+    expect(body).toMatch(/background:\s*rgb\(\s*var\(--color-background-rgb/);
+    expect(body).not.toMatch(/background:\s*var\(--color-background\b/);
+  });
+
   it('window-nav chevrons share WidgetFrame’s control metrics', () => {
     // These sit in WidgetFrame's own header. Drifting from .wf-ctrl button's
     // padding/size makes them a second, tighter control cluster in the same

--- a/frontend/src/views/Terminal/CenterPanel/screens/Workspace/Workspace.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Workspace/Workspace.vue
@@ -1260,7 +1260,11 @@ export default {
   background: rgba(var(--primary-rgb, 229, 61, 143), 0.08);
 }
 
-/* Popover: match terminal chrome (NOT --color-surface — that can be light). */
+/* Popover: fully opaque chrome. Under custom-bg, theme.js sets
+   --color-background to `transparent` so the wallpaper shows through panels
+   that opt into the rgba(--bg-opacity) treatment. This popover floats over
+   live widget content (Memory, chat, …), so var(--color-background) made
+   every label unreadable — same trap .ws-palette already documents. */
 .ws-ai-popover {
   position: fixed;
   z-index: 10050;
@@ -1269,7 +1273,7 @@ export default {
   box-sizing: border-box;
   padding: 12px;
   border-radius: 10px;
-  background: var(--color-background, #0e0e16);
+  background: rgb(var(--color-background-rgb, 16, 16, 31));
   border: 1px solid var(--terminal-border-color, rgba(255, 255, 255, 0.12));
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.55);
   display: flex;


### PR DESCRIPTION
## Summary
- The Workspace AI provider popover used `var(--color-background)`, which theme.js sets to `transparent` under custom wallpaper mode — so Memory/chat content bled through and made the picker unreadable on dark backgrounds.
- Paint it with opaque `rgb(var(--color-background-rgb))`, same pattern as the widget palette, and add a source-guard test so it cannot regress.

## Test plan
- [ ] Enable a custom dark background (Settings → Custom Background)
- [ ] Open a workspace with Memory (or another busy widget) visible
- [ ] Click the workspace AI / Default pill and confirm the Workspace AI popover is solid — no bleed-through of underlying labels
- [ ] Pick a provider + model and Apply still works
- [ ] `npm --prefix frontend test -- --run Workspace.spec.js -t "keeps the Workspace AI popover opaque"`


Made with [Cursor](https://cursor.com)