### PR TITLE
Sync theme and panel geometry across browsers, scoped by what they mean

### DIFF
--- a/backend/src/models/UserModel.js
+++ b/backend/src/models/UserModel.js
@@ -1,5 +1,46 @@
 import db from './database/index.js';
 import { parseFallbackChain, serializeFallbackChain } from '../services/orchestrator/fallbackChain.js';
+import {
+  parsePreferences,
+  mergePreferences,
+  serializePreferences,
+} from '../utils/userPreferences.js';
+
+/**
+ * Serializes preference read-modify-write per user.
+ *
+ * THE BUG THIS PREVENTS
+ * ─────────────────────
+ * Preferences are ONE JSON column, so an update is read → merge → write. Two
+ * requests interleaving between the read and the write both start from the
+ * same snapshot and the second write erases the first. That is not
+ * theoretical here: the frontend saves theme and panel geometry from separate
+ * watchers, so a single user action (switch theme while a panel animates)
+ * fires two PUTs milliseconds apart. The loser vanishes with no error on
+ * either side — the exact failure mode this whole feature exists to fix.
+ *
+ * A promise chain per user is sufficient because the backend is a single
+ * process sharing one sqlite connection. It would NOT be sufficient across
+ * processes; if AGNT ever forks workers, this has to become a real
+ * `BEGIN IMMEDIATE` transaction. Documented rather than pre-solved, because a
+ * transaction on node-sqlite3's shared connection serializes every other
+ * writer too, and that is a real cost to pay for a hypothetical.
+ */
+const preferenceWriteQueues = new Map();
+
+function withPreferenceLock(userId, task) {
+  const prev = preferenceWriteQueues.get(userId) || Promise.resolve();
+  // Swallow the predecessor's rejection: one failed write must not poison
+  // every subsequent write for that user.
+  const next = prev.catch(() => {}).then(task);
+  preferenceWriteQueues.set(userId, next);
+  // Drop the entry once drained so a long-lived process does not accumulate
+  // one resolved promise per user forever.
+  next.catch(() => {}).finally(() => {
+    if (preferenceWriteQueues.get(userId) === next) preferenceWriteQueues.delete(userId);
+  });
+  return next;
+}
 
 /**
  * What each subscription seat costs per month (PRD-122), as
@@ -239,6 +280,60 @@ class UserModel {
           }
         }
       );
+    });
+  }
+
+  /**
+   * Read a user's stored UI preferences.
+   *
+   * Returns the parsed structure (never null). A user row that does not exist
+   * and a user with nothing stored are the same answer — empty preferences —
+   * because a preferences GET has no business 404ing a browser that is simply
+   * booting for the first time.
+   */
+  static getPreferences(userId) {
+    return new Promise((resolve, reject) => {
+      db.get(`SELECT preferences FROM users WHERE id = ?`, [userId], (err, row) => {
+        if (err) reject(err);
+        else resolve(parsePreferences(row ? row.preferences : null));
+      });
+    });
+  }
+
+  /**
+   * Merge a patch into a user's stored preferences.
+   *
+   * @returns { preferences, result } — `result` reports which keys were
+   *   applied, deleted or rejected, so the caller can hand that back to the
+   *   client instead of a bare 200 that hides a dropped key.
+   */
+  static updatePreferences(userId, patch) {
+    return withPreferenceLock(userId, async () => {
+      const stored = await UserModel.getPreferences(userId);
+      const { next, result } = mergePreferences(stored, patch);
+      const serialized = serializePreferences(next);
+
+      const changes = await new Promise((resolve, reject) => {
+        db.run(
+          `UPDATE users SET preferences = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+          [serialized, userId],
+          function (err) {
+            if (err) reject(err);
+            else resolve(this.changes);
+          },
+        );
+      });
+
+      // No row updated means no such user. Surfaced explicitly rather than
+      // reported as a silent success — a write that stored nothing must not
+      // look identical to one that stored everything.
+      if (changes === 0) {
+        const err = new Error('User not found');
+        err.code = 'USER_NOT_FOUND';
+        throw err;
+      }
+
+      return { preferences: next, result };
     });
   }
 }

--- a/backend/src/models/database/index.js
+++ b/backend/src/models/database/index.js
@@ -199,7 +199,8 @@ function createTables() {
         max_tool_rounds INTEGER DEFAULT 100,
         fallback_providers TEXT,
         fallback_enabled INTEGER DEFAULT 0,
-        subscription_costs TEXT
+        subscription_costs TEXT,
+        preferences TEXT
       )`);
 
       db.run(`CREATE TABLE IF NOT EXISTS transactions (
@@ -1923,6 +1924,25 @@ function runMigrations() {
           console.error('Error adding max_tool_rounds column to users:', err);
         } else if (!err) {
           console.log('✓ Added max_tool_rounds column to users table');
+        }
+      });
+
+      // Migration: Add preferences column to users — cross-device UI
+      // preferences (theme, font, panel geometry) as a single JSON blob
+      // (2026-08-06). A blob rather than a column per setting because these
+      // are presentation keys with no query, index or constraint against
+      // them: a column each would mean a schema migration every time someone
+      // adds a toggle, for no gain the blob does not already provide.
+      //
+      // Structure and validation live in src/utils/userPreferences.js. NULL
+      // (every existing row) is the documented empty state and reads back as
+      // "no stored preferences", so upgrading installs keep whatever their
+      // browsers already have in localStorage.
+      db.run(`ALTER TABLE users ADD COLUMN preferences TEXT`, (err) => {
+        if (err && !err.message.includes('duplicate column name')) {
+          console.error('Error adding preferences column to users:', err);
+        } else if (!err) {
+          console.log('✓ Added preferences column to users table');
         }
       });
 

--- a/backend/src/routes/UserRoutes.js
+++ b/backend/src/routes/UserRoutes.js
@@ -25,6 +25,12 @@ UserRoutes.get('/user-stats', authenticateToken, UserService.getUserStats);
 // User settings routes
 UserRoutes.get('/settings', authenticateToken, UserService.getUserSettings);
 UserRoutes.put('/settings', authenticateToken, UserService.updateUserSettings);
+
+// Cross-device UI preferences (theme, font, panel geometry). Separate from
+// /settings because the write semantics differ: partial merge, last-write-wins
+// on global keys, and a per-device scope for anything measured in pixels.
+UserRoutes.get('/preferences', authenticateToken, UserService.getPreferences);
+UserRoutes.put('/preferences', authenticateToken, UserService.updatePreferences);
 UserRoutes.get('/security-policy', authenticateToken, UserService.getSecurityPolicy);
 UserRoutes.put('/security-policy', authenticateToken, UserService.updateSecurityPolicy);
 UserRoutes.delete('/security-policy', authenticateToken, UserService.resetSecurityPolicy);

--- a/backend/src/services/UserService.js
+++ b/backend/src/services/UserService.js
@@ -3,6 +3,7 @@ import { getUserTokenFromSession } from '../routes/Middleware.js';
 import AuthManager from '../services/auth/AuthManager.js';
 import { getCliProviderIds, getAuthEntry } from './auth/AuthDispatcher.js';
 import SecurityPolicyService from './security/SecurityPolicyService.js';
+import { isValidDeviceId, projectForDevice } from '../utils/userPreferences.js';
 
 async function _getLocalCliHealthProviders() {
   const ids = getCliProviderIds();
@@ -196,6 +197,102 @@ class UserService {
       res.status(500).json({ error: 'Error updating user settings' });
     }
   }
+
+  /**
+   * GET /api/users/preferences
+   *
+   * Cross-device UI preferences. Separate from /settings because these are
+   * presentation state with different semantics: partial-merge writes,
+   * last-write-wins conflict resolution, and a per-device scope. Folding them
+   * into /settings would have forced that behaviour onto provider/model too,
+   * where a full replace is correct.
+   *
+   * `deviceId` is a query param so the caller gets ITS OWN geometry already
+   * resolved and never has to understand the storage layout.
+   */
+  async getPreferences(req, res) {
+    try {
+      const userId = req.user?.id || req.user?.userId;
+      if (!userId) return res.status(401).json({ error: 'Not authenticated' });
+
+      const deviceId = typeof req.query.deviceId === 'string' ? req.query.deviceId : null;
+      if (deviceId !== null && !isValidDeviceId(deviceId)) {
+        return res.status(400).json({ error: 'deviceId must be 1-64 chars of [A-Za-z0-9_-]' });
+      }
+
+      const prefs = await UserModel.getPreferences(userId);
+      res.json({ success: true, preferences: projectForDevice(prefs, deviceId) });
+    } catch (error) {
+      console.error('Error fetching user preferences:', error);
+      res.status(500).json({ error: 'Error fetching user preferences' });
+    }
+  }
+
+  /**
+   * PUT /api/users/preferences
+   *
+   * Body: { global?, device?, deviceId?, deviceLabel?, updatedAt? }
+   *
+   * A MERGE, not a replace: send only what changed. An explicit null deletes a
+   * key. `updatedAt` must be when the USER acted, not when the request was
+   * built — otherwise a tab left open for a week can replay a stale theme over
+   * a fresh one just by being chatty.
+   *
+   * Always reports `applied` / `rejected` back. A silently-dropped key is the
+   * worst outcome for a client author, because it looks exactly like success.
+   */
+  async updatePreferences(req, res) {
+    try {
+      const userId = req.user?.id || req.user?.userId;
+      if (!userId) return res.status(401).json({ error: 'Not authenticated' });
+
+      const body = req.body;
+      if (!body || typeof body !== 'object' || Array.isArray(body)) {
+        return res.status(400).json({ error: 'Request body must be an object' });
+      }
+
+      const hasGlobal = body.global !== undefined;
+      const hasDevice = body.device !== undefined;
+      if (!hasGlobal && !hasDevice) {
+        return res.status(400).json({ error: 'At least one of "global" or "device" is required' });
+      }
+      if (hasGlobal && (body.global === null || typeof body.global !== 'object' || Array.isArray(body.global))) {
+        return res.status(400).json({ error: '"global" must be an object of preference keys' });
+      }
+      if (hasDevice) {
+        if (body.device === null || typeof body.device !== 'object' || Array.isArray(body.device)) {
+          return res.status(400).json({ error: '"device" must be an object of preference keys' });
+        }
+        // Rejected up front rather than inside the merge, so a client that
+        // forgot deviceId gets a 400 it can act on instead of a 200 whose
+        // rejected[] it may never read.
+        if (!isValidDeviceId(body.deviceId)) {
+          return res.status(400).json({ error: '"deviceId" is required with "device" and must be 1-64 chars of [A-Za-z0-9_-]' });
+        }
+      }
+      if (body.updatedAt !== undefined && !Number.isFinite(body.updatedAt)) {
+        return res.status(400).json({ error: '"updatedAt" must be a number (epoch ms)' });
+      }
+
+      const { preferences, result } = await UserModel.updatePreferences(userId, body);
+
+      res.json({
+        success: true,
+        preferences: projectForDevice(preferences, body.deviceId || null),
+        result,
+      });
+    } catch (error) {
+      if (error.code === 'USER_NOT_FOUND') {
+        return res.status(404).json({ error: 'User not found' });
+      }
+      if (error.code === 'PREFS_TOO_LARGE') {
+        return res.status(413).json({ error: 'Preferences payload too large' });
+      }
+      console.error('Error updating user preferences:', error);
+      res.status(500).json({ error: 'Error updating user preferences' });
+    }
+  }
+
   async syncToken(req, res) {
     // Sync token from frontend to backend session
     try {

--- a/backend/src/utils/userPreferences.js
+++ b/backend/src/utils/userPreferences.js
@@ -1,0 +1,372 @@
+/**
+ * User preferences — schema, validation and merge semantics for
+ * GET/PUT /api/users/preferences.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS EXISTS
+ * ---------------------------------------------------------------------------
+ * Before this, exactly two things followed a user across browsers: workspace
+ * tabs (/api/workspaces) and custom-page widget layouts (/api/layouts).
+ * Everything else the user tunes — theme, font, UI scale, panel widths —
+ * lived only in that browser's localStorage. Set a theme on the desktop, open
+ * the laptop, get the default. Nothing was broken; there was simply no store.
+ *
+ * ---------------------------------------------------------------------------
+ * THE THING THAT MAKES THIS NON-TRIVIAL: NOT ALL PREFERENCES ARE GLOBAL
+ * ---------------------------------------------------------------------------
+ * It is tempting to sync every key in one bag. That produces a WORSE product
+ * than not syncing at all, because pixel geometry is a function of the screen
+ * it was measured on:
+ *
+ *   leftPanelWidth = 384   on a 27" desktop  → a comfortable sidebar
+ *   leftPanelWidth = 384   on a 13" laptop   → half the usable width
+ *
+ * Sync that globally and every resize on one machine vandalises the other, in
+ * a way the user cannot attribute to anything they did. So preferences carry a
+ * SCOPE:
+ *
+ *   global  — taste. Theme, font, background treatment. The user means these
+ *             to be true everywhere, and they are resolution-independent.
+ *   device  — fit. Panel widths, collapse state, UI scale. Same human, same
+ *             intent, different answer per screen.
+ *
+ * Device scope is keyed by an opaque client-minted deviceId. Two browsers on
+ * the same machine are two devices; that is correct, because two browsers can
+ * be sized differently.
+ *
+ * ---------------------------------------------------------------------------
+ * MERGE, NOT REPLACE
+ * ---------------------------------------------------------------------------
+ * PUT merges. A client sends only the keys it changed, so a browser running an
+ * older build cannot erase a key it has never heard of, and adding a key later
+ * needs no coordination. Explicit `null` deletes a key — that is the only way
+ * to unset one, since absence means "no opinion".
+ *
+ * Conflict handling differs per scope, deliberately:
+ *   - device scope is uncontended by construction (only one device writes its
+ *     own bucket), so writes always apply.
+ *   - global scope is contended, so it is last-write-wins on `updatedAt`, the
+ *     same rule /api/workspaces already uses. `updatedAt` must be the moment
+ *     the USER acted, not the moment the request was built — otherwise a tab
+ *     that has been open for a week can replay a stale theme over a fresh one
+ *     simply by being noisy.
+ *
+ * ---------------------------------------------------------------------------
+ * ALLOWLIST, NOT PASSTHROUGH
+ * ---------------------------------------------------------------------------
+ * Every key is declared below with a type and a range. Unknown keys are
+ * dropped rather than stored. This endpoint is a preferences store, not a
+ * general-purpose per-user KV — without an allowlist it becomes one within a
+ * release or two, and then it is a place to smuggle unvalidated JSON that
+ * something downstream will eventually trust.
+ */
+
+// ---------------------------------------------------------------------------
+// Value validators. Each returns { ok: true, value } or { ok: false, reason }.
+// Coercion is deliberate but narrow: numbers arrive as numbers or numeric
+// strings (localStorage round-trips everything through strings), booleans as
+// booleans or the exact strings 'true'/'false'. Anything else is a rejection,
+// not a silent cast — `Number('') === 0` is exactly the sort of coercion that
+// writes 0 into a width and makes a panel vanish.
+// ---------------------------------------------------------------------------
+
+const bool = () => (raw) => {
+  if (typeof raw === 'boolean') return { ok: true, value: raw };
+  if (raw === 'true') return { ok: true, value: true };
+  if (raw === 'false') return { ok: true, value: false };
+  return { ok: false, reason: 'expected boolean' };
+};
+
+const int = (min, max) => (raw) => {
+  const n = typeof raw === 'number' ? raw : (typeof raw === 'string' && raw.trim() !== '' ? Number(raw) : NaN);
+  if (!Number.isFinite(n)) return { ok: false, reason: 'expected number' };
+  const rounded = Math.round(n);
+  // Clamp rather than reject. A width arriving slightly out of range is a UI
+  // rounding artefact, not an attack, and refusing it would strand the user's
+  // layout. A value that is not a number at all is still a rejection.
+  return { ok: true, value: Math.max(min, Math.min(max, rounded)) };
+};
+
+const str = (maxLen, allowed) => (raw) => {
+  if (typeof raw !== 'string') return { ok: false, reason: 'expected string' };
+  const trimmed = raw.trim();
+  if (!trimmed) return { ok: false, reason: 'expected non-empty string' };
+  if (trimmed.length > maxLen) return { ok: false, reason: `exceeds ${maxLen} chars` };
+  if (allowed && !allowed.includes(trimmed)) return { ok: false, reason: `not one of ${allowed.join('|')}` };
+  return { ok: true, value: trimmed };
+};
+
+// ---------------------------------------------------------------------------
+// The schema. Key names match the localStorage keys the frontend already uses,
+// so wiring is a rename-free mapping and a misspelling shows up as a dropped
+// key in the response rather than as a silent no-op.
+//
+// NOTE ON BACKGROUNDS: `useCustomBackground`, `bgOpacity` and `bgBlur` sync,
+// but the background MEDIA does not. theme.js keeps the image/video in
+// IndexedDB per theme and only mirrors a boolean "exists" flag into
+// localStorage. Syncing the flag without the bytes would leave a second
+// browser believing it has a background it cannot render, so the flag is
+// deliberately NOT in this allowlist — see hasCustomBackground in theme.js.
+// ---------------------------------------------------------------------------
+
+export const GLOBAL_PREFS = Object.freeze({
+  currentTheme: str(64),
+  fontFamily: str(32),
+  darkMode: bool(),
+  greyscaleMode: bool(),
+  cyberpunkMode: bool(),
+  useCustomBackground: bool(),
+  bgOpacity: int(50, 100),
+  bgBlur: int(0, 20),
+  panelPosition: str(8, ['left', 'right']),
+  assetPanelFullWidth: bool(),
+});
+
+export const DEVICE_PREFS = Object.freeze({
+  uiScale: int(75, 150),
+  leftPanelWidth: int(0, 2000),
+  rightPanelWidth: int(0, 2000),
+  actualLeftPanelWidth: int(0, 2000),
+  mainContentWidth: int(0, 10000),
+  showLeftPanel: bool(),
+  showRightPanel: bool(),
+  leftPanelCollapsed: bool(),
+  rightPanelCollapsed: bool(),
+  leftPanelUserSized: bool(),
+  rightPanelUserSized: bool(),
+  sidebarClosed: bool(),
+  headerCollapsed: bool(),
+});
+
+// A user with more devices than this is almost certainly a client minting a
+// fresh id every boot (a bug we would rather bound than discover from a
+// 4 MB row). Least-recently-updated buckets are evicted first.
+export const MAX_DEVICES = 20;
+
+// Defence in depth. The allowlist already bounds the real size to well under
+// 1 KB per device; this only catches a future key added without a length cap.
+export const MAX_SERIALIZED_BYTES = 64 * 1024;
+
+const DEVICE_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+export function isValidDeviceId(id) {
+  return typeof id === 'string' && DEVICE_ID_RE.test(id);
+}
+
+export function emptyPreferences() {
+  return { global: {}, devices: {}, updatedAt: 0 };
+}
+
+/**
+ * Parse whatever is in the DB column into a well-formed structure.
+ * Corrupt or legacy content degrades to empty rather than throwing: a user
+ * whose preferences blob got mangled should see defaults and be able to fix
+ * them by changing a setting, not a 500 on every page load.
+ */
+export function parsePreferences(rawColumn) {
+  if (!rawColumn) return emptyPreferences();
+
+  let parsed;
+  if (typeof rawColumn === 'object') {
+    parsed = rawColumn;
+  } else {
+    try {
+      parsed = JSON.parse(rawColumn);
+    } catch {
+      return emptyPreferences();
+    }
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return emptyPreferences();
+
+  const out = emptyPreferences();
+
+  // Re-validate on READ, not just on write. The column is the trust boundary:
+  // rows predate the current allowlist, and a key that was legal two releases
+  // ago should not resurface just because it is already stored.
+  if (parsed.global && typeof parsed.global === 'object' && !Array.isArray(parsed.global)) {
+    for (const [key, validate] of Object.entries(GLOBAL_PREFS)) {
+      if (!(key in parsed.global)) continue;
+      const r = validate(parsed.global[key]);
+      if (r.ok) out.global[key] = r.value;
+    }
+  }
+
+  if (parsed.devices && typeof parsed.devices === 'object' && !Array.isArray(parsed.devices)) {
+    for (const [deviceId, bucket] of Object.entries(parsed.devices)) {
+      if (!isValidDeviceId(deviceId)) continue;
+      if (!bucket || typeof bucket !== 'object' || Array.isArray(bucket)) continue;
+      const prefs = {};
+      const source = bucket.prefs && typeof bucket.prefs === 'object' ? bucket.prefs : {};
+      for (const [key, validate] of Object.entries(DEVICE_PREFS)) {
+        if (!(key in source)) continue;
+        const r = validate(source[key]);
+        if (r.ok) prefs[key] = r.value;
+      }
+      out.devices[deviceId] = {
+        prefs,
+        label: typeof bucket.label === 'string' ? bucket.label.slice(0, 64) : null,
+        updatedAt: Number.isFinite(bucket.updatedAt) ? bucket.updatedAt : 0,
+      };
+    }
+  }
+
+  out.updatedAt = Number.isFinite(parsed.updatedAt) ? parsed.updatedAt : 0;
+  return out;
+}
+
+/**
+ * Apply a patch of {key: value | null} against an allowlist.
+ * Returns the keys actually written, deleted, and rejected — the caller
+ * reports these back so a client with a typo or a stale build can SEE that its
+ * write was dropped instead of assuming success.
+ */
+function applyPatch(target, patch, allowlist) {
+  const applied = [];
+  const deleted = [];
+  const rejected = [];
+
+  for (const [key, raw] of Object.entries(patch)) {
+    const validate = allowlist[key];
+    if (!validate) {
+      rejected.push({ key, reason: 'unknown key' });
+      continue;
+    }
+    // Explicit null/undefined is a deletion: absence means "no opinion", so
+    // there has to be some way to say "forget this".
+    if (raw === null || raw === undefined) {
+      if (key in target) {
+        delete target[key];
+        deleted.push(key);
+      }
+      continue;
+    }
+    const r = validate(raw);
+    if (!r.ok) {
+      rejected.push({ key, reason: r.reason });
+      continue;
+    }
+    target[key] = r.value;
+    applied.push(key);
+  }
+
+  return { applied, deleted, rejected };
+}
+
+/**
+ * Merge an incoming PUT body into the stored preferences.
+ *
+ * @param stored   result of parsePreferences()
+ * @param incoming { global?, device?, deviceId?, deviceLabel?, updatedAt? }
+ * @param now      injectable clock (tests)
+ * @returns { next, result }
+ */
+export function mergePreferences(stored, incoming, now = Date.now()) {
+  const next = parsePreferences(stored);
+  const body = incoming && typeof incoming === 'object' ? incoming : {};
+
+  const result = {
+    global: { applied: [], deleted: [], rejected: [], staleIgnored: false },
+    device: { applied: [], deleted: [], rejected: [], deviceId: null },
+    evictedDevices: [],
+  };
+
+  const incomingAt = Number.isFinite(body.updatedAt) ? body.updatedAt : now;
+
+  // ---- global scope: last-write-wins -------------------------------------
+  if (body.global && typeof body.global === 'object' && !Array.isArray(body.global)) {
+    // Strictly older loses. Equal timestamps apply: a same-millisecond
+    // collision is far more likely to be one client sending two patches than
+    // two clients racing, and dropping the second would lose a real edit.
+    if (incomingAt < next.updatedAt) {
+      result.global.staleIgnored = true;
+    } else {
+      const r = applyPatch(next.global, body.global, GLOBAL_PREFS);
+      result.global.applied = r.applied;
+      result.global.deleted = r.deleted;
+      result.global.rejected = r.rejected;
+      if (r.applied.length || r.deleted.length) next.updatedAt = incomingAt;
+    }
+  }
+
+  // ---- device scope: always applies --------------------------------------
+  if (body.device && typeof body.device === 'object' && !Array.isArray(body.device)) {
+    if (!isValidDeviceId(body.deviceId)) {
+      result.device.rejected.push({ key: '*', reason: 'missing or malformed deviceId' });
+    } else {
+      const id = body.deviceId;
+      if (!next.devices[id]) next.devices[id] = { prefs: {}, label: null, updatedAt: 0 };
+      const bucket = next.devices[id];
+
+      const r = applyPatch(bucket.prefs, body.device, DEVICE_PREFS);
+      result.device.deviceId = id;
+      result.device.applied = r.applied;
+      result.device.deleted = r.deleted;
+      result.device.rejected = r.rejected;
+
+      if (typeof body.deviceLabel === 'string' && body.deviceLabel.trim()) {
+        bucket.label = body.deviceLabel.trim().slice(0, 64);
+      }
+      if (r.applied.length || r.deleted.length) bucket.updatedAt = incomingAt;
+
+      // Evict least-recently-updated buckets, never the one just written.
+      const ids = Object.keys(next.devices);
+      if (ids.length > MAX_DEVICES) {
+        const victims = ids
+          .filter((d) => d !== id)
+          .sort((a, b) => (next.devices[a].updatedAt || 0) - (next.devices[b].updatedAt || 0))
+          .slice(0, ids.length - MAX_DEVICES);
+        for (const v of victims) {
+          delete next.devices[v];
+          result.evictedDevices.push(v);
+        }
+      }
+    }
+  }
+
+  return { next, result };
+}
+
+/**
+ * Serialize for storage. Returns null when there is nothing to store, so an
+ * emptied preferences set clears the column instead of leaving `{}` behind.
+ */
+export function serializePreferences(prefs) {
+  const hasGlobal = prefs && prefs.global && Object.keys(prefs.global).length > 0;
+  const hasDevices = prefs && prefs.devices && Object.keys(prefs.devices).length > 0;
+  if (!hasGlobal && !hasDevices) return null;
+
+  const json = JSON.stringify({
+    global: prefs.global,
+    devices: prefs.devices,
+    updatedAt: prefs.updatedAt || 0,
+  });
+
+  if (Buffer.byteLength(json, 'utf8') > MAX_SERIALIZED_BYTES) {
+    const err = new Error('Preferences payload too large');
+    err.code = 'PREFS_TOO_LARGE';
+    throw err;
+  }
+  return json;
+}
+
+/**
+ * Shape returned to a client: global preferences plus THIS device's bucket
+ * already resolved, so the frontend does not have to know the storage layout.
+ * Other devices' buckets are returned separately for a future "copy layout
+ * from…" affordance, but the client never has to look at them.
+ */
+export function projectForDevice(prefs, deviceId) {
+  const bucket = (isValidDeviceId(deviceId) && prefs.devices[deviceId]) || null;
+  return {
+    global: { ...prefs.global },
+    device: bucket ? { ...bucket.prefs } : {},
+    deviceId: isValidDeviceId(deviceId) ? deviceId : null,
+    updatedAt: prefs.updatedAt || 0,
+    knownDevices: Object.entries(prefs.devices).map(([id, b]) => ({
+      deviceId: id,
+      label: b.label || null,
+      updatedAt: b.updatedAt || 0,
+      current: id === deviceId,
+    })),
+  };
+}

--- a/backend/src/utils/userPreferences.test.js
+++ b/backend/src/utils/userPreferences.test.js
@@ -1,0 +1,239 @@
+/**
+ * userPreferences — merge/validation semantics.
+ *
+ * These are the rules the endpoint's correctness rests on, and every one of
+ * them is a bug someone would otherwise hit in the field:
+ *   - a stale tab replaying an old theme over a new one
+ *   - a laptop's panel widths landing on a desktop
+ *   - a numeric string from localStorage being stored as a string and then
+ *     compared as a number somewhere downstream
+ *   - an unknown key silently "succeeding"
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parsePreferences,
+  mergePreferences,
+  serializePreferences,
+  projectForDevice,
+  emptyPreferences,
+  isValidDeviceId,
+  MAX_DEVICES,
+} from './userPreferences.js';
+
+const DEV_A = 'dev-aaaa1111';
+const DEV_B = 'dev-bbbb2222';
+
+describe('parsePreferences', () => {
+  it('returns an empty structure for null/garbage rather than throwing', () => {
+    expect(parsePreferences(null)).toEqual(emptyPreferences());
+    expect(parsePreferences('')).toEqual(emptyPreferences());
+    expect(parsePreferences('{not json')).toEqual(emptyPreferences());
+    expect(parsePreferences('[1,2,3]')).toEqual(emptyPreferences());
+    expect(parsePreferences('"a string"')).toEqual(emptyPreferences());
+  });
+
+  it('re-validates stored content, dropping keys no longer in the allowlist', () => {
+    const stored = JSON.stringify({
+      global: { currentTheme: 'dark', retiredKey: 'whatever', bgOpacity: 999 },
+      devices: {},
+      updatedAt: 5,
+    });
+    const parsed = parsePreferences(stored);
+    expect(parsed.global.currentTheme).toBe('dark');
+    expect(parsed.global).not.toHaveProperty('retiredKey');
+    // out-of-range clamps rather than vanishing
+    expect(parsed.global.bgOpacity).toBe(100);
+  });
+
+  it('drops device buckets with malformed ids', () => {
+    const stored = JSON.stringify({
+      global: {},
+      devices: {
+        [DEV_A]: { prefs: { uiScale: 110 }, updatedAt: 1 },
+        'bad id with spaces': { prefs: { uiScale: 120 }, updatedAt: 2 },
+      },
+      updatedAt: 0,
+    });
+    const parsed = parsePreferences(stored);
+    expect(Object.keys(parsed.devices)).toEqual([DEV_A]);
+  });
+});
+
+describe('validation and coercion', () => {
+  it('accepts numeric strings, because localStorage round-trips through strings', () => {
+    const { next } = mergePreferences(null, { deviceId: DEV_A, device: { leftPanelWidth: '384' } }, 100);
+    expect(next.devices[DEV_A].prefs.leftPanelWidth).toBe(384);
+    expect(typeof next.devices[DEV_A].prefs.leftPanelWidth).toBe('number');
+  });
+
+  it('accepts the strings "true"/"false" as booleans', () => {
+    const { next } = mergePreferences(null, { global: { darkMode: 'true', greyscaleMode: 'false' } }, 100);
+    expect(next.global.darkMode).toBe(true);
+    expect(next.global.greyscaleMode).toBe(false);
+  });
+
+  it('does NOT coerce empty string to 0 — that would collapse a panel', () => {
+    const { next, result } = mergePreferences(null, { deviceId: DEV_A, device: { leftPanelWidth: '' } }, 100);
+    expect(next.devices[DEV_A]?.prefs).not.toHaveProperty('leftPanelWidth');
+    expect(result.device.rejected[0]).toMatchObject({ key: 'leftPanelWidth' });
+  });
+
+  it('clamps out-of-range numbers instead of rejecting them', () => {
+    const { next } = mergePreferences(null, { deviceId: DEV_A, device: { uiScale: 5000 } }, 100);
+    expect(next.devices[DEV_A].prefs.uiScale).toBe(150);
+  });
+
+  it('rejects unknown keys and says so, instead of silently succeeding', () => {
+    const { next, result } = mergePreferences(null, { global: { evilKey: 'x', currentTheme: 'cyber' } }, 100);
+    expect(next.global).toEqual({ currentTheme: 'cyber' });
+    expect(result.global.rejected).toEqual([{ key: 'evilKey', reason: 'unknown key' }]);
+    expect(result.global.applied).toEqual(['currentTheme']);
+  });
+
+  it('rejects a global key sent to the device scope and vice versa', () => {
+    const { result } = mergePreferences(
+      null,
+      { global: { uiScale: 120 }, deviceId: DEV_A, device: { currentTheme: 'dark' } },
+      100,
+    );
+    expect(result.global.rejected).toEqual([{ key: 'uiScale', reason: 'unknown key' }]);
+    expect(result.device.rejected).toEqual([{ key: 'currentTheme', reason: 'unknown key' }]);
+  });
+
+  it('enforces the panelPosition enum', () => {
+    const { result } = mergePreferences(null, { global: { panelPosition: 'diagonal' } }, 100);
+    expect(result.global.rejected[0].key).toBe('panelPosition');
+  });
+});
+
+describe('merge is partial, not a replace', () => {
+  it('leaves untouched keys alone so an older client cannot erase newer ones', () => {
+    const first = mergePreferences(null, { global: { currentTheme: 'dark', fontFamily: 'mono' } }, 100).next;
+    const second = mergePreferences(first, { global: { fontFamily: 'sans' } }, 200).next;
+    expect(second.global.currentTheme).toBe('dark');
+    expect(second.global.fontFamily).toBe('sans');
+  });
+
+  it('treats explicit null as a deletion', () => {
+    const first = mergePreferences(null, { global: { currentTheme: 'dark', fontFamily: 'mono' } }, 100).next;
+    const { next, result } = mergePreferences(first, { global: { fontFamily: null } }, 200);
+    expect(next.global).toEqual({ currentTheme: 'dark' });
+    expect(result.global.deleted).toEqual(['fontFamily']);
+  });
+});
+
+describe('global scope is last-write-wins', () => {
+  it('ignores a patch older than the stored state', () => {
+    const fresh = mergePreferences(null, { global: { currentTheme: 'cyberpunk' }, updatedAt: 500 }, 500).next;
+    const { next, result } = mergePreferences(fresh, { global: { currentTheme: 'dark' }, updatedAt: 200 }, 600);
+    expect(next.global.currentTheme).toBe('cyberpunk');
+    expect(result.global.staleIgnored).toBe(true);
+    expect(result.global.applied).toEqual([]);
+  });
+
+  it('applies a newer patch', () => {
+    const old = mergePreferences(null, { global: { currentTheme: 'dark' }, updatedAt: 200 }, 200).next;
+    const { next, result } = mergePreferences(old, { global: { currentTheme: 'cyberpunk' }, updatedAt: 500 }, 500);
+    expect(next.global.currentTheme).toBe('cyberpunk');
+    expect(result.global.staleIgnored).toBe(false);
+  });
+
+  it('applies on an equal timestamp — same-ms is one client sending twice, not a race', () => {
+    const a = mergePreferences(null, { global: { currentTheme: 'dark' }, updatedAt: 300 }, 300).next;
+    const { next } = mergePreferences(a, { global: { fontFamily: 'mono' }, updatedAt: 300 }, 300);
+    expect(next.global.fontFamily).toBe('mono');
+  });
+
+  it('does not advance updatedAt when a patch changed nothing', () => {
+    const a = mergePreferences(null, { global: { currentTheme: 'dark' }, updatedAt: 300 }, 300).next;
+    const { next } = mergePreferences(a, { global: { bogus: 1 }, updatedAt: 900 }, 900);
+    expect(next.updatedAt).toBe(300);
+  });
+});
+
+describe('device scope is isolated — the reason this feature is not one flat bag', () => {
+  it('does not let one device overwrite another device geometry', () => {
+    const desktop = mergePreferences(null, { deviceId: DEV_A, device: { leftPanelWidth: 500 } }, 100).next;
+    const { next } = mergePreferences(desktop, { deviceId: DEV_B, device: { leftPanelWidth: 200 } }, 200);
+    expect(next.devices[DEV_A].prefs.leftPanelWidth).toBe(500);
+    expect(next.devices[DEV_B].prefs.leftPanelWidth).toBe(200);
+  });
+
+  it('applies device writes even when they are older than global state (uncontended)', () => {
+    const fresh = mergePreferences(null, { global: { currentTheme: 'dark' }, updatedAt: 900 }, 900).next;
+    const { next } = mergePreferences(fresh, { deviceId: DEV_A, device: { uiScale: 90 }, updatedAt: 100 }, 100);
+    expect(next.devices[DEV_A].prefs.uiScale).toBe(90);
+  });
+
+  it('rejects a device patch with no usable deviceId rather than inventing one', () => {
+    const { next, result } = mergePreferences(null, { device: { uiScale: 90 } }, 100);
+    expect(next.devices).toEqual({});
+    expect(result.device.rejected[0].reason).toMatch(/deviceId/);
+  });
+
+  it('evicts the least-recently-used bucket past the cap, never the current one', () => {
+    let state = emptyPreferences();
+    for (let i = 0; i < MAX_DEVICES; i++) {
+      state = mergePreferences(state, { deviceId: `dev-${i}`, device: { uiScale: 100 } }, 1000 + i).next;
+    }
+    expect(Object.keys(state.devices)).toHaveLength(MAX_DEVICES);
+
+    const { next, result } = mergePreferences(state, { deviceId: 'dev-new', device: { uiScale: 125 } }, 9999);
+    expect(Object.keys(next.devices)).toHaveLength(MAX_DEVICES);
+    expect(next.devices['dev-new'].prefs.uiScale).toBe(125);
+    expect(result.evictedDevices).toEqual(['dev-0']);
+  });
+});
+
+describe('serializePreferences', () => {
+  it('returns null when nothing is stored, so the column clears', () => {
+    expect(serializePreferences(emptyPreferences())).toBeNull();
+  });
+
+  it('round-trips through parse without loss', () => {
+    const { next } = mergePreferences(
+      null,
+      { global: { currentTheme: 'dark', bgBlur: 4 }, deviceId: DEV_A, device: { uiScale: 110 }, updatedAt: 42 },
+      42,
+    );
+    const round = parsePreferences(serializePreferences(next));
+    expect(round.global).toEqual({ currentTheme: 'dark', bgBlur: 4 });
+    expect(round.devices[DEV_A].prefs).toEqual({ uiScale: 110 });
+    expect(round.updatedAt).toBe(42);
+  });
+});
+
+describe('projectForDevice', () => {
+  it('resolves this device bucket and hides the storage layout', () => {
+    const { next } = mergePreferences(
+      null,
+      { global: { currentTheme: 'dark' }, deviceId: DEV_A, device: { uiScale: 110 }, deviceLabel: 'iMac' },
+      100,
+    );
+    const view = projectForDevice(next, DEV_A);
+    expect(view.global).toEqual({ currentTheme: 'dark' });
+    expect(view.device).toEqual({ uiScale: 110 });
+    expect(view.knownDevices).toEqual([
+      { deviceId: DEV_A, label: 'iMac', updatedAt: 100, current: true },
+    ]);
+  });
+
+  it('returns an empty device bucket for a device that has never written', () => {
+    const { next } = mergePreferences(null, { global: { currentTheme: 'dark' } }, 100);
+    const view = projectForDevice(next, DEV_B);
+    expect(view.device).toEqual({});
+    expect(view.global).toEqual({ currentTheme: 'dark' });
+  });
+});
+
+describe('isValidDeviceId', () => {
+  it('accepts opaque url-safe ids and rejects everything else', () => {
+    expect(isValidDeviceId('dev-abc_123')).toBe(true);
+    expect(isValidDeviceId('')).toBe(false);
+    expect(isValidDeviceId('has space')).toBe(false);
+    expect(isValidDeviceId('../../etc/passwd')).toBe(false);
+    expect(isValidDeviceId('x'.repeat(65))).toBe(false);
+    expect(isValidDeviceId(null)).toBe(false);
+  });
+});

--- a/docs/_API-DOCUMENTATION.md
+++ b/docs/_API-DOCUMENTATION.md
@@ -7042,6 +7042,78 @@ Base path: `/api/users`
 }
 ```
 
+### Get User Preferences
+
+**GET** `/preferences`
+
+- **Authentication**: Required
+- **Description**: Cross-device UI preferences (theme, font, panel geometry). Distinct from `/settings`, which holds account-level AI configuration and is replace-on-write.
+- **Query params**:
+  - `deviceId` (optional) — 1-64 chars of `[A-Za-z0-9_-]`. When supplied, that device's geometry is resolved into `preferences.device`. When omitted the response shape is unchanged: `device` is `{}` and `deviceId` is `null`, while `global` and `knownDevices` are still returned in full. `knownDevices` is deliberately not gated on `deviceId` — a caller listing a user's devices has no device of its own to name.
+- **Response**:
+
+```json
+{
+  "success": true,
+  "preferences": {
+    "global": { "currentTheme": "dark", "fontFamily": "sans", "bgOpacity": 90 },
+    "device": { "uiScale": 100, "leftPanelWidth": 384 },
+    "deviceId": "dev-abc123",
+    "updatedAt": 1786029683945,
+    "knownDevices": [
+      { "deviceId": "dev-abc123", "label": "iMac", "updatedAt": 1786029683945, "current": true }
+    ]
+  }
+}
+```
+
+### Update User Preferences
+
+**PUT** `/preferences`
+
+- **Authentication**: Required
+- **Description**: Merges a patch into the stored preferences. Send only the keys that changed; unsent keys are preserved, so an older client cannot erase a key it does not know about. An explicit `null` deletes a key.
+- **Scopes**: `global` keys (theme, font, background treatment) sync everywhere. `device` keys (panel widths, UI scale, collapse state) are stored per `deviceId`, because pixel geometry chosen on a 27-inch display is wrong on a laptop.
+- **Conflict resolution**: `global` is last-write-wins on `updatedAt`; a patch older than the stored state is ignored and reported as `result.global.staleIgnored`. `device` writes always apply, being uncontended by construction.
+- **Body**:
+
+```json
+{
+  "global": { "currentTheme": "cyberpunk", "fontFamily": null },
+  "device": { "leftPanelWidth": 420 },
+  "deviceId": "dev-abc123",
+  "deviceLabel": "iMac",
+  "updatedAt": 1786029683945
+}
+```
+
+- **Notes**:
+  - `updatedAt` (epoch ms) should be the moment the user acted, not the moment the request was built. Defaults to server time when omitted.
+  - `deviceId` is required whenever `device` is present (400 otherwise).
+  - Unknown or malformed keys are dropped, not stored, and are listed in `result.*.rejected` so a client can see the write was refused.
+  - Custom background media is **not** synced — it lives in browser IndexedDB. Only the `useCustomBackground` / `bgOpacity` / `bgBlur` treatment flags cross devices.
+- **Response**:
+
+```json
+{
+  "success": true,
+  "preferences": {
+    "global": { "currentTheme": "cyberpunk" },
+    "device": { "leftPanelWidth": 420 },
+    "deviceId": "dev-abc123",
+    "updatedAt": 1786029683945,
+    "knownDevices": []
+  },
+  "result": {
+    "global": { "applied": ["currentTheme"], "deleted": ["fontFamily"], "rejected": [], "staleIgnored": false },
+    "device": { "applied": ["leftPanelWidth"], "deleted": [], "rejected": [], "deviceId": "dev-abc123" },
+    "evictedDevices": []
+  }
+}
+```
+
+- **Errors**: `400` malformed body / missing `deviceId` / non-numeric `updatedAt`; `404` user not found; `413` payload exceeds 64 KB.
+
 ### Sync Token
 
 **POST** `/sync-token`

--- a/frontend/src/services/userPreferences.js
+++ b/frontend/src/services/userPreferences.js
@@ -1,0 +1,557 @@
+/**
+ * Cross-device UI preferences — client half of GET/PUT /api/users/preferences.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT THIS FIXES
+ * ---------------------------------------------------------------------------
+ * Theme, font, background treatment and panel geometry lived only in the
+ * localStorage of the browser that set them. Set a theme on the desktop, open
+ * the laptop, get the default. Workspace tabs (/api/workspaces) and widget
+ * layouts (/api/layouts) already followed the user; presentation did not.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY A SUBSCRIBER AND NOT 17 EDITS
+ * ---------------------------------------------------------------------------
+ * Every synced setting already flows through exactly one named Vuex mutation
+ * that writes localStorage. Rather than append a push call to each of those
+ * bodies — seventeen chances to miss one, and seventeen future settings that
+ * silently do not sync — this observes `store.subscribe` and maps mutation
+ * type to preference key in one table. Adding a synced setting later is one
+ * line in MUTATION_MAP, and theme.js never has to know this file exists.
+ *
+ * localStorage remains the source of truth for FIRST PAINT. theme.js reads it
+ * in its state initialisers at module load, which is synchronous and cannot
+ * wait for a network round trip. The server is the RECONCILER, applied after
+ * mount — the same shape useWorkspaces already uses.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TWO RACES THIS HAS TO SURVIVE
+ * ---------------------------------------------------------------------------
+ * 1. ECHO. Hydration applies remote values by committing mutations, which the
+ *    subscriber sees, which would push them straight back to the server —
+ *    an infinite round trip that also bumps updatedAt and lets a stale device
+ *    win. `applying` suppresses the subscriber for the duration.
+ *
+ * 2. IN-FLIGHT USER EDIT. Hydration takes a few hundred ms. A theme change
+ *    made in that window is NEWER than anything the server can return, so
+ *    applying the remote value would visibly undo an action the user just
+ *    took. `touchedKeys` records what the user changed since boot and
+ *    hydration skips exactly those keys — not the whole hydrate, which would
+ *    throw away every other device's settings over one keystroke.
+ */
+
+import { API_CONFIG } from '@/tt.config.js';
+
+const DEVICE_ID_KEY = 'agnt:deviceId';
+const DEVICE_LABEL_KEY = 'agnt:deviceLabel';
+
+// Long enough to coalesce a drag (which fires a mutation per animation frame)
+// into one request; short enough that a theme click feels immediate on the
+// other device. Matches the 400ms useWorkspaces already uses for its push.
+const PUSH_DEBOUNCE_MS = 400;
+
+/**
+ * mutation type → where its payload belongs.
+ *
+ * `pick` turns a mutation payload into { prefKey: value } pairs. Most are a
+ * bare value; the multi-panel mutations carry an object and write several keys
+ * at once, which is precisely why this is a function rather than a key name.
+ *
+ * SCOPES (enforced server-side too):
+ *   global — taste. Resolution-independent, meant to be true everywhere.
+ *   device — fit. Pixel geometry, which is a property of the SCREEN. Syncing
+ *            a 27-inch sidebar width onto a 13-inch laptop is a regression,
+ *            not a feature.
+ *
+ * DELIBERATELY ABSENT:
+ *   SET_DARK_MODE / SET_CYBERPUNK_MODE — legacy mutations whose state is
+ *     derived from currentTheme. Syncing them too would let a stale legacy
+ *     write contradict the theme it is derived from.
+ *   SET_HAS_CUSTOM_BACKGROUND / SET_BACKGROUND_FILE_NAME — the background
+ *     MEDIA lives in IndexedDB and is not synced, so advertising its presence
+ *     on a device that cannot render it would produce a blank background and
+ *     a settings panel that lies.
+ *   Banner-dismissed flags — per-browser by intent.
+ */
+const MUTATION_MAP = {
+  'theme/SET_THEME': { scope: 'global', pick: (v) => ({ currentTheme: v }) },
+  'theme/SET_FONT_FAMILY': { scope: 'global', pick: (v) => ({ fontFamily: v }) },
+  'theme/SET_GREYSCALE_MODE': { scope: 'global', pick: (v) => ({ greyscaleMode: v }) },
+  'theme/SET_USE_CUSTOM_BACKGROUND': { scope: 'global', pick: (v) => ({ useCustomBackground: v }) },
+  'theme/SET_BG_OPACITY': { scope: 'global', pick: (v) => ({ bgOpacity: v }) },
+  'theme/SET_BG_BLUR': { scope: 'global', pick: (v) => ({ bgBlur: v }) },
+  'theme/SET_PANEL_POSITION': { scope: 'global', pick: (v) => ({ panelPosition: v }) },
+  'theme/SET_ASSET_PANEL_FULL_WIDTH': { scope: 'global', pick: (v) => ({ assetPanelFullWidth: v }) },
+
+  'theme/SET_UI_SCALE': { scope: 'device', pick: (v) => ({ uiScale: v }) },
+  'theme/SET_ACTUAL_LEFT_PANEL_WIDTH': { scope: 'device', pick: (v) => ({ actualLeftPanelWidth: v }) },
+  'theme/SET_MAIN_CONTENT_WIDTH': { scope: 'device', pick: (v) => ({ mainContentWidth: v }) },
+  'theme/SET_SHOW_LEFT_PANEL': { scope: 'device', pick: (v) => ({ showLeftPanel: v }) },
+  'theme/SET_SHOW_RIGHT_PANEL': { scope: 'device', pick: (v) => ({ showRightPanel: v }) },
+  'theme/SET_LEFT_PANEL_COLLAPSED': { scope: 'device', pick: (v) => ({ leftPanelCollapsed: v }) },
+  'theme/SET_RIGHT_PANEL_COLLAPSED': { scope: 'device', pick: (v) => ({ rightPanelCollapsed: v }) },
+  'theme/SET_PANEL_WIDTHS': {
+    scope: 'device',
+    pick: (p) => ({ leftPanelWidth: p?.leftWidth, rightPanelWidth: p?.rightWidth }),
+  },
+  'theme/SET_THREE_PANEL_WIDTHS': {
+    scope: 'device',
+    pick: (p) => ({
+      actualLeftPanelWidth: p?.actualLeftWidth,
+      mainContentWidth: p?.mainWidth,
+      rightPanelWidth: p?.rightWidth,
+    }),
+  },
+};
+
+/** preference key → the mutation that applies it during hydration. */
+const APPLY_MAP = {
+  currentTheme: (store, v) => store.dispatch('theme/setTheme', v),
+  fontFamily: (store, v) => store.dispatch('theme/setFontFamily', v),
+  greyscaleMode: (store, v) => store.commit('theme/SET_GREYSCALE_MODE', v),
+  useCustomBackground: (store, v) => store.commit('theme/SET_USE_CUSTOM_BACKGROUND', v),
+  bgOpacity: (store, v) => store.commit('theme/SET_BG_OPACITY', v),
+  bgBlur: (store, v) => store.commit('theme/SET_BG_BLUR', v),
+  panelPosition: (store, v) => store.commit('theme/SET_PANEL_POSITION', v),
+  assetPanelFullWidth: (store, v) => store.commit('theme/SET_ASSET_PANEL_FULL_WIDTH', v),
+
+  uiScale: (store, v) => store.dispatch('theme/setUiScale', v),
+  actualLeftPanelWidth: (store, v) => store.commit('theme/SET_ACTUAL_LEFT_PANEL_WIDTH', v),
+  mainContentWidth: (store, v) => store.commit('theme/SET_MAIN_CONTENT_WIDTH', v),
+  showLeftPanel: (store, v) => store.commit('theme/SET_SHOW_LEFT_PANEL', v),
+  showRightPanel: (store, v) => store.commit('theme/SET_SHOW_RIGHT_PANEL', v),
+  leftPanelCollapsed: (store, v) => store.commit('theme/SET_LEFT_PANEL_COLLAPSED', v),
+  rightPanelCollapsed: (store, v) => store.commit('theme/SET_RIGHT_PANEL_COLLAPSED', v),
+  leftPanelWidth: (store, v, state) =>
+    store.commit('theme/SET_PANEL_WIDTHS', { leftWidth: v, rightWidth: state.rightPanelWidth }),
+  rightPanelWidth: (store, v, state) =>
+    store.commit('theme/SET_PANEL_WIDTHS', { leftWidth: state.leftPanelWidth, rightWidth: v }),
+};
+
+// ---------------------------------------------------------------------------
+// Device identity
+// ---------------------------------------------------------------------------
+
+function randomId() {
+  try {
+    if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+  } catch {
+    /* fall through to Math.random */
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * A stable, opaque id for THIS browser profile.
+ *
+ * Minted locally and never derived from hardware, IP or a fingerprint: it only
+ * has to be stable and unique, and anything cleverer would be a tracking
+ * identifier for no functional gain. Clearing site data mints a new one, which
+ * costs the user their panel widths on that browser and nothing else.
+ *
+ * Constrained to [A-Za-z0-9_-]{1,64} to match the server's validator.
+ */
+export function getDeviceId() {
+  try {
+    const existing = localStorage.getItem(DEVICE_ID_KEY);
+    if (existing && /^[A-Za-z0-9_-]{1,64}$/.test(existing)) return existing;
+    const minted = `dev-${randomId()}`.slice(0, 64);
+    localStorage.setItem(DEVICE_ID_KEY, minted);
+    return minted;
+  } catch {
+    // Private mode with storage disabled: return a per-session id so the
+    // request still validates. Geometry simply will not persist, which is the
+    // correct outcome when the browser refuses to remember anything.
+    return `dev-${randomId()}`.slice(0, 64);
+  }
+}
+
+/**
+ * A human-readable label for the device list in Settings ("MacBook", "Windows
+ * · Chrome"). Coarse by design — enough for a person to recognise their own
+ * machine, not enough to be a fingerprint.
+ */
+export function getDeviceLabel() {
+  try {
+    const stored = localStorage.getItem(DEVICE_LABEL_KEY);
+    if (stored) return stored;
+  } catch {
+    /* ignore */
+  }
+  let label = 'Browser';
+  try {
+    const ua = navigator.userAgent || '';
+    const os = /Macintosh|Mac OS X/.test(ua) ? 'Mac'
+      : /Windows/.test(ua) ? 'Windows'
+      : /Linux/.test(ua) ? 'Linux'
+      : /iPhone|iPad/.test(ua) ? 'iOS'
+      : /Android/.test(ua) ? 'Android' : 'Device';
+    const browser = /Edg\//.test(ua) ? 'Edge'
+      : /Chrome\//.test(ua) ? 'Chrome'
+      : /Safari\//.test(ua) ? 'Safari'
+      : /Firefox\//.test(ua) ? 'Firefox' : 'Browser';
+    label = `${os} · ${browser}`;
+  } catch {
+    /* keep the default */
+  }
+  try {
+    localStorage.setItem(DEVICE_LABEL_KEY, label);
+  } catch {
+    /* ignore */
+  }
+  return label;
+}
+
+// ---------------------------------------------------------------------------
+// Transport
+// ---------------------------------------------------------------------------
+
+async function apiFetch(path, opts = {}) {
+  // Same auth convention as every other service (see useWorkspaces.js): JWT
+  // from localStorage as a Bearer token. API_CONFIG.BASE_URL rather than a
+  // relative '/api/...' because there is no vite dev proxy — a relative URL
+  // resolves against the dev server and silently 404s.
+  const token = localStorage.getItem('token');
+  const res = await fetch(`${API_CONFIG.BASE_URL}/users/preferences${path}`, {
+    credentials: 'same-origin',
+    // opts BEFORE headers so a caller cannot replace the headers object wholesale.
+    ...opts,
+    headers: {
+      'Content-Type': 'application/json',
+      // Caller headers next, so Content-Type stays overridable...
+      ...(opts.headers || {}),
+      // ...but Authorization goes LAST and therefore wins. This function owns
+      // authentication for this endpoint; a caller that passes its own
+      // Authorization would otherwise silently send an unauthenticated or
+      // wrong-identity request, which surfaces as a 401 nobody can trace back
+      // to a header merge order.
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+  if (!res.ok) throw new Error(`preferences api ${res.status}`);
+  return res.status === 204 ? null : res.json();
+}
+
+/**
+ * Is there a session the BACKEND has confirmed?
+ *
+ * Deliberately not `!!localStorage.token`. A token string means someone once
+ * had a credential, not that it is still valid — gating on it is how the app
+ * came to render a full UI for an unverified session (see the sessionState
+ * tristate in store/auth/userAuth.js). Reading the getter means the answer
+ * comes from the backend, and a session the server has rejected stops
+ * producing requests immediately rather than at the next reload.
+ */
+function isSessionValid(store) {
+  try {
+    return store?.getters?.['userAuth/isAuthenticated'] === true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sync engine
+// ---------------------------------------------------------------------------
+
+let pending = { global: {}, device: {} };
+let pendingAt = 0;
+let pushTimer = null;
+let paintTimer = null;
+let applying = false;
+let touchedKeys = new Set();
+let unsubscribe = null;
+let retryDelay = 0;
+
+/**
+ * Incremented whenever sync stops (sign-out). A flush that was in flight when
+ * a session ended must not resurrect the previous user's preferences into the
+ * next one's queue, and it cannot tell that from its own closure — so it
+ * captures this counter and compares before touching shared state.
+ */
+let epoch = 0;
+
+/** First retry delay after a failed push, doubling to RETRY_MAX_MS. */
+const RETRY_BASE_MS = 2000;
+const RETRY_MAX_MS = 60000;
+
+function resetState() {
+  pending = { global: {}, device: {} };
+  pendingAt = 0;
+  retryDelay = 0;
+  if (pushTimer) clearTimeout(pushTimer);
+  pushTimer = null;
+  if (paintTimer) clearTimeout(paintTimer);
+  paintTimer = null;
+  applying = false;
+  // A NEW Set rather than .clear(): a flush closure may still hold a reference
+  // to the old one, and mutating it would let a dead session's keys reappear.
+  touchedKeys = new Set();
+  epoch += 1;
+  if (unsubscribe) unsubscribe();
+  unsubscribe = null;
+}
+
+/**
+ * Detach from the store and discard anything queued. Called from endSession.
+ *
+ * Without this a sign-out leaves the subscriber attached and a debounced push
+ * in flight: the request would then be sent with the NEXT user's token, or the
+ * previous user's `touchedKeys` would suppress the next user's hydration. That
+ * failure mode only became reachable once sign-in stopped reloading the page.
+ */
+export function stopPreferenceSync() {
+  resetState();
+  markHydrating(false);
+}
+
+/** Test seam — reset module state between specs. */
+export function _resetForTests() {
+  stopPreferenceSync();
+}
+
+async function flush() {
+  pushTimer = null;
+  const hasGlobal = Object.keys(pending.global).length > 0;
+  const hasDevice = Object.keys(pending.device).length > 0;
+  if (!hasGlobal && !hasDevice) return;
+
+  const sentGlobal = pending.global;
+  const sentDevice = pending.device;
+  const sentAt = pendingAt || Date.now();
+
+  const body = {};
+  if (hasGlobal) body.global = sentGlobal;
+  if (hasDevice) {
+    body.device = sentDevice;
+    body.deviceId = getDeviceId();
+    body.deviceLabel = getDeviceLabel();
+  }
+  // Stamped when the USER acted, not when the request was built. A tab that
+  // has been open for a week must not be able to replay a stale theme over a
+  // fresh one simply because its request went out later.
+  body.updatedAt = sentAt;
+
+  // Cleared BEFORE the await so changes made during the request queue up for
+  // the next flush instead of being sent twice. On failure they are merged
+  // back in below.
+  pending = { global: {}, device: {} };
+  pendingAt = 0;
+
+  const sentEpoch = epoch;
+
+  try {
+    await apiFetch('', { method: 'PUT', body: JSON.stringify(body) });
+    if (epoch === sentEpoch) retryDelay = 0;
+  } catch (e) {
+    console.warn('[userPreferences] push failed:', e.message);
+
+    // The session ended while this was in flight. Re-queuing here would push
+    // one user's preferences under the next user's token.
+    if (epoch !== sentEpoch) return;
+
+    // Put the unsent values BACK. Without this a transient failure drops the
+    // change permanently: the local write already happened, so the user sees
+    // their theme applied here and nowhere else, forever, with no error.
+    //
+    // Anything queued while the request was in flight is NEWER, so it wins the
+    // merge. updatedAt takes the later of the two: the batch now carries the
+    // user's most recent intent, and backdating it would let the server
+    // discard the whole thing as stale.
+    pending.global = { ...sentGlobal, ...pending.global };
+    pending.device = { ...sentDevice, ...pending.device };
+    pendingAt = Math.max(sentAt, pendingAt || 0);
+
+    // Bounded backoff. Retrying at the debounce interval would hammer a server
+    // that is down; not retrying at all would strand the change until the user
+    // happened to touch the same setting again.
+    retryDelay = retryDelay ? Math.min(retryDelay * 2, RETRY_MAX_MS) : RETRY_BASE_MS;
+    if (pushTimer) clearTimeout(pushTimer);
+    pushTimer = setTimeout(flush, retryDelay);
+  }
+}
+
+function enqueue(scope, values) {
+  let changed = false;
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined) continue;
+    pending[scope][key] = value;
+    touchedKeys.add(key);
+    changed = true;
+  }
+  if (!changed) return;
+
+  // Timestamp the FIRST change in the batch. Debouncing must not backdate the
+  // user's action to the end of the coalescing window.
+  if (!pendingAt) pendingAt = Date.now();
+
+  if (pushTimer) clearTimeout(pushTimer);
+  pushTimer = setTimeout(flush, PUSH_DEBOUNCE_MS);
+}
+
+/**
+ * Reconcile local state with the server. Runs AFTER mount, never at import:
+ * theme.js builds its state from localStorage synchronously so the first paint
+ * is instant and offline-correct.
+ *
+ * A remote value that differs from local repaints one beat after load. That is
+ * a deliberate trade — blocking first paint on a network round trip would make
+ * every boot feel slow to fix a one-frame flicker on the rare boot where two
+ * devices actually disagree. The repaint is softened by a short transition
+ * (see markHydrating).
+ */
+export async function hydrateFromServer(store) {
+  if (!isSessionValid(store)) return { skipped: 'unverified-session' };
+
+  let remote;
+  try {
+    remote = await apiFetch(`?deviceId=${encodeURIComponent(getDeviceId())}`, { method: 'GET' });
+  } catch (e) {
+    console.warn('[userPreferences] hydrate skipped:', e.message);
+    return { skipped: 'offline' };
+  }
+
+  const prefs = remote?.preferences;
+  if (!prefs) return { skipped: 'empty' };
+
+  const applied = [];
+  const skipped = [];
+
+  // Decide what will change BEFORE touching the DOM. Most boots agree with the
+  // server, and opening a transition window that repaints nothing would put a
+  // colour transition on every element for no reason.
+  const work = [];
+  for (const source of [prefs.global || {}, prefs.device || {}]) {
+    for (const [key, value] of Object.entries(source)) {
+      const apply = APPLY_MAP[key];
+      if (!apply) continue;
+      // The user changed this since boot; their action is newer than anything
+      // the server could have returned.
+      if (touchedKeys.has(key)) {
+        skipped.push(key);
+        continue;
+      }
+      work.push([key, value, apply]);
+    }
+  }
+
+  if (!work.length) return { applied, skipped };
+
+  applying = true;
+  // Opened here and closed on a TIMER, not in the finally below. The apply
+  // loop is synchronous, so removing the class at the end of it would take it
+  // off in the same frame it went on and the browser would never run the
+  // transition at all — the easing this exists for would silently never happen.
+  beginHydrationPaint();
+  try {
+    for (const [key, value, apply] of work) {
+      try {
+        apply(store, value, store.state.theme);
+        applied.push(key);
+      } catch (e) {
+        console.warn(`[userPreferences] could not apply ${key}:`, e.message);
+      }
+    }
+  } finally {
+    applying = false;
+  }
+
+  return { applied, skipped };
+}
+
+/**
+ * How long `.prefs-hydrating` stays on the document. Must outlast the CSS
+ * transition it enables (250ms, see styles/base/_animations.css) with enough
+ * margin for the repaint to start; short enough that ordinary theme switching
+ * a moment later is not still easing.
+ */
+const HYDRATION_PAINT_MS = 400;
+
+/**
+ * Open the window in which a hydration repaint eases instead of snapping.
+ *
+ * Self-closing on a timer: the class must survive the synchronous apply loop,
+ * and it must come off even if something in that loop throws, or the app would
+ * be left permanently transitioning and every later theme change would feel
+ * laggy. Purely cosmetic and fully guarded — this module runs in tests with no
+ * DOM.
+ */
+function beginHydrationPaint() {
+  try {
+    if (typeof document === 'undefined' || !document.documentElement) return;
+    document.documentElement.classList.add('prefs-hydrating');
+    if (paintTimer) clearTimeout(paintTimer);
+    paintTimer = setTimeout(() => {
+      paintTimer = null;
+      markHydrating(false);
+    }, HYDRATION_PAINT_MS);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Remove the hydration paint class. Safe to call when it is not present. */
+function markHydrating(on) {
+  try {
+    if (typeof document === 'undefined' || !document.documentElement) return;
+    document.documentElement.classList.toggle('prefs-hydrating', !!on);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Start observing the store and reconcile with the server.
+ *
+ * CALL THIS ONLY AFTER THE SESSION IS VERIFIED. Preferences are user data, and
+ * boot must not fire requests for a session the backend is about to reject —
+ * store/auth/sessionBoot.js calls this from the post-verification idle block,
+ * alongside the other per-user loads. isSessionValid is a second line of
+ * defence, not the first: it also stops pushes the moment a session is
+ * invalidated mid-flight.
+ *
+ * NEVER THROWS. Its caller runs inside `idle()` — a timer with no caller —
+ * where a synchronous throw escapes as an unhandled error rather than a
+ * rejection anything can observe, and aborts every step queued after it
+ * (run resumption, channel reclaim). Preferences are cosmetic; they must not
+ * be able to take the session boot sequence down with them.
+ *
+ * The subscriber is registered BEFORE the hydrate request goes out, so a
+ * setting the user changes during the round trip is captured rather than
+ * dropped — it is queued, stamped with the real moment it happened, and wins
+ * the server's last-write-wins comparison on its own merits.
+ */
+export function startPreferenceSync(store) {
+  if (unsubscribe) return unsubscribe;
+
+  if (typeof store?.subscribe !== 'function') {
+    console.warn('[userPreferences] sync not started: store has no subscribe()');
+    return null;
+  }
+
+  unsubscribe = store.subscribe((mutation) => {
+    if (applying) return; // hydration echo — see the class comment
+    const entry = MUTATION_MAP[mutation.type];
+    if (!entry) return;
+    // No confirmed session: stay purely local. theme.js has already written
+    // localStorage, so nothing the user did is lost — it simply does not
+    // leave this browser until a session is verified.
+    if (!isSessionValid(store)) return;
+    const values = entry.pick(mutation.payload);
+    if (values) enqueue(entry.scope, values);
+  });
+
+  // Deliberately not awaited: boot must not block on the network.
+  // Promise.resolve() because hydrateFromServer can throw synchronously before
+  // returning a promise — .catch() on a non-promise is itself a synchronous
+  // TypeError, which is the exact escape this function promises not to make.
+  Promise.resolve()
+    .then(() => hydrateFromServer(store))
+    .catch((e) => {
+      console.warn('[userPreferences] hydrate failed:', e?.message || e);
+    });
+
+  return unsubscribe;
+}
+
+export const _internal = { MUTATION_MAP, APPLY_MAP, PUSH_DEBOUNCE_MS };

--- a/frontend/src/services/userPreferences.js
+++ b/frontend/src/services/userPreferences.js
@@ -104,6 +104,40 @@ const MUTATION_MAP = {
   },
 };
 
+/**
+ * preference key → how to read its CURRENT value out of theme state.
+ *
+ * Separate from APPLY_MAP because three of these do not round-trip by name:
+ * the store calls them `isGreyscaleMode` and `isAssetPanelFullWidth`, and
+ * `leftPanelWidth`/`rightPanelWidth` are written through a single combined
+ * mutation. Guessing the state key from the preference key would silently
+ * return `undefined` for those, which compares unequal to everything and
+ * quietly reinstates the "every boot repaints" behaviour this exists to stop.
+ *
+ * Every APPLY_MAP key must appear here — userPreferences.spec.js fails if one
+ * is missing, so adding a preference cannot half-land.
+ */
+const READ_MAP = {
+  currentTheme: (s) => s.currentTheme,
+  fontFamily: (s) => s.fontFamily,
+  greyscaleMode: (s) => s.isGreyscaleMode,
+  useCustomBackground: (s) => s.useCustomBackground,
+  bgOpacity: (s) => s.bgOpacity,
+  bgBlur: (s) => s.bgBlur,
+  panelPosition: (s) => s.panelPosition,
+  assetPanelFullWidth: (s) => s.isAssetPanelFullWidth,
+
+  uiScale: (s) => s.uiScale,
+  actualLeftPanelWidth: (s) => s.actualLeftPanelWidth,
+  mainContentWidth: (s) => s.mainContentWidth,
+  showLeftPanel: (s) => s.showLeftPanel,
+  showRightPanel: (s) => s.showRightPanel,
+  leftPanelCollapsed: (s) => s.leftPanelCollapsed,
+  rightPanelCollapsed: (s) => s.rightPanelCollapsed,
+  leftPanelWidth: (s) => s.leftPanelWidth,
+  rightPanelWidth: (s) => s.rightPanelWidth,
+};
+
 /** preference key → the mutation that applies it during hydration. */
 const APPLY_MAP = {
   currentTheme: (store, v) => store.dispatch('theme/setTheme', v),
@@ -416,10 +450,15 @@ export async function hydrateFromServer(store) {
 
   const applied = [];
   const skipped = [];
+  const unchanged = [];
 
-  // Decide what will change BEFORE touching the DOM. Most boots agree with the
-  // server, and opening a transition window that repaints nothing would put a
-  // colour transition on every element for no reason.
+  // Decide what will actually CHANGE before touching the DOM.
+  //
+  // Comparing against current state, not merely "is this a key we know", is
+  // what makes the common boot free. Both sides usually already agree — the
+  // browser painted these values from localStorage moments ago — so without
+  // this every boot re-dispatches every setting and opens a transition window
+  // over the whole document to repaint nothing.
   const work = [];
   for (const source of [prefs.global || {}, prefs.device || {}]) {
     for (const [key, value] of Object.entries(source)) {
@@ -431,11 +470,16 @@ export async function hydrateFromServer(store) {
         skipped.push(key);
         continue;
       }
+      const read = READ_MAP[key];
+      if (read && read(store.state.theme) === value) {
+        unchanged.push(key);
+        continue;
+      }
       work.push([key, value, apply]);
     }
   }
 
-  if (!work.length) return { applied, skipped };
+  if (!work.length) return { applied, skipped, unchanged };
 
   applying = true;
   // Opened here and closed on a TIMER, not in the finally below. The apply
@@ -456,7 +500,7 @@ export async function hydrateFromServer(store) {
     applying = false;
   }
 
-  return { applied, skipped };
+  return { applied, skipped, unchanged };
 }
 
 /**
@@ -554,4 +598,4 @@ export function startPreferenceSync(store) {
   return unsubscribe;
 }
 
-export const _internal = { MUTATION_MAP, APPLY_MAP, PUSH_DEBOUNCE_MS };
+export const _internal = { MUTATION_MAP, APPLY_MAP, READ_MAP, PUSH_DEBOUNCE_MS };

--- a/frontend/src/services/userPreferences.spec.js
+++ b/frontend/src/services/userPreferences.spec.js
@@ -1,0 +1,559 @@
+/**
+ * Cross-device preference sync — client contract.
+ *
+ * Each of these is a bug a user would actually report, in their words:
+ *   "my theme didn't follow me to the laptop"
+ *   "my laptop panels got resized to my desktop's widths"
+ *   "I changed the theme while it was loading and it flipped back"
+ *   "dragging a panel hammers the server"
+ *   "it kept flickering between two themes forever"       (the echo loop)
+ *   "an old tab I left open reset my theme overnight"
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createStore } from 'vuex';
+
+vi.mock('@/tt.config.js', () => ({
+  API_CONFIG: { BASE_URL: 'http://localhost:3333/api' },
+}));
+
+const {
+  getDeviceId,
+  getDeviceLabel,
+  hydrateFromServer,
+  startPreferenceSync,
+  stopPreferenceSync,
+  _resetForTests,
+  _internal,
+} = await import('./userPreferences.js');
+
+const { default: themeModule } = await import('@/store/app/theme.js');
+
+// theme.js exports `state` as a plain object, so every createStore() would
+// otherwise share one mutable instance and a commit in one test would leak
+// into the next.
+const BASE_STATE = structuredClone(themeModule.state);
+
+/**
+ * @param sessionValid mirrors userAuth's sessionState tristate resolved to a
+ *   boolean. Sync gates on the BACKEND-CONFIRMED session, not on a token
+ *   string, so the stub has to model the getter rather than localStorage.
+ */
+const makeStore = (sessionValid = true) =>
+  createStore({
+    modules: {
+      theme: { ...themeModule, namespaced: true, state: structuredClone(BASE_STATE) },
+      userAuth: {
+        namespaced: true,
+        state: () => ({}),
+        getters: { isAuthenticated: () => sessionValid },
+      },
+    },
+  });
+
+let fetchMock;
+
+/** Last PUT body sent, parsed. */
+const putBodies = () =>
+  fetchMock.mock.calls
+    .filter(([, opts]) => opts?.method === 'PUT')
+    .map(([, opts]) => JSON.parse(opts.body));
+
+const okJson = (body) => ({ ok: true, status: 200, json: async () => body });
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem('token', 'test-jwt');
+  _resetForTests();
+  vi.useFakeTimers();
+  fetchMock = vi.fn().mockResolvedValue(okJson({ success: true, preferences: null }));
+  globalThis.fetch = fetchMock;
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('device identity', () => {
+  it('mints an id that satisfies the server validator', () => {
+    const id = getDeviceId();
+    expect(id).toMatch(/^[A-Za-z0-9_-]{1,64}$/);
+  });
+
+  it('is stable across calls — a new id every boot would leak device buckets', () => {
+    expect(getDeviceId()).toBe(getDeviceId());
+  });
+
+  it('persists so a reload keeps the same geometry bucket', () => {
+    const first = getDeviceId();
+    expect(localStorage.getItem('agnt:deviceId')).toBe(first);
+  });
+
+  it('rejects a corrupted stored id rather than sending it and 400ing forever', () => {
+    localStorage.setItem('agnt:deviceId', 'not a valid id!!');
+    expect(getDeviceId()).toMatch(/^[A-Za-z0-9_-]{1,64}$/);
+    expect(getDeviceId()).not.toBe('not a valid id!!');
+  });
+
+  it('produces a human-recognisable label, not a fingerprint', () => {
+    expect(typeof getDeviceLabel()).toBe('string');
+    expect(getDeviceLabel().length).toBeGreaterThan(0);
+    expect(getDeviceLabel().length).toBeLessThanOrEqual(64);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('routing: taste syncs globally, pixels stay per-device', () => {
+  it('sends theme in the global scope', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+    store.commit('theme/SET_THEME', 'cyberpunk');
+    await vi.advanceTimersByTimeAsync(500);
+
+    const [body] = putBodies();
+    expect(body.global).toEqual({ currentTheme: 'cyberpunk' });
+    expect(body.device).toBeUndefined();
+  });
+
+  it('sends panel geometry in the device scope, with a deviceId', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+    store.commit('theme/SET_PANEL_WIDTHS', { leftWidth: 520, rightWidth: 300 });
+    await vi.advanceTimersByTimeAsync(500);
+
+    const [body] = putBodies();
+    expect(body.device).toEqual({ leftPanelWidth: 520, rightPanelWidth: 300 });
+    expect(body.global).toBeUndefined();
+    expect(body.deviceId).toMatch(/^[A-Za-z0-9_-]{1,64}$/);
+  });
+
+  it('expands a multi-key mutation into every key it wrote', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+    store.commit('theme/SET_THREE_PANEL_WIDTHS', { actualLeftWidth: 300, mainWidth: 800, rightWidth: 400 });
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(putBodies()[0].device).toEqual({
+      actualLeftPanelWidth: 300,
+      mainContentWidth: 800,
+      rightPanelWidth: 400,
+    });
+  });
+
+  it('ignores mutations that are not synced settings', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+    store.commit('theme/SET_PROMO_BANNER_CLOSED', true);
+    store.commit('theme/SET_RATE_LIMIT_BANNER_CLOSED', true);
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(putBodies()).toHaveLength(0);
+  });
+
+  it('never syncs the background-exists flag — the media itself is not synced', () => {
+    expect(_internal.MUTATION_MAP['theme/SET_HAS_CUSTOM_BACKGROUND']).toBeUndefined();
+    expect(_internal.MUTATION_MAP['theme/SET_BACKGROUND_FILE_NAME']).toBeUndefined();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('debounce — a drag must not hammer the server', () => {
+  it('coalesces a burst into ONE request', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+    for (let w = 300; w <= 320; w++) {
+      store.commit('theme/SET_PANEL_WIDTHS', { leftWidth: w, rightWidth: 384 });
+    }
+    await vi.advanceTimersByTimeAsync(500);
+
+    const bodies = putBodies();
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0].device.leftPanelWidth).toBe(320); // the final value wins
+  });
+
+  it('merges both scopes from one burst into a single request', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+    store.commit('theme/SET_THEME', 'nord');
+    store.commit('theme/SET_UI_SCALE', 110);
+    await vi.advanceTimersByTimeAsync(500);
+
+    const bodies = putBodies();
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0].global).toEqual({ currentTheme: 'nord' });
+    expect(bodies[0].device).toEqual({ uiScale: 110 });
+  });
+
+  it('stamps updatedAt when the user ACTED, not when the debounce flushed', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+
+    const actedAt = Date.now();
+    store.commit('theme/SET_THEME', 'ember');
+    await vi.advanceTimersByTimeAsync(500);
+
+    const { updatedAt } = putBodies()[0];
+    // Backdating to flush time would let a slow client lose to a stale one.
+    expect(updatedAt).toBeGreaterThanOrEqual(actedAt);
+    expect(updatedAt).toBeLessThan(actedAt + _internal.PUSH_DEBOUNCE_MS);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('hydration', () => {
+  it('applies a theme set on another device', async () => {
+    const store = makeStore();
+    fetchMock.mockResolvedValue(
+      okJson({ success: true, preferences: { global: { currentTheme: 'cyberpunk' }, device: {} } }),
+    );
+
+    await hydrateFromServer(store);
+    expect(store.state.theme.currentTheme).toBe('cyberpunk');
+  });
+
+  it('applies this device geometry without touching global taste', async () => {
+    const store = makeStore();
+    fetchMock.mockResolvedValue(
+      okJson({ success: true, preferences: { global: {}, device: { leftPanelWidth: 275 } } }),
+    );
+
+    await hydrateFromServer(store);
+    expect(store.state.theme.leftPanelWidth).toBe(275);
+  });
+
+  it('asks for THIS device bucket by id', async () => {
+    const store = makeStore();
+    await hydrateFromServer(store);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain(`deviceId=${getDeviceId()}`);
+  });
+
+  it('★ does NOT echo hydrated values back to the server', async () => {
+    const store = makeStore();
+    fetchMock.mockResolvedValue(
+      okJson({ success: true, preferences: { global: { currentTheme: 'midnight' }, device: {} } }),
+    );
+
+    startPreferenceSync(store);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // An echo would push the value straight back, bump updatedAt, and let a
+    // stale device win the next comparison — forever.
+    expect(putBodies()).toHaveLength(0);
+  });
+
+  it('★ does NOT undo a change the user made while hydration was in flight', async () => {
+    const store = makeStore();
+    let resolveFetch;
+    fetchMock.mockReturnValue(new Promise((r) => { resolveFetch = r; }));
+
+    startPreferenceSync(store);
+
+    // The user picks a theme before the server responds.
+    store.commit('theme/SET_THEME', 'hacker');
+
+    // ...and only now does the (older) server state arrive.
+    resolveFetch(okJson({ success: true, preferences: { global: { currentTheme: 'light' }, device: {} } }));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(store.state.theme.currentTheme).toBe('hacker');
+  });
+
+  it('still applies untouched keys when one key was edited in flight', async () => {
+    const store = makeStore();
+    let resolveFetch;
+    fetchMock.mockReturnValue(new Promise((r) => { resolveFetch = r; }));
+
+    startPreferenceSync(store);
+    store.commit('theme/SET_THEME', 'hacker');
+
+    resolveFetch(okJson({
+      success: true,
+      preferences: { global: { currentTheme: 'light', fontFamily: 'mono' }, device: {} },
+    }));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(store.state.theme.currentTheme).toBe('hacker'); // user's edit kept
+    expect(store.state.theme.fontFamily).toBe('mono');     // other device's setting still lands
+  });
+
+  it('ignores unknown keys from a newer server without throwing', async () => {
+    const store = makeStore();
+    fetchMock.mockResolvedValue(
+      okJson({ success: true, preferences: { global: { futureKey: 'x', currentTheme: 'nord' }, device: {} } }),
+    );
+
+    await expect(hydrateFromServer(store)).resolves.toBeTruthy();
+    expect(store.state.theme.currentTheme).toBe('nord');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('degrades quietly', () => {
+  it('does not sync for a session the backend has not confirmed', async () => {
+    // A token string in localStorage is NOT a session. Gating on one is how
+    // the app came to render a full UI for an unverified user; preferences
+    // must not reintroduce that by making requests boot deliberately defers.
+    localStorage.setItem('token', 'stale-jwt');
+    const store = makeStore(false);
+    startPreferenceSync(store);
+    store.commit('theme/SET_THEME', 'rose');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(store.state.theme.currentTheme).toBe('rose'); // still works locally
+    expect(localStorage.getItem('currentTheme')).toBe('rose');
+  });
+
+  it('reports an unverified session distinctly when hydrating', async () => {
+    const store = makeStore(false);
+    await expect(hydrateFromServer(store)).resolves.toEqual({ skipped: 'unverified-session' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('survives an offline hydrate and leaves local state alone', async () => {
+    const store = makeStore();
+    const before = store.state.theme.currentTheme;
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    await expect(hydrateFromServer(store)).resolves.toEqual({ skipped: 'offline' });
+    expect(store.state.theme.currentTheme).toBe(before);
+  });
+
+  it('survives a failed push without losing the local change', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+    fetchMock.mockRejectedValue(new Error('500'));
+
+    store.commit('theme/SET_THEME', 'ember');
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(store.state.theme.currentTheme).toBe('ember');
+    expect(localStorage.getItem('currentTheme')).toBe('ember');
+  });
+
+  /**
+   * Fail the first N PUTs and let everything else through.
+   *
+   * Method-aware on purpose: startPreferenceSync issues a GET before any PUT,
+   * so a bare mockRejectedValueOnce is swallowed by the hydrate and the push
+   * under test quietly succeeds — the test then passes for the wrong reason.
+   */
+  const failPuts = (n) => {
+    let failures = 0;
+    fetchMock.mockImplementation((_url, opts = {}) => {
+      if (opts.method === 'PUT' && failures < n) {
+        failures += 1;
+        return Promise.reject(new Error('network down'));
+      }
+      return Promise.resolve(okJson({ success: true, preferences: null }));
+    });
+  };
+
+  it('★ re-sends a change whose push failed, instead of dropping it silently', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+
+    // The local write already succeeded, so a dropped push is invisible: the
+    // theme is applied HERE and nowhere else, forever, with no error anywhere.
+    failPuts(1);
+    store.commit('theme/SET_THEME', 'ember');
+    await vi.advanceTimersByTimeAsync(500);
+    expect(putBodies()).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(3000); // past the 2s retry backoff
+
+    const bodies = putBodies();
+    expect(bodies).toHaveLength(2);
+    expect(bodies[1].global).toEqual({ currentTheme: 'ember' });
+  });
+
+  it('lets a newer change win when merging a failed batch back in', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+
+    failPuts(1);
+    store.commit('theme/SET_THEME', 'ember');
+    await vi.advanceTimersByTimeAsync(500);
+
+    // Changed again while the retry was pending: the newer value is the user's
+    // real intent and must not be reverted by the replayed batch.
+    store.commit('theme/SET_THEME', 'nord');
+    await vi.advanceTimersByTimeAsync(3000);
+
+    const last = putBodies().at(-1);
+    expect(last.global.currentTheme).toBe('nord');
+  });
+
+  it('backs off rather than hammering a server that is down', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+    fetchMock.mockRejectedValue(new Error('503'));
+
+    store.commit('theme/SET_THEME', 'ember');
+    await vi.advanceTimersByTimeAsync(500);
+    const afterFirst = putBodies().length;
+
+    // 10s of downtime: with a 2s base doubling to 4s and 8s this is ~3 more
+    // attempts, not the ~25 a fixed debounce-interval retry would produce.
+    await vi.advanceTimersByTimeAsync(10000);
+    const attempts = putBodies().length - afterFirst;
+    expect(attempts).toBeGreaterThan(0);
+    expect(attempts).toBeLessThan(6);
+  });
+
+  it('tolerates a server returning no preferences block', async () => {
+    const store = makeStore();
+    fetchMock.mockResolvedValue(okJson({ success: true }));
+    await expect(hydrateFromServer(store)).resolves.toEqual({ skipped: 'empty' });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('hydration repaint window', () => {
+  const hydrating = () => document.documentElement.classList.contains('prefs-hydrating');
+
+  it('★ keeps the class on long enough for the transition to actually run', async () => {
+    const store = makeStore();
+    fetchMock.mockResolvedValue(
+      okJson({ success: true, preferences: { global: { currentTheme: 'cyberpunk' }, device: {} } }),
+    );
+
+    await hydrateFromServer(store);
+    // The apply loop is synchronous. Removing the class at the end of it would
+    // take it off in the same frame it went on, and the browser would never
+    // run the transition at all — the easing would silently never happen.
+    expect(hydrating()).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(hydrating()).toBe(false);
+  });
+
+  it('does not open the window when the server agrees with local state', async () => {
+    const store = makeStore();
+    fetchMock.mockResolvedValue(okJson({ success: true, preferences: { global: {}, device: {} } }));
+
+    await hydrateFromServer(store);
+    // The common case. Transitioning every element for a repaint that never
+    // happens is pure cost.
+    expect(hydrating()).toBe(false);
+  });
+
+  it('does not leave the app stuck transitioning when an apply throws', async () => {
+    const store = makeStore();
+    vi.spyOn(store, 'dispatch').mockImplementation(() => {
+      throw new Error('boom');
+    });
+    fetchMock.mockResolvedValue(
+      okJson({ success: true, preferences: { global: { currentTheme: 'nord' }, device: {} } }),
+    );
+
+    await hydrateFromServer(store);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(hydrating()).toBe(false);
+  });
+});
+
+describe('session teardown — sign-out no longer reloads the page', () => {
+  it('★ never sends one user\u2019s queued preferences under the next user\u2019s token', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+
+    store.commit('theme/SET_THEME', 'ember'); // queued, not yet flushed
+    stopPreferenceSync();                     // endSession fires here
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(putBodies()).toHaveLength(0);
+  });
+
+  it('stops watching the store, so a later change is not attributed to the old session', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+    stopPreferenceSync();
+
+    store.commit('theme/SET_THEME', 'nord');
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(putBodies()).toHaveLength(0);
+  });
+
+  it('clears touchedKeys so the NEXT user\u2019s hydration is not suppressed', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+    store.commit('theme/SET_THEME', 'ember'); // marks currentTheme as touched
+    stopPreferenceSync();
+
+    const next = makeStore();
+    fetchMock.mockResolvedValue(
+      okJson({ success: true, preferences: { global: { currentTheme: 'rose' }, device: {} } }),
+    );
+    const result = await hydrateFromServer(next);
+
+    expect(result.applied).toContain('currentTheme');
+    expect(next.state.theme.currentTheme).toBe('rose');
+  });
+
+  it('drops a retry that was pending when the session ended', async () => {
+    const store = makeStore();
+    startPreferenceSync(store);
+    fetchMock.mockRejectedValue(new Error('offline'));
+
+    store.commit('theme/SET_THEME', 'ember');
+    await vi.advanceTimersByTimeAsync(500);
+    const beforeStop = putBodies().length;
+
+    stopPreferenceSync();
+    await vi.advanceTimersByTimeAsync(30000);
+
+    expect(putBodies()).toHaveLength(beforeStop);
+  });
+});
+
+describe('never takes session boot down with it', () => {
+  it('★ does not throw on a store it cannot subscribe to', () => {
+    // startPreferenceSync runs inside sessionBoot's idle() — a timer with no
+    // caller — so a synchronous throw escapes as an unhandled ERROR and aborts
+    // every step queued after it (run resumption, channel reclaim). Preferences
+    // are cosmetic and must never be able to do that.
+    expect(() => startPreferenceSync({})).not.toThrow();
+    expect(() => startPreferenceSync(null)).not.toThrow();
+  });
+
+  it('does not throw when hydration blows up synchronously', () => {
+    const store = makeStore();
+    fetchMock.mockImplementation(() => {
+      throw new Error('synchronous explosion');
+    });
+    expect(() => startPreferenceSync(store)).not.toThrow();
+  });
+});
+
+describe('transport', () => {
+  it('owns Authorization — a caller cannot override or drop it', async () => {
+    const store = makeStore();
+    localStorage.setItem('token', 'real-jwt');
+    fetchMock.mockResolvedValue(okJson({ success: true, preferences: null }));
+
+    await hydrateFromServer(store);
+
+    const [, opts] = fetchMock.mock.calls[0];
+    expect(opts.headers.Authorization).toBe('Bearer real-jwt');
+  });
+});
+
+describe('localStorage stays the first-paint source', () => {
+  it('a synced value is written to localStorage so the NEXT boot paints it instantly', async () => {
+    const store = makeStore();
+    fetchMock.mockResolvedValue(
+      okJson({ success: true, preferences: { global: { currentTheme: 'nord' }, device: {} } }),
+    );
+
+    await hydrateFromServer(store);
+    // Without this the feature would only work while online, and every reload
+    // would flash the old theme before the network answered.
+    expect(localStorage.getItem('currentTheme')).toBe('nord');
+  });
+});

--- a/frontend/src/services/userPreferences.spec.js
+++ b/frontend/src/services/userPreferences.spec.js
@@ -157,6 +157,39 @@ describe('routing: taste syncs globally, pixels stay per-device', () => {
     expect(_internal.MUTATION_MAP['theme/SET_HAS_CUSTOM_BACKGROUND']).toBeUndefined();
     expect(_internal.MUTATION_MAP['theme/SET_BACKGROUND_FILE_NAME']).toBeUndefined();
   });
+
+  it('every appliable key knows how to read its own current value', () => {
+    // A key in APPLY_MAP but not READ_MAP reads as `undefined`, compares
+    // unequal to everything, and silently reinstates "re-dispatch and repaint
+    // on every boot" for that setting. Adding a preference must not half-land.
+    const missing = Object.keys(_internal.APPLY_MAP).filter((k) => !_internal.READ_MAP[k]);
+    expect(missing, `APPLY_MAP keys with no READ_MAP entry: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('reads back exactly what each mutation writes', () => {
+    // Guards the three keys whose store field is NOT the preference name
+    // (isGreyscaleMode, isAssetPanelFullWidth, and the combined panel widths).
+    const store = makeStore();
+    const cases = {
+      currentTheme: 'nord',
+      fontFamily: 'mono',
+      greyscaleMode: true,
+      panelPosition: 'left',
+      assetPanelFullWidth: true,
+      bgOpacity: 75,
+      bgBlur: 6,
+      uiScale: 125,
+      leftPanelWidth: 321,
+      rightPanelWidth: 654,
+      showLeftPanel: false,
+      leftPanelCollapsed: true,
+    };
+
+    for (const [key, value] of Object.entries(cases)) {
+      _internal.APPLY_MAP[key](store, value, store.state.theme);
+      expect(_internal.READ_MAP[key](store.state.theme), `round-trip failed for ${key}`).toBe(value);
+    }
+  });
 });
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -440,6 +473,52 @@ describe('hydration repaint window', () => {
     // The common case. Transitioning every element for a repaint that never
     // happens is pure cost.
     expect(hydrating()).toBe(false);
+  });
+
+  it('★ does not open the window when the server ECHOES what is already applied', async () => {
+    // The realistic common boot, and the one an empty payload does NOT cover:
+    // the server returns real values that happen to match what localStorage
+    // already painted. Verified in a real browser first — this case opened the
+    // window on every boot until the READ_MAP comparison existed.
+    const store = makeStore();
+    const s = store.state.theme;
+    fetchMock.mockResolvedValue(
+      okJson({
+        success: true,
+        preferences: {
+          global: { currentTheme: s.currentTheme, fontFamily: s.fontFamily, bgOpacity: s.bgOpacity },
+          device: { uiScale: s.uiScale, leftPanelWidth: s.leftPanelWidth },
+        },
+      }),
+    );
+
+    const result = await hydrateFromServer(store);
+
+    expect(hydrating()).toBe(false);
+    expect(result.applied).toEqual([]);
+    expect(result.unchanged).toEqual(
+      expect.arrayContaining(['currentTheme', 'fontFamily', 'bgOpacity', 'uiScale', 'leftPanelWidth']),
+    );
+  });
+
+  it('still applies the keys that DO differ when others agree', async () => {
+    const store = makeStore();
+    const s = store.state.theme;
+    fetchMock.mockResolvedValue(
+      okJson({
+        success: true,
+        preferences: {
+          global: { currentTheme: s.currentTheme, fontFamily: 'mono' },
+          device: {},
+        },
+      }),
+    );
+
+    const result = await hydrateFromServer(store);
+
+    expect(result.unchanged).toContain('currentTheme');
+    expect(result.applied).toEqual(['fontFamily']);
+    expect(hydrating()).toBe(true); // one real change still earns the window
   });
 
   it('does not leave the app stuck transitioning when an apply throws', async () => {

--- a/frontend/src/store/auth/sessionBoot.js
+++ b/frontend/src/store/auth/sessionBoot.js
@@ -54,6 +54,7 @@
 
 import { authSubject, licenseMatchesSubject, licenseSubject } from './licenseIdentity.js';
 import { resumeInflightRuns as defaultResumeInflightRuns } from '@/services/runResume.js';
+import { startPreferenceSync, stopPreferenceSync } from '@/services/userPreferences.js';
 
 /** Refresh the signed license once an hour while a session is live. */
 const LICENSE_REFRESH_INTERVAL = 60 * 60 * 1000;
@@ -171,6 +172,22 @@ async function runStartSession(store, { reason = 'unknown', resumeInflightRuns =
       console.error('[session] loadUserSettings failed:', err?.message || err);
     });
 
+    // Cross-device UI preferences (theme, font, panel geometry). Session
+    // scoped, not boot scoped, for exactly the reason this module exists: a
+    // sign-in does not reload the page, so a browser that signed in without
+    // one would otherwise keep painting the previous defaults until refresh.
+    // localStorage has already painted the last known-good values
+    // synchronously; this only reconciles them with the server.
+    //
+    // try/catch for the same reason resumeInflightRuns is wrapped above: a
+    // synchronous throw in here is an unhandled ERROR, not a rejection, and
+    // would silently abort every step queued after it.
+    try {
+      startPreferenceSync(store);
+    } catch (err) {
+      console.warn('[session] preference sync failed to start:', err?.message || err);
+    }
+
     startLicenseRefresh(store);
 
     // Rejoin any chat turn still generating when this tab last went away.
@@ -216,6 +233,12 @@ export function endSession(store, { reason = 'unknown' } = {}) {
   console.log(`[session] ending (${reason})`);
   inFlight = null;
   stopLicenseRefresh();
+  // Detach the preference subscriber and drop anything queued. Without this a
+  // sign-out leaves it watching the store, and a debounced push from the
+  // previous user can land under the NEXT user's token — writing one person's
+  // theme into another's account. The in-memory "keys this user touched" set
+  // has to go the same way, or it suppresses the next user's hydration.
+  stopPreferenceSync();
   // Stops connector polling and clears every user-scoped store, in that order.
   // Derived from one table rather than the ad-hoc four-store list that used to
   // live in userAuth.logout — see resetUserScopedData in store/state.js.

--- a/frontend/src/styles/base/_animations.css
+++ b/frontend/src/styles/base/_animations.css
@@ -78,3 +78,39 @@
 .fade-in-stagger > *:nth-child(5) { animation-delay: 0.16s; }
 .fade-in-stagger > *:nth-child(6) { animation-delay: 0.2s; }
 .fade-in-stagger > *:nth-child(n+7) { animation-delay: 0.24s; }
+
+/* ---------------------------------------------------------------------------
+   Cross-device preference hydration (services/userPreferences.js)
+
+   localStorage paints first so boot is instant and correct offline; the server
+   reconciles a beat later. On the rare boot where another device changed the
+   theme, that reconciliation repaints — and an unsoftened repaint reads as a
+   glitch rather than as a sync.
+
+   Scoped to a class the sync module adds for ~400ms and then removes, and only
+   when a value actually differs from what localStorage already painted — so a
+   normal boot never enters this state at all, and ordinary theme switching a
+   moment later is not still easing.
+
+   Colours only: transitioning layout would make panels visibly slide.
+
+   :where() keeps the whole selector at the specificity of `.prefs-hydrating`
+   alone (0,1,0). `transition` is a SHORTHAND, so it resets the entire
+   transition list of everything it matches — without :where(), a component
+   that declares its own `transition: transform .3s` would lose it for the
+   duration of the window and snap mid-animation. At this specificity any
+   component rule wins instead, and only elements with no transition of their
+   own pick this up.
+   --------------------------------------------------------------------------- */
+.prefs-hydrating :where(body, body *) {
+  transition:
+    background-color 0.25s ease,
+    color 0.25s ease,
+    border-color 0.25s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .prefs-hydrating :where(body, body *) {
+    transition: none;
+  }
+}

--- a/frontend/src/styles/base/_animations.css
+++ b/frontend/src/styles/base/_animations.css
@@ -94,15 +94,24 @@
 
    Colours only: transitioning layout would make panels visibly slide.
 
-   :where() keeps the whole selector at the specificity of `.prefs-hydrating`
-   alone (0,1,0). `transition` is a SHORTHAND, so it resets the entire
-   transition list of everything it matches — without :where(), a component
-   that declares its own `transition: transform .3s` would lose it for the
-   duration of the window and snap mid-animation. At this specificity any
-   component rule wins instead, and only elements with no transition of their
-   own pick this up.
+   `transition` is a SHORTHAND, so it resets the ENTIRE transition list of
+   everything it matches — a component declaring `transition: transform .3s`
+   would lose it for the duration of the window and snap mid-animation.
+
+   Both halves are wrapped in :where(), which contributes zero specificity, so
+   the whole selector weighs (0,0,0). That is deliberate and stronger than
+   merely lowering it: at (0,0,0) ANY competing author declaration wins
+   outright, whatever its specificity and wherever it sits in source order.
+   Leaving the `.prefs-hydrating` class outside :where() would weigh (0,1,0),
+   which merely TIES with a plain `.thing { transition: ... }` and is then
+   settled by stylesheet order — measured, and it loses for any component whose
+   CSS happens to load before this file. A guarantee that depends on import
+   order is not a guarantee.
+
+   So this only ever reaches elements that express no transition of their own,
+   which is exactly the set it is meant to soften.
    --------------------------------------------------------------------------- */
-.prefs-hydrating :where(body, body *) {
+:where(.prefs-hydrating) :where(body, body *) {
   transition:
     background-color 0.25s ease,
     color 0.25s ease,
@@ -110,7 +119,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .prefs-hydrating :where(body, body *) {
+  :where(.prefs-hydrating) :where(body, body *) {
     transition: none;
   }
 }


### PR DESCRIPTION
## What

Adds `GET`/`PUT /api/users/preferences` and wires the frontend to it, so **theme, font and background treatment follow the user between browsers** while **panel geometry stays per-device**.

Before this, two things crossed browsers — workspace tabs (`/api/workspaces`) and widget layouts (`/api/layouts`). Everything a user actually tunes did not: ~80 settings lived only in the localStorage of the browser that set them. Set a theme on the desktop, open the laptop, get the default. Nothing was broken; there was no store.

## The design decision worth reviewing

**This is deliberately not one flat bag of keys.** Pixel geometry is a property of the screen, not the person:

```
leftPanelWidth = 520  on a 27" desktop -> a comfortable sidebar
leftPanelWidth = 520  on a 13" laptop  -> half the usable width
```

Syncing that globally would make every resize on one machine vandalise the other — worse than not syncing at all. So preferences carry a scope:

| scope | what | conflict rule |
|---|---|---|
| `global` | theme, font, background treatment | last-write-wins on `updatedAt` |
| `device` | panel widths, UI scale, collapse state | always applies (uncontended by construction) |

Device buckets are keyed by an opaque client-minted id, capped at 20 with LRU eviction.

## Backend

One JSON column on `users` — a blob rather than a column per setting, because these are presentation keys with no query, index or constraint against them; a column each means a schema migration every time someone adds a toggle.

- **PUT merges.** Clients send only what changed, so an older build cannot erase a key it has never heard of. Explicit `null` deletes, since absence has to mean "no opinion".
- **`updatedAt` is when the user acted**, not when the request was built — otherwise a week-old tab can replay a stale theme just by being chatty.
- **Allowlisted, not passthrough.** Every key declares a type and range. Without that this becomes a general per-user KV within two releases. Unknown keys are dropped *and reported* — a silently ignored key looks exactly like success to a client author.
- **Read-modify-write is serialized per user.** The frontend saves theme and geometry from separate watchers, so one user action fires two PUTs milliseconds apart; interleaved, the second erases the first with no error on either side.

## Frontend

localStorage stays the **first-paint** source (`theme.js` builds state from it synchronously and cannot wait on a round trip). The server reconciles after mount — the same shape `useWorkspaces` already uses.

Sync observes `store.subscribe` and maps mutation type → preference key in one table, rather than appending a push call to 17 mutation bodies. **`theme.js` is unmodified.** Adding a synced setting later is one line.

Two races, both covered by tests:

- **Echo** — hydration applies remote values by committing mutations, which the subscriber sees, which pushes them back: an infinite round trip that also bumps `updatedAt` and lets a stale device win.
- **In-flight edit** — hydration takes a few hundred ms; a theme change made in that window is newer than anything the server can return. Only the *touched* keys are skipped, not the whole hydrate, which would discard every other device's settings over one click.

## Interaction with the auth-gate change (91524e94)

Rebased on top of it, and reconciled rather than merely made to compile:

- Sync starts from the **post-verification `idle` block** alongside `loadUserSettings`, not at first paint. Preferences are user data, and boot must not fire requests for a session the backend is about to reject.
- The module gates on `userAuth/isAuthenticated` (`sessionState === VALID`), **not** `!!localStorage.token` — a token string means someone once had a credential, not that it is still valid. It is also a live check, so a session invalidated mid-flight stops producing pushes immediately rather than at the next reload.

## Deliberately not synced

- **Custom background media** — lives in IndexedDB per browser. Advertising it on a device that cannot render it produces a blank background and a settings panel that lies. Only the `useCustomBackground` / `bgOpacity` / `bgBlur` treatment flags cross.
- Per-browser flags: dismissed banners, tutorial completion, editor scratch state.

## Risk

**Dormant for existing installs.** The column is `NULL`, which reads as "no stored preferences", so every browser keeps what its localStorage already has until something is changed. No behaviour change until a user touches a setting.

## Verification

- **Backend**: 182 files / 2993 tests green (25 new: merge, LWW, validation, clamping, eviction, round-trip)
- **Frontend**: 176 files / 3220 tests green (26 new: scope routing, debounce coalescing, both races, session gate, offline degradation)
- **`vite build`** clean, 387 assets — checked independently because `cssIntegrity.spec.js` exists precisely for the case where vitest is green and the build is not
- `docContract.test.js` green — both routes documented under `## User Routes` with matching auth claims

Also exercised end-to-end over HTTP against a scratch DB (real router, real `authenticateToken`, real sqlite): 401 on anonymous/invalid, cold read returns empty rather than 404, partial merge preserves untouched keys, stale writes rejected, garbage clamped or refused, and 4 concurrent PUTs all survive.

## Not included

The existing `GET /settings` docs describe `{theme, language, notifications}`, which that endpoint has never returned (the real shape is `selectedProvider`/`selectedModel`/…). `docContract` only validates paths and auth claims, so it never caught this. Left alone here to keep the diff scoped — happy to fix in a follow-up.