### PR TITLE
feat(cursor-cli): surface tool events, make execution policy configurable

### DIFF
--- a/backend/src/services/ai/CursorCliClient.js
+++ b/backend/src/services/ai/CursorCliClient.js
@@ -181,6 +181,18 @@ export function createCursorCliClient({
   conversationId = null,
   provider = 'cursor-cli',
   timeoutMs = CursorCliService.getDefaultTimeoutMs?.() ?? 300000,
+  // Execution policy, resolved by the caller instead of hardcoded at the spawn
+  // site. The defaults reproduce today's behaviour exactly, so nothing changes
+  // unless someone opts in: CURSOR_CLI_FORCE=0 turns auto-approval off without
+  // a code change, and CURSOR_CLI_MODE=plan makes the provider read-only.
+  force = process.env.CURSOR_CLI_FORCE !== '0',
+  mode = process.env.CURSOR_CLI_MODE || null,
+  sandbox = process.env.CURSOR_CLI_SANDBOX || null,
+  // Opt-in observer for file reads/writes/shell commands Cursor performs.
+  // Left null by default: the OpenAI delta shape has no slot for "the agent
+  // wrote a file", so surfacing these in chat needs a UI channel decision.
+  // The capability lands here; the wiring is a separate change.
+  onToolCall = null,
 } = {}) {
   const resolvedSessionKey =
     sessionKey || `cursor-cli::${userId || 'anon'}::${conversationId || 'default'}`;
@@ -202,7 +214,9 @@ export function createCursorCliClient({
             prompt,
             model,
             cwd,
-            force: true,
+            force,
+            mode,
+            sandbox,
             resume: Boolean(existingSessionId),
             sessionId: existingSessionId,
             timeoutMs,
@@ -211,7 +225,10 @@ export function createCursorCliClient({
           // Streaming must return the generator BEFORE the run completes,
           // otherwise the deltas are already history by the time anyone reads.
           if (options.stream) {
-            return createCursorStreamGenerator(runOptions, resolvedSessionKey);
+            return createCursorStreamGenerator(
+              onToolCall ? { ...runOptions, onToolCall } : runOptions,
+              resolvedSessionKey,
+            );
           }
 
           const result = await CursorCliService.runExec(runOptions);

--- a/backend/src/services/ai/CursorCliClient.js
+++ b/backend/src/services/ai/CursorCliClient.js
@@ -221,14 +221,18 @@ export function createCursorCliClient({
             sessionId: existingSessionId,
             timeoutMs,
           };
+          // Tool events are orthogonal to how the caller wants the ANSWER
+          // delivered. A non-streaming completion still runs an agent that
+          // reads and writes files, and an observer asked to watch that should
+          // not fall silent because the reply arrives in one piece. Supplying
+          // this puts the CLI in stream-json so the events exist to be parsed;
+          // the aggregated result is unaffected.
+          if (onToolCall) runOptions.onToolCall = onToolCall;
 
           // Streaming must return the generator BEFORE the run completes,
           // otherwise the deltas are already history by the time anyone reads.
           if (options.stream) {
-            return createCursorStreamGenerator(
-              onToolCall ? { ...runOptions, onToolCall } : runOptions,
-              resolvedSessionKey,
-            );
+            return createCursorStreamGenerator(runOptions, resolvedSessionKey);
           }
 
           const result = await CursorCliService.runExec(runOptions);

--- a/backend/src/services/ai/CursorCliService.events.test.js
+++ b/backend/src/services/ai/CursorCliService.events.test.js
@@ -1,0 +1,217 @@
+/**
+ * Stream-event tests for CursorCliService.
+ *
+ * The sibling CursorCliService.test.js deliberately never spawns, so it covers
+ * none of the NDJSON parsing. These tests mock `spawn` and push real Cursor
+ * wire objects through the parser, which is the only way to pin:
+ *
+ *   - the delta discriminator (the pre-tool-call flush used to be double-counted)
+ *   - tool_call / system events, which used to be dropped by `default:`
+ *   - the execution-policy flags actually handed to the CLI
+ *
+ * Everything else about the process lifecycle (timeouts, the post-result hang)
+ * stays an integration concern.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import os from 'os';
+import path from 'path';
+
+const spawnCalls = [];
+let currentChild = null;
+
+function makeChild() {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = Object.assign(new EventEmitter(), { end() {}, write() {} });
+  child.kill = () => {};
+  return child;
+}
+
+// Keep every other child_process export real — binary resolution uses them.
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    spawn: (command, args, opts) => {
+      spawnCalls.push({ command, args, opts });
+      currentChild = makeChild();
+      return currentChild;
+    },
+  };
+});
+
+const CursorCliService = (await import('./CursorCliService.js')).default;
+
+/** Feed NDJSON lines to the mocked child, then close it. */
+async function runWith(lines, opts = {}) {
+  const promise = CursorCliService.runExecRaw({ prompt: 'test', ...opts });
+  await Promise.resolve();
+  currentChild.stdout.emit('data', Buffer.from(lines.map((l) => `${JSON.stringify(l)}\n`).join('')));
+  currentChild.emit('close', 0);
+  return promise;
+}
+
+const RESULT = { type: 'result', subtype: 'success', is_error: false, result: 'done', session_id: 's1' };
+const say = (text, extra = {}) => ({
+  type: 'assistant',
+  message: { content: [{ text }] },
+  ...extra,
+});
+
+let prevBin; let prevWorkdir;
+
+beforeEach(() => {
+  spawnCalls.length = 0;
+  currentChild = null;
+  prevBin = process.env.AGNT_CURSOR_BIN;
+  prevWorkdir = process.env.AGNT_CURSOR_WORKDIR;
+  process.env.AGNT_CURSOR_BIN = '/usr/local/bin/cursor-agent';
+  process.env.AGNT_CURSOR_WORKDIR = path.join(os.tmpdir(), 'agnt-cursor-test');
+});
+
+afterEach(() => {
+  if (prevBin === undefined) delete process.env.AGNT_CURSOR_BIN; else process.env.AGNT_CURSOR_BIN = prevBin;
+  if (prevWorkdir === undefined) delete process.env.AGNT_CURSOR_WORKDIR; else process.env.AGNT_CURSOR_WORKDIR = prevWorkdir;
+});
+
+describe('CursorCliService delta discriminator', () => {
+  it('forwards genuine deltas (timestamp, no model_call_id)', async () => {
+    const deltas = [];
+    await runWith([say('Hello ', { timestamp_ms: 1 }), say('world', { timestamp_ms: 2 }), RESULT], {
+      onDelta: (t) => deltas.push(t),
+    });
+    expect(deltas.join('')).toBe('Hello world');
+  });
+
+  it('drops the pre-tool-call flush instead of emitting the text twice', async () => {
+    // REGRESSION: this flush carries a timestamp, so the old `timestamp_ms == null`
+    // test let it through and the user saw the sentence rendered twice.
+    const deltas = [];
+    await runWith([
+      say('Reading the file', { timestamp_ms: 1 }),
+      say('Reading the file', { timestamp_ms: 2, model_call_id: 'call_1' }),
+      RESULT,
+    ], { onDelta: (t) => deltas.push(t) });
+    expect(deltas.join('')).toBe('Reading the file');
+  });
+
+  it('still drops the end-of-turn flush (no timestamp)', async () => {
+    const deltas = [];
+    await runWith([say('hi', { timestamp_ms: 1 }), say('hi'), RESULT], {
+      onDelta: (t) => deltas.push(t),
+    });
+    expect(deltas.join('')).toBe('hi');
+  });
+});
+
+describe('CursorCliService tool + system events', () => {
+  it('normalizes a write tool call and reports its stats', async () => {
+    const events = [];
+    await runWith([
+      {
+        type: 'tool_call',
+        subtype: 'completed',
+        call_id: 'c1',
+        tool_call: {
+          writeToolCall: {
+            args: { path: 'src/app.js', fileText: 'x'.repeat(5000) },
+            result: { success: { linesCreated: 12, fileSize: 5000 } },
+          },
+        },
+      },
+      RESULT,
+    ], { onToolCall: (e) => events.push(e) });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      id: 'c1', name: 'write', status: 'completed', path: 'src/app.js',
+      stats: { linesCreated: 12, fileSize: 5000 },
+    });
+    // The 5000-char body must never ride along in the event.
+    expect(JSON.stringify(events[0]).length).toBeLessThan(400);
+  });
+
+  it('caps a long shell command and surfaces tool errors', async () => {
+    const events = [];
+    await runWith([
+      {
+        type: 'tool_call',
+        subtype: 'completed',
+        tool_call: {
+          shellToolCall: { args: { command: 'echo '.repeat(400) }, result: { error: 'exit 1' } },
+        },
+      },
+      RESULT,
+    ], { onToolCall: (e) => events.push(e) });
+
+    expect(events[0].name).toBe('shell');
+    expect(events[0].error).toBe('exit 1');
+    expect(events[0].command.length).toBeLessThan(300);
+    expect(events[0].command).toMatch(/more chars/);
+  });
+
+  it('reports the init event without leaking a credential', async () => {
+    const inits = [];
+    await runWith([
+      {
+        type: 'system',
+        subtype: 'init',
+        session_id: 'sess-9',
+        cwd: '/repo',
+        model: 'composer-2.5',
+        permissionMode: 'default',
+        apiKeySource: 'login',
+      },
+      RESULT,
+    ], { onInit: (e) => inits.push(e) });
+
+    expect(inits[0]).toEqual({
+      sessionId: 'sess-9', cwd: '/repo', model: 'composer-2.5',
+      permissionMode: 'default', apiKeySource: 'login',
+    });
+  });
+
+  it('ignores an unrecognised tool payload rather than guessing', async () => {
+    const events = [];
+    await runWith([{ type: 'tool_call', subtype: 'started', tool_call: {} }, RESULT], {
+      onToolCall: (e) => events.push(e),
+    });
+    expect(events).toHaveLength(0);
+  });
+});
+
+describe('CursorCliService execution policy', () => {
+  it('sends --force by default, and streams when a handler is supplied', async () => {
+    await runWith([RESULT], { onDelta: () => {} });
+    const { args } = spawnCalls[0];
+    expect(args).toContain('--force');
+    expect(args).toContain('--stream-partial-output');
+    expect(args[args.indexOf('--output-format') + 1]).toBe('stream-json');
+  });
+
+  it('omits --force in a read-only mode and passes --mode through', async () => {
+    await runWith([RESULT], { mode: 'plan' });
+    const { args } = spawnCalls[0];
+    expect(args).not.toContain('--force');
+    expect(args[args.indexOf('--mode') + 1]).toBe('plan');
+  });
+
+  it('honors force:false', async () => {
+    await runWith([RESULT], { force: false });
+    expect(spawnCalls[0].args).not.toContain('--force');
+  });
+
+  it('maps sandbox:true to enabled', async () => {
+    await runWith([RESULT], { sandbox: true });
+    const { args } = spawnCalls[0];
+    expect(args[args.indexOf('--sandbox') + 1]).toBe('enabled');
+  });
+
+  it('rejects an unsupported mode before spawning', async () => {
+    await expect(CursorCliService.runExecRaw({ prompt: 'x', mode: 'yolo' }))
+      .rejects.toThrow(/unsupported mode/i);
+    expect(spawnCalls).toHaveLength(0);
+  });
+});

--- a/backend/src/services/ai/CursorCliService.events.test.js
+++ b/backend/src/services/ai/CursorCliService.events.test.js
@@ -180,6 +180,27 @@ describe('CursorCliService tool + system events', () => {
     });
     expect(events).toHaveLength(0);
   });
+
+  it('does not mistake a non-tool sibling key for the tool itself', async () => {
+    // A metadata sibling must not be reported as a tool named 'metadata'.
+    const events = [];
+    await runWith([
+      {
+        type: 'tool_call',
+        subtype: 'started',
+        tool_call: {
+          metadata: { requestId: 'r1' },
+          readToolCall: { args: { path: 'a.js' } },
+        },
+      },
+      // Only metadata: nothing identifiable, so nothing is reported.
+      { type: 'tool_call', subtype: 'started', tool_call: { metadata: { requestId: 'r2' } } },
+      RESULT,
+    ], { onToolCall: (e) => events.push(e) });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ name: 'read', path: 'a.js' });
+  });
 });
 
 describe('CursorCliService execution policy', () => {
@@ -207,6 +228,13 @@ describe('CursorCliService execution policy', () => {
     await runWith([RESULT], { sandbox: true });
     const { args } = spawnCalls[0];
     expect(args[args.indexOf('--sandbox') + 1]).toBe('enabled');
+  });
+
+  it('watching tools alone needs the event stream, not text deltas', async () => {
+    await runWith([RESULT], { onToolCall: () => {} });
+    const { args } = spawnCalls[0];
+    expect(args[args.indexOf('--output-format') + 1]).toBe('stream-json');
+    expect(args).not.toContain('--stream-partial-output');
   });
 
   it('rejects an unsupported mode before spawning', async () => {

--- a/backend/src/services/ai/CursorCliService.js
+++ b/backend/src/services/ai/CursorCliService.js
@@ -182,15 +182,30 @@ async function runExec({
   sessionId = null,
   timeoutMs = DEFAULT_TIMEOUT_MS,
   extraArgs = [],
-  // Streaming handlers. Supplying either switches the CLI to stream-json and
-  // emits token deltas as they arrive instead of one blob at the end.
+  // Execution policy. `force` auto-approves every tool the agent decides to
+  // run (shell, write, network) — it is the CLI's YOLO switch, so callers get
+  // to decide rather than having it welded on at the spawn site. `mode`
+  // selects a read-only posture: 'plan' proposes an approach without editing,
+  // 'ask' answers questions. Auto-approval is meaningless under both.
+  mode = null,
+  sandbox = null,
+  // Streaming handlers. Supplying any of these switches the CLI to stream-json
+  // and emits events as they arrive instead of one blob at the end.
   onDelta = null,
   onReasoning = null,
+  onToolCall = null,
+  onInit = null,
 } = {}) {
   if (!prompt || !String(prompt).trim()) {
     throw new Error('cursor_exec: prompt is required');
   }
-  const streaming = typeof onDelta === 'function' || typeof onReasoning === 'function';
+  if (mode != null && !READ_ONLY_MODES.has(mode)) {
+    throw new Error(`cursor_exec: unsupported mode '${mode}' (expected 'plan' or 'ask')`);
+  }
+  const streaming = typeof onDelta === 'function'
+    || typeof onReasoning === 'function'
+    || typeof onToolCall === 'function'
+    || typeof onInit === 'function';
   const invocation = resolveCursorInvocation();
   const workdir = cwd ? expandUserPath(cwd) : getDefaultWorkdir();
   try { fs.mkdirSync(workdir, { recursive: true }); } catch { /* ignore */ }
@@ -200,7 +215,11 @@ async function runExec({
   // so the non-streaming path keeps its proven behaviour.
   const args = ['-p', '--output-format', streaming ? 'stream-json' : 'json'];
   if (streaming) args.push('--stream-partial-output');
-  if (force) args.push('--force');
+  // A read-only mode cannot edit anything, so auto-approval would be both
+  // pointless and misleading to anyone reading the process list.
+  if (force && !mode) args.push('--force');
+  if (mode) args.push('--mode', mode);
+  if (sandbox) args.push('--sandbox', sandbox === true ? 'enabled' : sandbox);
   if (model) args.push('--model', model);
   if (resume && sessionId) args.push('--resume', sessionId);
   else if (resume) args.push('--continue');
@@ -255,11 +274,17 @@ async function runExec({
       if (!obj || typeof obj !== 'object') return;
       switch (obj.type) {
         case 'assistant': {
-          // With --stream-partial-output the CLI emits BOTH incremental deltas
-          // (which carry timestamp_ms) and a final consolidated assistant
-          // message (which does not). Counting both doubles the text, so the
-          // presence of timestamp_ms is the delta discriminator.
-          if (!streaming || obj.timestamp_ms == null) return;
+          // With --stream-partial-output the CLI emits real deltas AND
+          // consolidated re-sends of text it has already delivered. There are
+          // TWO kinds of re-send and both have to be dropped or text doubles:
+          //   end-of-turn flush   -> timestamp_ms absent
+          //   pre-tool-call flush -> timestamp_ms present, model_call_id present
+          // Only an event carrying a timestamp and no model_call_id is new.
+          // The model_call_id half of this test was missing, so every sentence
+          // emitted just before a tool call reached the user twice. It went
+          // unnoticed because it only shows up on runs that call tools, and no
+          // existing streaming test drives one.
+          if (!streaming || obj.timestamp_ms == null || obj.model_call_id != null) return;
           const parts = Array.isArray(obj.message?.content) ? obj.message.content : [];
           const text = parts.map((p) => (typeof p?.text === 'string' ? p.text : '')).join('');
           if (text && onDelta) onDelta(text);
@@ -268,6 +293,30 @@ async function runExec({
         case 'thinking': {
           if (!streaming || obj.subtype !== 'delta') return;
           if (typeof obj.text === 'string' && obj.text && onReasoning) onReasoning(obj.text);
+          return;
+        }
+        case 'tool_call': {
+          // Previously swallowed by `default:`. That meant while Cursor read,
+          // wrote and ran shell commands against the user's checkout, AGNT
+          // observed precisely nothing until the final blob landed.
+          if (!onToolCall) return;
+          const summary = summarizeToolCall(obj);
+          if (summary) onToolCall(summary);
+          return;
+        }
+        case 'system': {
+          // Emitted once at startup. Carries what is needed to attribute the
+          // run: which session, which checkout, which model actually served it
+          // (Cursor may substitute), and the permission posture in effect.
+          if (obj.subtype !== 'init' || !onInit) return;
+          onInit({
+            sessionId: obj.session_id || null,
+            cwd: obj.cwd || null,
+            model: obj.model || null,
+            permissionMode: obj.permissionMode || obj.permission_mode || null,
+            // A source label ('login' | 'env' | 'flag'), never the secret.
+            apiKeySource: obj.apiKeySource || obj.api_key_source || null,
+          });
           return;
         }
         case 'result': {
@@ -343,6 +392,61 @@ async function runExec({
 
     child.on('error', (err) => finish(new Error(`cursor_exec spawn failed: ${err.message}`), true));
   });
+}
+
+const READ_ONLY_MODES = new Set(['plan', 'ask']);
+
+// Longest string carried out of a tool event. A write call's args hold the
+// entire new file body and a read result holds the entire file that was read;
+// forwarding those verbatim would push megabytes through the event stream and
+// into the logs. Consumers that need full content should read the file.
+const TOOL_TEXT_MAX = 240;
+
+function briefText(value) {
+  if (typeof value !== 'string') return undefined;
+  if (value.length <= TOOL_TEXT_MAX) return value;
+  return `${value.slice(0, TOOL_TEXT_MAX)}… (+${value.length - TOOL_TEXT_MAX} more chars)`;
+}
+
+/**
+ * Cursor nests each tool event under a single key naming the tool, e.g.
+ * { readToolCall: {…} }, { writeToolCall: {…} }, { shellToolCall: {…} }.
+ * Flatten that to a stable { id, name, status, path, command, stats } shape so
+ * consumers need not know Cursor's wire format, and keep it small. Returns
+ * null for anything unrecognised rather than guessing at a shape.
+ */
+function summarizeToolCall(obj) {
+  const payload = obj?.tool_call;
+  if (!payload || typeof payload !== 'object') return null;
+  const key = Object.keys(payload).find((k) => payload[k] && typeof payload[k] === 'object');
+  if (!key) return null;
+  const inner = payload[key];
+  const args = inner.args && typeof inner.args === 'object' ? inner.args : {};
+  const summary = {
+    id: obj.call_id || obj.id || null,
+    name: key.replace(/ToolCall$/, ''),
+    status: obj.subtype === 'completed' ? 'completed' : 'started',
+  };
+  if (typeof args.path === 'string') summary.path = args.path;
+  const command = briefText(args.command);
+  if (command !== undefined) summary.command = command;
+  // `result` appears only on the completed event, as a one-of:
+  // { success: {…} } | { error: … }.
+  const result = inner.result && typeof inner.result === 'object' ? inner.result : null;
+  if (result) {
+    if (result.error != null) {
+      summary.error = briefText(
+        typeof result.error === 'string' ? result.error : JSON.stringify(result.error),
+      );
+    } else if (result.success && typeof result.success === 'object') {
+      const stats = {};
+      for (const f of ['linesCreated', 'linesRemoved', 'fileSize', 'totalLines', 'exitCode']) {
+        if (typeof result.success[f] === 'number') stats[f] = result.success[f];
+      }
+      if (Object.keys(stats).length) summary.stats = stats;
+    }
+  }
+  return summary;
 }
 
 function buildResult(obj, rawStdout, model) {

--- a/backend/src/services/ai/CursorCliService.js
+++ b/backend/src/services/ai/CursorCliService.js
@@ -214,7 +214,9 @@ async function runExec({
   // terminal object. Only opt into streaming when a handler wants the deltas,
   // so the non-streaming path keeps its proven behaviour.
   const args = ['-p', '--output-format', streaming ? 'stream-json' : 'json'];
-  if (streaming) args.push('--stream-partial-output');
+  // Partial output only concerns text. Asking for it when the caller wants
+  // tool events alone would multiply the event volume for nobody's benefit.
+  if (onDelta || onReasoning) args.push('--stream-partial-output');
   // A read-only mode cannot edit anything, so auto-approval would be both
   // pointless and misleading to anyone reading the process list.
   if (force && !mode) args.push('--force');
@@ -414,11 +416,18 @@ function briefText(value) {
  * Flatten that to a stable { id, name, status, path, command, stats } shape so
  * consumers need not know Cursor's wire format, and keep it small. Returns
  * null for anything unrecognised rather than guessing at a shape.
+ *
+ * The key must actually look like a tool entry. Matching any object-valued key
+ * would let a future sibling of metadata be reported as though it were a tool,
+ * inventing a name from whatever that key happened to be called. Dropping an
+ * event we cannot identify is the better failure: a missing entry in a
+ * progress feed is recoverable, a fabricated one is not.
  */
 function summarizeToolCall(obj) {
   const payload = obj?.tool_call;
   if (!payload || typeof payload !== 'object') return null;
-  const key = Object.keys(payload).find((k) => payload[k] && typeof payload[k] === 'object');
+  const key = Object.keys(payload)
+    .find((k) => k.endsWith('ToolCall') && payload[k] && typeof payload[k] === 'object');
   if (!key) return null;
   const inner = payload[key];
   const args = inner.args && typeof inner.args === 'object' ? inner.args : {};


### PR DESCRIPTION
## What

Three additive changes to the Cursor CLI provider, plus a streaming bug fix found while making them.

1. **Tool and init events are surfaced instead of discarded.** `handleObject()` handled `assistant`/`thinking`/`result` and let everything else fall through `default:`. Adds `onToolCall` / `onInit` handlers.
2. **Execution policy is a caller decision.** `--force` was unconditionally appended at the spawn site; it is now configurable, along with `--sandbox`.
3. **Read-only modes.** Exposes `--mode plan|ask`.

Every default reproduces today's behaviour exactly, so nothing changes for existing callers unless they opt in.

## Why

The provider drove `cursor-agent` as if it were a plain text model, which cost us two things:

**Visibility.** Cursor emits structured `tool_call` events as it reads, writes and runs shell commands against the user's checkout. We dropped all of them, so AGNT observed nothing until the final result blob landed — no progress, no file-change audit trail.

**Control.** `--force` auto-approves *every* tool the agent decides to run: shell, write, network. It was hardcoded `true`, so every AGNT-routed Cursor call was unrestricted, with no way to narrow it short of editing the source. `--mode plan|ask` gives a propose-before-execute posture for flows that want to review before anything is written.

## How

**Tool events.** `tool_call` payloads are nested under a key naming the tool (`writeToolCall`, `readToolCall`, `shellToolCall`, …). Rather than leak that shape to consumers, `summarizeToolCall()` flattens it to a stable `{ id, name, status, path, command, stats }` and returns `null` for anything unrecognised rather than guessing.

Long values are capped at 240 chars: a write call's `args` carry the entire new file body and a read result carries the entire file read, neither of which belongs in an event stream that gets logged and forwarded to a UI. Consumers needing full content should read the file.

`system`/`init` reports session, cwd, the model that actually served the request (Cursor may substitute), and the permission posture. It includes `apiKeySource`, which is a source *label* (`login` | `env` | `flag`) and never the credential itself.

**Policy.** `force`, `mode` and `sandbox` are threaded through `CursorCliClient` with env-var defaults (`CURSOR_CLI_FORCE=0`, `CURSOR_CLI_MODE`, `CURSOR_CLI_SANDBOX`) so the posture can be changed without a code change. `--force` is suppressed under `plan`/`ask`, where auto-approval is both meaningless and misleading to anyone reading the process list. An invalid mode throws before spawning.

**Scope note:** `onToolCall` defaults to `null` and currently has no consumer. The OpenAI delta shape this client implements has no slot for "the agent wrote a file", and forcing it through `reasoning_content` would misrepresent it. This PR lands the capability and its tests; choosing a UI channel is a separate change.

### Bug fix: duplicated text before every tool call

Found while mapping the event shapes. Cursor re-sends text it has already delivered in two situations, and only one was being discarded:

| `timestamp_ms` | `model_call_id` | meaning | old behaviour |
| --- | --- | --- | --- |
| present | absent | genuine delta | used ✓ |
| present | **present** | pre-tool-call flush | **counted again ✗** |
| absent | absent | end-of-turn flush | dropped ✓ |

```diff
-if (!streaming || obj.timestamp_ms == null) return;
+if (!streaming || obj.timestamp_ms == null || obj.model_call_id != null) return;
```

Every sentence emitted immediately before a tool call therefore reached the user twice. It survived because it only manifests on runs that call tools, and no existing streaming test drives one.

## Testing

Adds `CursorCliService.events.test.js` (12 tests). The existing `CursorCliService.test.js` deliberately never spawns, which left all NDJSON parsing uncovered; these mock `spawn` and push real Cursor wire objects through the parser — the only way to pin the delta discriminator and the event shapes.

Covered: all three delta cases, write-call normalisation and stats, long-command capping, tool errors, init without credential leakage, unrecognised payloads, and the policy flags actually handed to the CLI.

The duplicate-delta test was verified to *fail* against the old discriminator (`expected 'Reading the fileReading the file' to be 'Reading the file'`) before the fix was restored, so it is a real regression test rather than one written to pass.

**40/40 pass** across the five Cursor suites, run from the repo root.
