### PR TITLE
Allow custom OpenAI-compatible providers as failover tiers

### DIFF
--- a/backend/src/services/AutonomousMessageService.js
+++ b/backend/src/services/AutonomousMessageService.js
@@ -9,6 +9,7 @@ import conversationManager from './ConversationManager.js';
 import { createLlmClient } from './ai/LlmService.js';
 import { createLlmAdapter } from './orchestrator/llmAdapters.js';
 import { buildProviderChain, runWithFallback } from './orchestrator/ProviderFallback.js';
+import CustomOpenAIProviderService from './ai/CustomOpenAIProviderService.js';
 import AgentModel from '../models/AgentModel.js';
 import UserModel from '../models/UserModel.js';
 import { executeTool } from './orchestrator/tools.js';
@@ -235,6 +236,18 @@ Be empathetic and suggest potential solutions or next steps if appropriate.`,
       // a single-tier chain = today's behavior. Dormant by default.
       let autoProviderChain = [{ provider: context.normalizedProvider, model: context.model, tier: 0, primary: true }];
       try {
+        // Custom providers (UUID-keyed, not in ProviderRegistry) are only
+        // admitted as tiers when their ids are supplied. Same contract as the
+        // interactive path in OrchestratorService; failure costs only the
+        // custom tiers.
+        let customProviderIds = [];
+        try {
+          const activeCustomProviders = await CustomOpenAIProviderService.getProvidersByUserId(context.userId);
+          customProviderIds = (activeCustomProviders || []).map((p) => p.id);
+        } catch (cpErr) {
+          log(`[AutonomousMessage] Could not load custom providers for failover chain: ${cpErr.message}`);
+        }
+
         let agChain = null;
         if (context.agentId && context.agentId !== 'agent-chat' && context.agentId !== 'orchestrator') {
           const agFb = await AgentModel.findOne(context.agentId);
@@ -244,6 +257,7 @@ Be empathetic and suggest potential solutions or next steps if appropriate.`,
               model: context.model,
               fallbackEnabled: true,
               fallbackProviders: agFb.fallbackProviders,
+              customProviderIds,
             });
           }
         }
@@ -257,6 +271,7 @@ Be empathetic and suggest potential solutions or next steps if appropriate.`,
               model: context.model,
               fallbackEnabled: uFb.fallbackEnabled,
               fallbackProviders: uFb.fallbackProviders,
+              customProviderIds,
             });
           }
         }

--- a/backend/src/services/AutonomousMessageService.js
+++ b/backend/src/services/AutonomousMessageService.js
@@ -8,7 +8,7 @@ import { randomUUID } from 'crypto';
 import conversationManager from './ConversationManager.js';
 import { createLlmClient } from './ai/LlmService.js';
 import { createLlmAdapter } from './orchestrator/llmAdapters.js';
-import { buildProviderChain, runWithFallback } from './orchestrator/ProviderFallback.js';
+import { buildProviderChain, runWithFallback, createCustomProviderIdResolver } from './orchestrator/ProviderFallback.js';
 import CustomOpenAIProviderService from './ai/CustomOpenAIProviderService.js';
 import AgentModel from '../models/AgentModel.js';
 import UserModel from '../models/UserModel.js';
@@ -238,15 +238,13 @@ Be empathetic and suggest potential solutions or next steps if appropriate.`,
       try {
         // Custom providers (UUID-keyed, not in ProviderRegistry) are only
         // admitted as tiers when their ids are supplied. Same contract as the
-        // interactive path in OrchestratorService; failure costs only the
-        // custom tiers.
-        let customProviderIds = [];
-        try {
-          const activeCustomProviders = await CustomOpenAIProviderService.getProvidersByUserId(context.userId);
-          customProviderIds = (activeCustomProviders || []).map((p) => p.id);
-        } catch (cpErr) {
-          log(`[AutonomousMessage] Could not load custom providers for failover chain: ${cpErr.message}`);
-        }
+        // interactive path in OrchestratorService: lazy, so a follow-up with
+        // failover disabled costs no query, and memoized so the two call sites
+        // below cost one. Fails safe to [] = no custom tiers.
+        const resolveCustomProviderIds = createCustomProviderIdResolver(
+          () => CustomOpenAIProviderService.getProvidersByUserId(context.userId),
+          (cpErr) => log(`[AutonomousMessage] Could not load custom providers for failover chain: ${cpErr.message}`),
+        );
 
         let agChain = null;
         if (context.agentId && context.agentId !== 'agent-chat' && context.agentId !== 'orchestrator') {
@@ -257,7 +255,7 @@ Be empathetic and suggest potential solutions or next steps if appropriate.`,
               model: context.model,
               fallbackEnabled: true,
               fallbackProviders: agFb.fallbackProviders,
-              customProviderIds,
+              customProviderIds: await resolveCustomProviderIds(),
             });
           }
         }
@@ -271,7 +269,7 @@ Be empathetic and suggest potential solutions or next steps if appropriate.`,
               model: context.model,
               fallbackEnabled: uFb.fallbackEnabled,
               fallbackProviders: uFb.fallbackProviders,
-              customProviderIds,
+              customProviderIds: await resolveCustomProviderIds(),
             });
           }
         }

--- a/backend/src/services/OrchestratorService.js
+++ b/backend/src/services/OrchestratorService.js
@@ -13,6 +13,7 @@ import { createLlmClient } from './ai/LlmService.js';
 const __failoverMemory = new Map();
 import { createLlmAdapter, requiresResponsesApi } from './orchestrator/llmAdapters.js';
 import { buildProviderChain, runWithFallback } from './orchestrator/ProviderFallback.js';
+import CustomOpenAIProviderService from './ai/CustomOpenAIProviderService.js';
 import { computeCacheSavings } from '../utils/cacheSavings.js';
 import { recordLlmCall } from './execution/LedgerRecorder.js';
 import { updateEstimateCalibration, computeResidualDrift } from '../utils/contextManager.js';
@@ -921,6 +922,20 @@ async function universalChatHandler(req, res, context = {}) {
   // updateUserSettings with a fallback tier.
   let providerChain = [{ provider: normalizedProvider, model, tier: 0, primary: true }];
   try {
+    // Custom OpenAI-compatible providers are keyed by UUID and are absent from
+    // ProviderRegistry, so buildProviderChain drops them unless we hand it the
+    // user's active ids. createLlmAdapter already resolves such a provider at
+    // call time, so a custom tier runs fine once it survives chain building.
+    // Its own try/catch: a lookup failure must cost the custom tiers, not the
+    // whole turn.
+    let customProviderIds = [];
+    try {
+      const activeCustomProviders = await CustomOpenAIProviderService.getProvidersByUserId(userId);
+      customProviderIds = (activeCustomProviders || []).map((p) => p.id);
+    } catch (cpErr) {
+      console.warn('[Chat] Could not load custom providers for failover chain:', cpErr.message);
+    }
+
     // Phase 4: prefer the ACTIVE AGENT's own fallback chain when it has one
     // (fallbackEnabled). A coding agent pinned to Claude-Code should fail over
     // to ITS configured backups, not the user's global list. Only when the
@@ -935,6 +950,7 @@ async function universalChatHandler(req, res, context = {}) {
             model,
             fallbackEnabled: true,
             fallbackProviders: agentForFb.fallbackProviders,
+            customProviderIds,
           });
         }
       } catch (agErr) {
@@ -953,6 +969,7 @@ async function universalChatHandler(req, res, context = {}) {
           model,
           fallbackEnabled: fbSettings.fallbackEnabled,
           fallbackProviders: fbSettings.fallbackProviders,
+          customProviderIds,
         });
         if (providerChain.length > 1) {
           console.log('[Chat] Provider failover chain (user):', providerChain.map(t => `${t.provider}/${t.model || '(default model)'}`).join(' → '));

--- a/backend/src/services/OrchestratorService.js
+++ b/backend/src/services/OrchestratorService.js
@@ -12,7 +12,7 @@ import { createLlmClient } from './ai/LlmService.js';
 // 'provider_recovered' and clear the entry. Ephemeral, per-process, tiny.
 const __failoverMemory = new Map();
 import { createLlmAdapter, requiresResponsesApi } from './orchestrator/llmAdapters.js';
-import { buildProviderChain, runWithFallback } from './orchestrator/ProviderFallback.js';
+import { buildProviderChain, runWithFallback, createCustomProviderIdResolver } from './orchestrator/ProviderFallback.js';
 import CustomOpenAIProviderService from './ai/CustomOpenAIProviderService.js';
 import { computeCacheSavings } from '../utils/cacheSavings.js';
 import { recordLlmCall } from './execution/LedgerRecorder.js';
@@ -926,15 +926,15 @@ async function universalChatHandler(req, res, context = {}) {
     // ProviderRegistry, so buildProviderChain drops them unless we hand it the
     // user's active ids. createLlmAdapter already resolves such a provider at
     // call time, so a custom tier runs fine once it survives chain building.
-    // Its own try/catch: a lookup failure must cost the custom tiers, not the
-    // whole turn.
-    let customProviderIds = [];
-    try {
-      const activeCustomProviders = await CustomOpenAIProviderService.getProvidersByUserId(userId);
-      customProviderIds = (activeCustomProviders || []).map((p) => p.id);
-    } catch (cpErr) {
-      console.warn('[Chat] Could not load custom providers for failover chain:', cpErr.message);
-    }
+    //
+    // LAZY: this is a SQLite query on the per-turn hot path, and failover is
+    // off by default, so it must only be paid where a chain is actually built.
+    // Memoized, so the two call sites below cost one query, not two. Fails safe
+    // to [] = no custom tiers, never a broken turn.
+    const resolveCustomProviderIds = createCustomProviderIdResolver(
+      () => CustomOpenAIProviderService.getProvidersByUserId(userId),
+      (cpErr) => console.warn('[Chat] Could not load custom providers for failover chain:', cpErr.message),
+    );
 
     // Phase 4: prefer the ACTIVE AGENT's own fallback chain when it has one
     // (fallbackEnabled). A coding agent pinned to Claude-Code should fail over
@@ -950,7 +950,7 @@ async function universalChatHandler(req, res, context = {}) {
             model,
             fallbackEnabled: true,
             fallbackProviders: agentForFb.fallbackProviders,
-            customProviderIds,
+            customProviderIds: await resolveCustomProviderIds(),
           });
         }
       } catch (agErr) {
@@ -969,7 +969,7 @@ async function universalChatHandler(req, res, context = {}) {
           model,
           fallbackEnabled: fbSettings.fallbackEnabled,
           fallbackProviders: fbSettings.fallbackProviders,
-          customProviderIds,
+          customProviderIds: await resolveCustomProviderIds(),
         });
         if (providerChain.length > 1) {
           console.log('[Chat] Provider failover chain (user):', providerChain.map(t => `${t.provider}/${t.model || '(default model)'}`).join(' → '));

--- a/backend/src/services/ai/CustomOpenAIProviderService.js
+++ b/backend/src/services/ai/CustomOpenAIProviderService.js
@@ -12,8 +12,9 @@ class CustomOpenAIProviderService {
    */
   async testConnection(baseUrl, apiKey) {
     try {
-      // Normalize the base URL
-      let normalizedUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+      // Normalize the base URL (trim — trailing space → /v1%20/v1/models)
+      let normalizedUrl = String(baseUrl || '').trim();
+      normalizedUrl = normalizedUrl.endsWith('/') ? normalizedUrl.slice(0, -1) : normalizedUrl;
 
       // If the URL doesn't end with /v1, add it (for OpenAI-compatible APIs like LM Studio)
       if (!normalizedUrl.endsWith('/v1')) {
@@ -209,7 +210,7 @@ class CustomOpenAIProviderService {
 
     if (base_url) {
       updateFields.push('base_url = ?');
-      updateValues.push(base_url);
+      updateValues.push(String(base_url).trim());
     }
 
     // Allow updating API key (including setting it to null/empty if passed as empty string)
@@ -294,7 +295,8 @@ class CustomOpenAIProviderService {
     }
 
     // Normalize base URL - ensure it ends with /v1 for OpenAI compatibility
-    let normalizedBaseUrl = base_url.endsWith('/') ? base_url.slice(0, -1) : base_url;
+    let normalizedBaseUrl = String(base_url || '').trim();
+    normalizedBaseUrl = normalizedBaseUrl.endsWith('/') ? normalizedBaseUrl.slice(0, -1) : normalizedBaseUrl;
     if (!normalizedBaseUrl.endsWith('/v1')) {
       normalizedBaseUrl = `${normalizedBaseUrl}/v1`;
     }
@@ -342,7 +344,8 @@ class CustomOpenAIProviderService {
 
     try {
       // Normalize the base URL
-      let normalizedUrl = provider.base_url.endsWith('/') ? provider.base_url.slice(0, -1) : provider.base_url;
+      let normalizedUrl = String(provider.base_url || '').trim();
+      normalizedUrl = normalizedUrl.endsWith('/') ? normalizedUrl.slice(0, -1) : normalizedUrl;
 
       // If the URL doesn't end with /v1, add it (for OpenAI-compatible APIs like LM Studio)
       if (!normalizedUrl.endsWith('/v1')) {

--- a/backend/src/services/ai/CustomOpenAIProviderService.urlTrim.test.js
+++ b/backend/src/services/ai/CustomOpenAIProviderService.urlTrim.test.js
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
+
+/**
+ * Whitespace in a custom provider's base_url must never reach the wire.
+ *
+ * A base_url pasted with a trailing space produced a request to
+ * `…/v1%20/v1/models`: the space survived normalization, the `endsWith('/v1')`
+ * check then failed against `"…/v1 "`, so a SECOND `/v1` was appended, and the
+ * space was percent-encoded on the way out. The provider 404s and the only
+ * clue is a mangled URL in a log line.
+ *
+ * There are two halves to this and a fix that only does the first is not a
+ * fix: trimming on WRITE (create/update) protects new rows, but every row
+ * saved before the fix still has the space in the database. Reads must trim
+ * too, or existing providers stay broken until the user re-saves them by hand.
+ * `fetchModels` covers that case below.
+ */
+
+const fetchMock = vi.fn();
+vi.mock('node-fetch', () => ({ default: (...args) => fetchMock(...args) }));
+
+const { default: service } = await import('./CustomOpenAIProviderService.js');
+const { default: db } = await import('../../models/database/index.js');
+
+const USER_ID = 'trim-test-user';
+
+/** A models response shaped like the OpenAI /v1/models payload. */
+function okModels(ids = ['model-a']) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({ data: ids.map((id) => ({ id })) }),
+  };
+}
+
+/** The URL the service actually requested. */
+const requestedUrl = () => fetchMock.mock.calls[0][0];
+
+function insertRaw(id, baseUrl) {
+  return new Promise((resolve, reject) => {
+    db.run(
+      `INSERT INTO custom_openai_providers
+       (id, user_id, provider_name, base_url, api_key, is_active, created_at, updated_at)
+       VALUES (?, ?, ?, ?, NULL, 1, datetime('now'), datetime('now'))`,
+      [id, USER_ID, `legacy-${id}`, baseUrl],
+      (err) => (err ? reject(err) : resolve()),
+    );
+  });
+}
+
+beforeAll(async () => {
+  // custom_openai_providers.user_id is a FK onto users(id).
+  await new Promise((resolve, reject) => {
+    db.run(
+      `INSERT OR IGNORE INTO users (id, email, name) VALUES (?, ?, ?)`,
+      [USER_ID, 'trim-test@example.invalid', 'Trim Test'],
+      (err) => (err ? reject(err) : resolve()),
+    );
+  });
+});
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(okModels());
+});
+
+afterAll(async () => {
+  const run = (sql, params) =>
+    new Promise((resolve) => db.run(sql, params, () => resolve()));
+  await run('DELETE FROM custom_openai_providers WHERE user_id = ?', [USER_ID]);
+  await run('DELETE FROM users WHERE id = ?', [USER_ID]);
+});
+
+describe('testConnection — the URL that goes on the wire', () => {
+  it('does not percent-encode a trailing space into the path', async () => {
+    await service.testConnection('http://spark-4db0.local:8002/v1 ', null);
+    expect(requestedUrl()).toBe('http://spark-4db0.local:8002/v1/models');
+  });
+
+  it('reports the exact broken URL from the bug, so a regression is recognisable', async () => {
+    await service.testConnection('http://spark-4db0.local:8002/v1 ', null);
+    expect(requestedUrl()).not.toContain('%20');
+    expect(requestedUrl()).not.toContain('/v1/v1');
+  });
+
+  it('trims leading whitespace too', async () => {
+    await service.testConnection('  http://localhost:11434/v1', null);
+    expect(requestedUrl()).toBe('http://localhost:11434/v1/models');
+  });
+
+  it('still appends /v1 when the URL genuinely lacks it', async () => {
+    await service.testConnection('http://localhost:1234 ', null);
+    expect(requestedUrl()).toBe('http://localhost:1234/v1/models');
+  });
+
+  it('still strips a trailing slash', async () => {
+    await service.testConnection('http://localhost:1234/v1/', null);
+    expect(requestedUrl()).toBe('http://localhost:1234/v1/models');
+  });
+
+  it('trims a newline, the likeliest paste artifact of all', async () => {
+    await service.testConnection('http://spark-4db0.local:8002/v1\n', null);
+    expect(requestedUrl()).toBe('http://spark-4db0.local:8002/v1/models');
+  });
+
+  it('trims a tab', async () => {
+    await service.testConnection('\thttp://localhost:1234/v1\t', null);
+    expect(requestedUrl()).toBe('http://localhost:1234/v1/models');
+  });
+
+  it('returns a result instead of throwing when base_url is null', async () => {
+    // The `String(baseUrl || '')` guard is what buys this: the pre-fix code
+    // called .endsWith() straight on the argument and threw
+    // "Cannot read properties of null". It was caught by the surrounding
+    // try/catch, so the caller saw a TypeError message dressed up as a
+    // connection failure. The URL built here is relative ('/v1/models'), which
+    // node-fetch rejects as a non-absolute URL in production -- so this is
+    // still a failed test-connection, just not a type error.
+    await expect(service.testConnection(null, null)).resolves.toEqual(
+      expect.objectContaining({ success: expect.any(Boolean) }),
+    );
+  });
+});
+
+describe('createProvider — what gets persisted', () => {
+  it('stores the trimmed base_url', async () => {
+    const created = await service.createProvider(USER_ID, {
+      provider_name: 'spark-ling',
+      base_url: 'http://spark-4db0.local:8002/v1 ',
+    });
+    expect(created.base_url).toBe('http://spark-4db0.local:8002/v1');
+
+    const stored = await service.getProviderById(created.id, USER_ID);
+    expect(stored.base_url).toBe('http://spark-4db0.local:8002/v1');
+  });
+
+  it('still appends /v1 to a whitespace-padded URL that lacks it', async () => {
+    const created = await service.createProvider(USER_ID, {
+      provider_name: 'lm-studio',
+      base_url: ' http://localhost:1234 ',
+    });
+    expect(created.base_url).toBe('http://localhost:1234/v1');
+  });
+});
+
+describe('updateProvider — what gets persisted on edit', () => {
+  it('stores the trimmed base_url', async () => {
+    const created = await service.createProvider(USER_ID, {
+      provider_name: 'spark-qwen',
+      base_url: 'http://spark-4db0.local:8000/v1',
+    });
+
+    await service.updateProvider(created.id, USER_ID, {
+      base_url: 'http://spark-4db0.local:8001/v1 ',
+    });
+
+    const stored = await service.getProviderById(created.id, USER_ID);
+    expect(stored.base_url).toBe('http://spark-4db0.local:8001/v1');
+  });
+});
+
+describe('fetchModels — rows saved BEFORE the fix', () => {
+  it('heals a legacy row whose stored base_url still has a trailing space', async () => {
+    // Trimming on write cannot repair rows that are already in the database.
+    // This inserts the untrimmed value directly, exactly as the pre-fix
+    // createProvider would have left it.
+    const id = 'legacy-trailing-space';
+    await insertRaw(id, 'http://spark-4db0.local:8002/v1 ');
+
+    await service.fetchModels(id, USER_ID);
+
+    expect(requestedUrl()).toBe('http://spark-4db0.local:8002/v1/models');
+    expect(requestedUrl()).not.toContain('%20');
+  });
+});

--- a/backend/src/services/orchestrator/ProviderFallback.customProviders.wiring.test.mjs
+++ b/backend/src/services/orchestrator/ProviderFallback.customProviders.wiring.test.mjs
@@ -18,6 +18,11 @@ import { fileURLToPath } from 'url';
  * follow-ups) and each builds TWO chains (the agent's own chain, and the user's
  * global chain). All four must be fed, so this asserts on every call site
  * rather than on the presence of the feature somewhere in the file.
+ *
+ * The ids come from a SQLite query, and failover is OFF by default, so the
+ * lookup must also be LAZY: paid only where a chain is actually built, never
+ * once per turn regardless. That is a property of the call sites, not of the
+ * resolver, so it is asserted here too.
  */
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -44,6 +49,17 @@ describe.each(Object.entries(FILES))('custom-provider failover is wired into %s'
     expect(SRC).toMatch(/CustomOpenAIProviderService\.getProvidersByUserId\(/);
   });
 
+  it('resolves them through the shared lazy resolver', () => {
+    expect(SRC).toMatch(/createCustomProviderIdResolver\(/);
+  });
+
+  it('never awaits the lookup directly — that would query on every turn', () => {
+    // Failover is off for almost every user, so an unconditional
+    // `await …getProvidersByUserId(...)` buys a per-turn SQLite query that
+    // nothing consumes. The lookup must be wrapped in a thunk instead.
+    expect(SRC).not.toMatch(/await\s+CustomOpenAIProviderService\.getProvidersByUserId/);
+  });
+
   it('builds at least two chains (agent chain and user chain)', () => {
     expect(chainCallSites(SRC).length).toBeGreaterThanOrEqual(2);
   });
@@ -54,24 +70,21 @@ describe.each(Object.entries(FILES))('custom-provider failover is wired into %s'
     expect(missing).toEqual([]);
   });
 
-  it('resolves the ids BEFORE the first chain is built', () => {
-    const resolvedAt = SRC.indexOf('CustomOpenAIProviderService.getProvidersByUserId(');
-    const firstChain = SRC.indexOf('buildProviderChain({');
-    expect(resolvedAt).toBeGreaterThan(-1);
-    expect(firstChain).toBeGreaterThan(-1);
-    // Resolving after the chain is built would pass an always-empty list —
-    // every positional check above would still pass while the feature is dead.
-    expect(resolvedAt).toBeLessThan(firstChain);
+  it('awaits the resolver AT every call site, so the query follows the chain', () => {
+    // This is what makes it lazy in practice: the only place the ids are
+    // resolved is inside a branch that has already decided to build a chain.
+    const sites = chainCallSites(SRC);
+    const missing = sites.filter((s) => !/await\s+resolveCustomProviderIds\(\)/.test(s));
+    expect(missing).toEqual([]);
   });
 
-  it('fails safe: id resolution cannot break the turn', () => {
-    // A custom-provider lookup failure must degrade to "no custom tiers", not
-    // throw out of the turn. Both call sites already sit inside a try/catch
-    // that falls back to a single-tier chain; assert the lookup is inside one.
-    const resolvedAt = SRC.indexOf('CustomOpenAIProviderService.getProvidersByUserId(');
-    const tryBefore = SRC.lastIndexOf('try {', resolvedAt);
-    const catchAfter = SRC.indexOf('} catch', resolvedAt);
-    expect(tryBefore).toBeGreaterThan(-1);
-    expect(catchAfter).toBeGreaterThan(resolvedAt);
+  it('creates the resolver BEFORE the first chain is built', () => {
+    const createdAt = SRC.indexOf('createCustomProviderIdResolver(');
+    const firstChain = SRC.indexOf('buildProviderChain({');
+    expect(createdAt).toBeGreaterThan(-1);
+    expect(firstChain).toBeGreaterThan(-1);
+    // Creating it after the chain is built would leave the call sites
+    // referencing an undefined resolver.
+    expect(createdAt).toBeLessThan(firstChain);
   });
 });

--- a/backend/src/services/orchestrator/ProviderFallback.customProviders.wiring.test.mjs
+++ b/backend/src/services/orchestrator/ProviderFallback.customProviders.wiring.test.mjs
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * A positional source-contract test for custom-provider failover wiring.
+ *
+ * buildProviderChain() only admits a custom provider when the caller hands it
+ * that user's active custom-provider IDs. The unit tests prove the chain
+ * builder honours the argument; they prove nothing about whether the callers
+ * actually PASS it. Miss one call site and the failure is silent and specific:
+ * that path drops the custom tier with no error, so failover looks configured
+ * in the UI and never fires — which is exactly the bug this feature fixes,
+ * reintroduced one layer up.
+ *
+ * There are two independent turn paths (interactive chat and autonomous
+ * follow-ups) and each builds TWO chains (the agent's own chain, and the user's
+ * global chain). All four must be fed, so this asserts on every call site
+ * rather than on the presence of the feature somewhere in the file.
+ */
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const FILES = {
+  OrchestratorService: path.join(__dirname, '../OrchestratorService.js'),
+  AutonomousMessageService: path.join(__dirname, '../AutonomousMessageService.js'),
+};
+
+/** Every `buildProviderChain({ ... })` call in a source file. Args are flat. */
+function chainCallSites(src) {
+  return src.match(/buildProviderChain\(\{[^}]*\}\)/g) || [];
+}
+
+describe.each(Object.entries(FILES))('custom-provider failover is wired into %s', (name, file) => {
+  const SRC = fs.readFileSync(file, 'utf8');
+
+  it('imports CustomOpenAIProviderService', () => {
+    expect(SRC).toMatch(
+      /import\s+CustomOpenAIProviderService\s+from\s+'\.\.?\/(?:ai\/)?CustomOpenAIProviderService\.js'/
+    );
+  });
+
+  it('resolves the active custom provider ids for the user', () => {
+    expect(SRC).toMatch(/CustomOpenAIProviderService\.getProvidersByUserId\(/);
+  });
+
+  it('builds at least two chains (agent chain and user chain)', () => {
+    expect(chainCallSites(SRC).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('passes customProviderIds at EVERY buildProviderChain call site', () => {
+    const sites = chainCallSites(SRC);
+    const missing = sites.filter((s) => !s.includes('customProviderIds'));
+    expect(missing).toEqual([]);
+  });
+
+  it('resolves the ids BEFORE the first chain is built', () => {
+    const resolvedAt = SRC.indexOf('CustomOpenAIProviderService.getProvidersByUserId(');
+    const firstChain = SRC.indexOf('buildProviderChain({');
+    expect(resolvedAt).toBeGreaterThan(-1);
+    expect(firstChain).toBeGreaterThan(-1);
+    // Resolving after the chain is built would pass an always-empty list —
+    // every positional check above would still pass while the feature is dead.
+    expect(resolvedAt).toBeLessThan(firstChain);
+  });
+
+  it('fails safe: id resolution cannot break the turn', () => {
+    // A custom-provider lookup failure must degrade to "no custom tiers", not
+    // throw out of the turn. Both call sites already sit inside a try/catch
+    // that falls back to a single-tier chain; assert the lookup is inside one.
+    const resolvedAt = SRC.indexOf('CustomOpenAIProviderService.getProvidersByUserId(');
+    const tryBefore = SRC.lastIndexOf('try {', resolvedAt);
+    const catchAfter = SRC.indexOf('} catch', resolvedAt);
+    expect(tryBefore).toBeGreaterThan(-1);
+    expect(catchAfter).toBeGreaterThan(resolvedAt);
+  });
+});

--- a/backend/src/services/orchestrator/ProviderFallback.js
+++ b/backend/src/services/orchestrator/ProviderFallback.js
@@ -106,6 +106,43 @@ export function isKnownProvider(provider, customProviderIds) {
 }
 
 /**
+ * Build a lazy, memoized resolver for a user's active custom-provider ids.
+ *
+ * `buildProviderChain` needs these ids, but fetching them is a SQLite query and
+ * both turn paths call the builder at TWO sites (the agent chain and the user
+ * chain). Resolving eagerly costs a query on EVERY turn, including the common
+ * case where failover is switched off and no chain is ever built; resolving at
+ * each call site would instead double the query. Hence: call it only where a
+ * chain is actually being built, and pay at most once per turn.
+ *
+ * The fetch is INJECTED rather than imported so this module keeps its "no
+ * dependencies beyond ProviderRegistry" property and stays trivially testable.
+ *
+ * Fails safe: any lookup error resolves to [], which `buildProviderChain`
+ * treats as "no custom providers" — exactly the pre-feature behaviour. The
+ * failure is cached too, so a broken lookup is not retried at the second call
+ * site.
+ *
+ * @param {() => Promise<Array<{id: string}>>} fetchProviders
+ * @param {(err: Error) => void} [onError]  optional reporter for the caller's log
+ * @returns {() => Promise<string[]>}
+ */
+export function createCustomProviderIdResolver(fetchProviders, onError) {
+  let cache = null;
+  return async () => {
+    if (cache !== null) return cache;
+    try {
+      const providers = await fetchProviders();
+      cache = (providers || []).map((p) => p.id);
+    } catch (err) {
+      if (typeof onError === 'function') onError(err);
+      cache = [];
+    }
+    return cache;
+  };
+}
+
+/**
  * Pick a usable model for a fallback tier. If the configured model is falsy or
  * doesn't belong to the provider's text-model set, fall back to the provider's
  * first text model. Returns null if the provider exposes no text models
@@ -364,6 +401,7 @@ export default {
   MAX_FALLBACKS,
   parseFallbackList,
   isKnownProvider,
+  createCustomProviderIdResolver,
   resolveTierModel,
   buildProviderChain,
   classifyFailure,

--- a/backend/src/services/orchestrator/ProviderFallback.js
+++ b/backend/src/services/orchestrator/ProviderFallback.js
@@ -79,11 +79,29 @@ export function parseFallbackList(raw) {
  * True if a provider key is known to the registry (case-insensitive).
  * Unknown providers would throw "Unsupported provider for LLM client factory"
  * in LlmService, so we filter them out of the chain up front.
+ *
+ * Custom OpenAI-compatible providers are keyed by UUID and live in the
+ * `custom_openai_providers` table, NOT in ProviderRegistry — so the registry
+ * lookup alone rejects them. `createLlmAdapter` already resolves them at
+ * runtime (llmAdapters.js: `CustomOpenAIProviderService.isCustomProvider`), so
+ * the only thing that ever blocked them as failover tiers was this check.
+ *
+ * That lookup is a DB call and this function is synchronous and on the hot path
+ * (every turn), so callers pass the user's active custom-provider IDs in
+ * instead. Omit the argument and behavior is exactly as before.
+ *
+ * @param {string} provider
+ * @param {Iterable<string>} [customProviderIds]  active custom provider UUIDs
  */
-export function isKnownProvider(provider) {
+export function isKnownProvider(provider, customProviderIds) {
   if (!provider || typeof provider !== 'string') return false;
-  const caps = ProviderRegistry.PROVIDER_CAPABILITIES || {};
   const lower = provider.toLowerCase();
+  if (customProviderIds) {
+    for (const id of customProviderIds) {
+      if (typeof id === 'string' && id.trim().toLowerCase() === lower) return true;
+    }
+  }
+  const caps = ProviderRegistry.PROVIDER_CAPABILITIES || {};
   return Object.keys(caps).some((k) => k.toLowerCase() === lower);
 }
 
@@ -124,26 +142,42 @@ export function resolveTierModel(provider, model) {
  * @param {string} args.model            primary model
  * @param {boolean} args.fallbackEnabled
  * @param {string|Array} args.fallbackProviders  raw column value or array
+ * @param {Iterable<string>} [args.customProviderIds]  active custom provider
+ *   UUIDs for this user. Omit and custom providers are dropped from the chain
+ *   (the pre-existing behavior).
  * @returns {{provider: string, model: string|null, tier: number, primary: boolean}[]}
  */
-export function buildProviderChain({ provider, model, fallbackEnabled, fallbackProviders }) {
+export function buildProviderChain({ provider, model, fallbackEnabled, fallbackProviders, customProviderIds }) {
   const primaryProviderLc = String(provider || '').toLowerCase();
   const chain = [{ provider, model: model || null, tier: 0, primary: true }];
   const seen = new Set([`${primaryProviderLc}::${model || ''}`]);
 
   if (!fallbackEnabled) return chain;
 
+  const customIdSet = new Set(
+    (customProviderIds ? Array.from(customProviderIds) : [])
+      .filter((id) => typeof id === 'string' && id.trim())
+      .map((id) => id.trim().toLowerCase())
+  );
+
   const candidates = parseFallbackList(fallbackProviders);
   let tier = 1;
   for (const cand of candidates) {
     if (chain.length - 1 >= MAX_FALLBACKS) break;
-    if (!isKnownProvider(cand.provider)) continue;
+    if (!isKnownProvider(cand.provider, customIdSet)) continue;
 
     // Never fail over to the SAME provider we just exhausted — a different
     // model on the same down provider will almost certainly fail too.
     if (cand.provider.toLowerCase() === primaryProviderLc) continue;
 
+    const isCustom = customIdSet.has(cand.provider.toLowerCase());
     const usableModel = resolveTierModel(cand.provider, cand.model);
+
+    // A custom provider has no static model list to draw a default from, so an
+    // unset model would reach OpenAiLikeAdapter as `model: null` and fail the
+    // request at runtime. Drop the tier instead of shipping a dead one.
+    if (isCustom && !usableModel) continue;
+
     const key = `${cand.provider.toLowerCase()}::${usableModel || ''}`;
     if (seen.has(key)) continue;
     seen.add(key);

--- a/backend/src/services/orchestrator/ProviderFallback.test.mjs
+++ b/backend/src/services/orchestrator/ProviderFallback.test.mjs
@@ -246,3 +246,99 @@ describe('ProviderFallback.buildProviderChain — custom providers', () => {
     expect(c.length).toBe(1);
   });
 });
+
+/**
+ * Resolving the custom-provider ids without paying for them.
+ *
+ * The ids come from a SQLite query, and both turn paths need them at TWO call
+ * sites (the agent chain and the user chain). Resolving eagerly costs a query
+ * on EVERY turn -- including the overwhelmingly common case where failover is
+ * switched off entirely and no chain is ever built. Resolving at each call site
+ * instead would double the query when both paths are considered.
+ *
+ * So: lazy AND memoized. The fetch is injected rather than imported so this
+ * module keeps its "no dependencies beyond ProviderRegistry" property and
+ * stays trivially unit-testable.
+ */
+describe('ProviderFallback.createCustomProviderIdResolver', () => {
+  it('does not touch the database until it is actually called', async () => {
+    let calls = 0;
+    PF.createCustomProviderIdResolver(async () => { calls += 1; return []; });
+    // Merely creating the resolver must not query -- that is the entire point
+    // when failover is disabled and no chain is built.
+    expect(calls).toBe(0);
+  });
+
+  it('queries once when invoked', async () => {
+    let calls = 0;
+    const resolve = PF.createCustomProviderIdResolver(async () => {
+      calls += 1;
+      return [{ id: CUSTOM_ID }];
+    });
+    await expect(resolve()).resolves.toEqual([CUSTOM_ID]);
+    expect(calls).toBe(1);
+  });
+
+  it('memoizes across call sites — two chains cost one query', async () => {
+    let calls = 0;
+    const resolve = PF.createCustomProviderIdResolver(async () => {
+      calls += 1;
+      return [{ id: CUSTOM_ID }, { id: OTHER_CUSTOM_ID }];
+    });
+    const first = await resolve();
+    const second = await resolve();
+    expect(calls).toBe(1);
+    expect(second).toEqual(first);
+  });
+
+  it('maps rows to bare ids', async () => {
+    const resolve = PF.createCustomProviderIdResolver(async () => [
+      { id: CUSTOM_ID, provider_name: 'spark-ling', base_url: 'http://x/v1' },
+    ]);
+    await expect(resolve()).resolves.toEqual([CUSTOM_ID]);
+  });
+
+  it('fails safe to [] when the lookup throws', async () => {
+    // A custom-provider lookup failure must cost the custom tiers, never the
+    // turn. buildProviderChain treats [] as "no custom providers", which is
+    // exactly the pre-feature behaviour.
+    const resolve = PF.createCustomProviderIdResolver(async () => {
+      throw new Error('SQLITE_BUSY');
+    });
+    await expect(resolve()).resolves.toEqual([]);
+  });
+
+  it('does not retry a failed lookup on the second call site', async () => {
+    let calls = 0;
+    const resolve = PF.createCustomProviderIdResolver(async () => {
+      calls += 1;
+      throw new Error('SQLITE_BUSY');
+    });
+    await resolve();
+    await resolve();
+    expect(calls).toBe(1);
+  });
+
+  it('reports the failure to the caller-supplied handler', async () => {
+    const seen = [];
+    const resolve = PF.createCustomProviderIdResolver(
+      async () => { throw new Error('SQLITE_BUSY'); },
+      (err) => seen.push(err.message),
+    );
+    await resolve();
+    expect(seen).toEqual(['SQLITE_BUSY']);
+  });
+
+  it('tolerates a null result from the fetcher', async () => {
+    const resolve = PF.createCustomProviderIdResolver(async () => null);
+    await expect(resolve()).resolves.toEqual([]);
+  });
+
+  it('caches an empty result too, so a user with no custom providers pays once', async () => {
+    let calls = 0;
+    const resolve = PF.createCustomProviderIdResolver(async () => { calls += 1; return []; });
+    await resolve();
+    await resolve();
+    expect(calls).toBe(1);
+  });
+});

--- a/backend/src/services/orchestrator/ProviderFallback.test.mjs
+++ b/backend/src/services/orchestrator/ProviderFallback.test.mjs
@@ -112,3 +112,137 @@ describe('ProviderFallback.runWithFallback', () => {
     expect(tier.provider).toBe('B');
   });
 });
+
+/**
+ * Custom OpenAI-compatible providers as failover tiers.
+ *
+ * Custom providers are keyed by UUID and are NOT in ProviderRegistry, so
+ * isKnownProvider() rejected them and buildProviderChain() silently dropped the
+ * tier — a chain configured via the API appeared saved but never fired.
+ *
+ * The registry lookup cannot be made async (buildProviderChain is sync and
+ * called on every turn), so callers pass the user's active custom-provider IDs
+ * in explicitly. Omitting the argument keeps the old behavior exactly.
+ */
+const CUSTOM_ID = '2d6a62f5-b7e9-4cfe-92cc-d4bede6e9202';
+const OTHER_CUSTOM_ID = '052c419d-1beb-42c9-81b8-f287685af155';
+
+describe('ProviderFallback.isKnownProvider — custom providers', () => {
+  it('accepts a custom provider id that is in the supplied list', () => {
+    expect(PF.isKnownProvider(CUSTOM_ID, [CUSTOM_ID])).toBe(true);
+  });
+  it('rejects a custom provider id that is NOT in the supplied list', () => {
+    expect(PF.isKnownProvider(CUSTOM_ID, [OTHER_CUSTOM_ID])).toBe(false);
+  });
+  it('rejects a custom provider id when no list is supplied (unchanged default)', () => {
+    expect(PF.isKnownProvider(CUSTOM_ID)).toBe(false);
+  });
+  it('accepts a Set as well as an Array', () => {
+    expect(PF.isKnownProvider(CUSTOM_ID, new Set([CUSTOM_ID]))).toBe(true);
+  });
+  it('matches custom ids case-insensitively', () => {
+    expect(PF.isKnownProvider(CUSTOM_ID.toUpperCase(), [CUSTOM_ID])).toBe(true);
+  });
+  it('still accepts built-in providers when a custom list is supplied', () => {
+    expect(PF.isKnownProvider('openai', [CUSTOM_ID])).toBe(true);
+  });
+});
+
+describe('ProviderFallback.buildProviderChain — custom providers', () => {
+  it('includes a custom provider tier when its id is supplied', () => {
+    const c = PF.buildProviderChain({
+      provider: 'Anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: CUSTOM_ID, model: 'ling-mini' }],
+      customProviderIds: [CUSTOM_ID],
+    });
+    expect(c.length).toBe(2);
+    expect(c[1].provider).toBe(CUSTOM_ID);
+    expect(c[1].tier).toBe(1);
+    expect(c[1].primary).toBe(false);
+  });
+
+  it('drops the custom tier when no ids are supplied (documents the old bug)', () => {
+    const c = PF.buildProviderChain({
+      provider: 'Anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: CUSTOM_ID, model: 'ling-mini' }],
+    });
+    expect(c.length).toBe(1);
+  });
+
+  it('keeps the configured model verbatim (custom providers have no static model list)', () => {
+    const c = PF.buildProviderChain({
+      provider: 'Anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: CUSTOM_ID, model: 'some-local-model:7b' }],
+      customProviderIds: [CUSTOM_ID],
+    });
+    expect(c[1].model).toBe('some-local-model:7b');
+  });
+
+  it('drops a custom tier with no model — there is no list to pick a default from', () => {
+    const c = PF.buildProviderChain({
+      provider: 'Anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: CUSTOM_ID, model: null }],
+      customProviderIds: [CUSTOM_ID],
+    });
+    expect(c.length).toBe(1);
+  });
+
+  it('never fails over from a custom primary to the same custom provider', () => {
+    const c = PF.buildProviderChain({
+      provider: CUSTOM_ID,
+      model: 'ling-mini',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: CUSTOM_ID, model: 'ling-large' }],
+      customProviderIds: [CUSTOM_ID],
+    });
+    expect(c.length).toBe(1);
+  });
+
+  it('supports a custom primary failing over to a built-in provider', () => {
+    const c = PF.buildProviderChain({
+      provider: CUSTOM_ID,
+      model: 'ling-mini',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: 'openai', model: 'gpt-4o' }],
+      customProviderIds: [CUSTOM_ID],
+    });
+    expect(c.length).toBe(2);
+    expect(c[0].provider).toBe(CUSTOM_ID);
+    expect(c[1].provider).toBe('openai');
+  });
+
+  it('preserves configured order across mixed custom and built-in tiers', () => {
+    const c = PF.buildProviderChain({
+      provider: 'Anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [
+        { provider: CUSTOM_ID, model: 'ling-mini' },
+        { provider: 'openai', model: 'gpt-4o' },
+        { provider: OTHER_CUSTOM_ID, model: 'deepseek-chat' },
+      ],
+      customProviderIds: [CUSTOM_ID, OTHER_CUSTOM_ID],
+    });
+    expect(c.map((t) => t.provider)).toEqual(['Anthropic', CUSTOM_ID, 'openai', OTHER_CUSTOM_ID]);
+    expect(c.map((t) => t.tier)).toEqual([0, 1, 2, 3]);
+  });
+
+  it('still drops a genuinely unknown provider even when custom ids are supplied', () => {
+    const c = PF.buildProviderChain({
+      provider: 'Anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: 'totally-fake-xyz', model: 'x' }],
+      customProviderIds: [CUSTOM_ID],
+    });
+    expect(c.length).toBe(1);
+  });
+});

--- a/frontend/src/views/Terminal/CenterPanel/screens/Agents/components/AgentDetails/tabs/ConfigureTab.customProviders.spec.js
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Agents/components/AgentDetails/tabs/ConfigureTab.customProviders.spec.js
@@ -1,0 +1,382 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import ConfigureTab from './ConfigureTab.vue';
+
+/**
+ * Custom OpenAI-compatible providers as PER-AGENT fallback tiers.
+ *
+ * The backend feeds customProviderIds to both the agent chain and the user
+ * chain (OrchestratorService / AutonomousMessageService), and the global
+ * dropdown (FallbackProviders.vue) already offers custom providers. This
+ * component is the remaining surface that writes a chain, and it still built
+ * its options from `aiProviders` alone — the filteredProviders getter, which
+ * returns state.providers, i.e. built-ins only.
+ *
+ * Two rules make this NOT a copy of the global editor:
+ *
+ *   1. The model select here offers an explicit { value: '', label: 'Provider
+ *      default' } option. That is a valid choice for a built-in (the chain
+ *      builder substitutes the provider's first text model) and an invalid one
+ *      for a custom provider (no static model list, so buildProviderChain drops
+ *      the tier). Offering it to a custom provider invites the user to build a
+ *      tier that silently never fires.
+ *   2. The PRIMARY provider select must not change. Its option values are
+ *      display names, so a custom provider would render as a raw UUID.
+ *
+ * `<script setup>` does not expose internals on wrapper.vm, so these tests
+ * assert on what the rendered BaseSelects are actually handed and on the
+ * emitted save payload — which is the real contract anyway.
+ */
+
+const SPARK_LING = '2d6a62f5-b7e9-4cfe-92cc-d4bede6e9202';
+const SPARK_QWEN = '56515f9f-92ca-4456-b9cf-72bfdc30277e';
+
+/** Records the props each select was handed, addressable by its id. */
+const BaseSelectStub = {
+  name: 'BaseSelect',
+  props: ['modelValue', 'label', 'id', 'options', 'disabled', 'placeholder', 'maxHeight', 'selectClass', 'zIndex'],
+  emits: ['update:modelValue'],
+  template: '<div class="base-select-stub"></div>',
+};
+
+const ListWithSearchStub = {
+  name: 'ListWithSearch',
+  props: ['items', 'selectedItems', 'title'],
+  template: '<div class="list-stub"></div>',
+};
+
+const SimpleModalStub = {
+  name: 'SimpleModal',
+  template: '<div class="modal-stub"></div>',
+  methods: { showModal: () => Promise.resolve(false) },
+};
+
+function makeAgent(overrides = {}) {
+  return {
+    id: 'agent-1',
+    name: 'Test Agent',
+    description: '',
+    provider: 'Anthropic',
+    model: 'claude-opus-5',
+    fallbackEnabled: true,
+    fallbackProviders: [],
+    assignedTools: [],
+    assignedWorkflows: [],
+    assignedSkills: [],
+    ...overrides,
+  };
+}
+
+function makeStore({
+  providers = ['Anthropic', 'OpenAI', 'GrokAI'],
+  customProviders = [],
+  allModels = {},
+} = {}) {
+  const dispatched = [];
+  const store = createStore({
+    modules: {
+      aiProvider: {
+        namespaced: true,
+        state: () => ({ allModels, customProviders, selectedProvider: 'Anthropic' }),
+        getters: { filteredProviders: () => providers },
+        actions: {
+          fetchProviderModels: () => Promise.resolve([]),
+          fetchCustomProviders: () => Promise.resolve([]),
+        },
+      },
+    },
+  });
+  const realDispatch = store.dispatch.bind(store);
+  store.dispatch = (type, payload) => {
+    dispatched.push({ type, payload });
+    return realDispatch(type, payload);
+  };
+  return { store, dispatched };
+}
+
+async function mountTab({ agent = {}, ...storeOpts } = {}) {
+  const { store, dispatched } = makeStore(storeOpts);
+  const wrapper = mount(ConfigureTab, {
+    props: {
+      selectedAgent: makeAgent(agent),
+      availableTools: [],
+      availableSkills: [],
+      categoryOptions: [],
+    },
+    global: {
+      plugins: [store],
+      stubs: {
+        BaseSelect: BaseSelectStub,
+        ListWithSearch: ListWithSearchStub,
+        SimpleModal: SimpleModalStub,
+      },
+    },
+  });
+  await flushPromises();
+  return { wrapper, store, dispatched };
+}
+
+/** The options a given BaseSelect (addressed by its id) was rendered with. */
+function optionsOf(wrapper, id) {
+  const hit = wrapper.findAllComponents(BaseSelectStub).find((c) => c.props('id') === id);
+  if (!hit) throw new Error(`no BaseSelect rendered with id "${id}"`);
+  return hit.props('options');
+}
+
+function selectProp(wrapper, id, prop) {
+  const hit = wrapper.findAllComponents(BaseSelectStub).find((c) => c.props('id') === id);
+  if (!hit) throw new Error(`no BaseSelect rendered with id "${id}"`);
+  return hit.props(prop);
+}
+
+async function saveAndGetPayload(wrapper) {
+  await wrapper.find('.action-button.primary').trigger('click');
+  await flushPromises();
+  const events = wrapper.emitted('save-configuration');
+  return events[events.length - 1][0];
+}
+
+beforeEach(() => {
+  localStorage.setItem('token', 'test-token');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  localStorage.clear();
+});
+
+describe('ConfigureTab — custom providers in the per-agent fallback dropdown', () => {
+  it('offers an active custom provider as a fallback tier', async () => {
+    const { wrapper } = await mountTab({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+      agent: { fallbackProviders: [{ provider: '', model: '' }] },
+    });
+    const opts = optionsOf(wrapper, 'agentFallbackProvider0');
+    expect(opts).toContainEqual({ value: SPARK_LING, label: 'spark-ling' });
+  });
+
+  it('labels the custom option with its name, not its UUID', async () => {
+    const { wrapper } = await mountTab({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+      agent: { fallbackProviders: [{ provider: '', model: '' }] },
+    });
+    const opt = optionsOf(wrapper, 'agentFallbackProvider0').find((o) => o.value === SPARK_LING);
+    expect(opt.label).toBe('spark-ling');
+  });
+
+  it('leaves the PRIMARY provider dropdown alone', async () => {
+    // providerOptions values are display names; a custom provider there would
+    // render as a raw UUID and be saved as the agent's primary by that id.
+    const { wrapper } = await mountTab({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+    });
+    const values = optionsOf(wrapper, 'agentConfigProvider').map((o) => o.value);
+    expect(values).not.toContain(SPARK_LING);
+    expect(values).toContain('Anthropic');
+  });
+
+  it('still offers the built-in providers alongside the custom ones', async () => {
+    const { wrapper } = await mountTab({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+      agent: { provider: 'Anthropic', fallbackProviders: [{ provider: '', model: '' }] },
+    });
+    const values = optionsOf(wrapper, 'agentFallbackProvider0').map((o) => o.value);
+    expect(values).toContain('OpenAI');
+    expect(values).toContain(SPARK_LING);
+  });
+
+  it('excludes a custom provider that is the agent primary', async () => {
+    const { wrapper } = await mountTab({
+      customProviders: [
+        { id: SPARK_LING, provider_name: 'spark-ling' },
+        { id: SPARK_QWEN, provider_name: 'spark-qwen' },
+      ],
+      agent: { provider: SPARK_LING, fallbackProviders: [{ provider: '', model: '' }] },
+    });
+    const values = optionsOf(wrapper, 'agentFallbackProvider0').map((o) => o.value);
+    expect(values).not.toContain(SPARK_LING);
+    expect(values).toContain(SPARK_QWEN);
+  });
+
+  it('does not offer the same custom provider on two rows', async () => {
+    const { wrapper } = await mountTab({
+      customProviders: [
+        { id: SPARK_LING, provider_name: 'spark-ling' },
+        { id: SPARK_QWEN, provider_name: 'spark-qwen' },
+      ],
+      agent: {
+        fallbackProviders: [
+          { provider: SPARK_LING, model: 'ling-mini' },
+          { provider: '', model: '' },
+        ],
+      },
+    });
+    const values = optionsOf(wrapper, 'agentFallbackProvider1').map((o) => o.value);
+    expect(values).not.toContain(SPARK_LING);
+    expect(values).toContain(SPARK_QWEN);
+  });
+
+  it('keeps the row\'s own custom selection in its option list', async () => {
+    // Otherwise the select renders with a value absent from its options and
+    // shows blank, which reads as "my configured tier vanished".
+    const { wrapper } = await mountTab({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+      agent: { fallbackProviders: [{ provider: SPARK_LING, model: 'ling-mini' }] },
+    });
+    const values = optionsOf(wrapper, 'agentFallbackProvider0').map((o) => o.value);
+    expect(values).toContain(SPARK_LING);
+  });
+
+  it('enables "Add fallback" when only a custom provider is left to choose', async () => {
+    const { wrapper } = await mountTab({
+      providers: ['Anthropic'],
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+      agent: { provider: 'Anthropic', fallbackProviders: [] },
+    });
+    const addBtn = wrapper.find('.fallback-add');
+    expect(addBtn.exists()).toBe(true);
+    expect(addBtn.attributes('disabled')).toBeUndefined();
+  });
+});
+
+describe('ConfigureTab — model options for a custom fallback tier', () => {
+  it('does NOT offer "Provider default" for a custom provider', async () => {
+    // buildProviderChain drops a custom tier with no model, so this option
+    // would let the user configure a tier that can never fire.
+    const { wrapper } = await mountTab({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+      allModels: { [SPARK_LING]: ['ling-mini'] },
+      agent: { fallbackProviders: [{ provider: SPARK_LING, model: 'ling-mini' }] },
+    });
+    const values = optionsOf(wrapper, 'agentFallbackModel0').map((o) => o.value);
+    expect(values).not.toContain('');
+  });
+
+  it('still offers "Provider default" for a built-in provider', async () => {
+    const { wrapper } = await mountTab({
+      allModels: { OpenAI: ['gpt-4o'] },
+      agent: { fallbackProviders: [{ provider: 'OpenAI', model: '' }] },
+    });
+    const opts = optionsOf(wrapper, 'agentFallbackModel0');
+    expect(opts).toContainEqual({ value: '', label: 'Provider default' });
+  });
+
+  it('lists the custom provider\'s fetched models', async () => {
+    const { wrapper } = await mountTab({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+      allModels: { [SPARK_LING]: ['ling-mini', 'ling-large'] },
+      agent: { fallbackProviders: [{ provider: SPARK_LING, model: 'ling-mini' }] },
+    });
+    const values = optionsOf(wrapper, 'agentFallbackModel0').map((o) => o.value);
+    expect(values).toEqual(['ling-mini', 'ling-large']);
+  });
+
+  it('does not tell the user a custom tier will use a provider default', async () => {
+    const { wrapper } = await mountTab({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+      agent: { fallbackProviders: [{ provider: SPARK_LING, model: '' }] },
+    });
+    expect(selectProp(wrapper, 'agentFallbackModel0', 'placeholder')).not.toBe('Provider default');
+  });
+
+  it('fetches models for a custom fallback provider', async () => {
+    const { wrapper, dispatched } = await mountTab({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+      agent: { fallbackProviders: [{ provider: '', model: '' }] },
+    });
+    const select = wrapper
+      .findAllComponents(BaseSelectStub)
+      .find((c) => c.props('id') === 'agentFallbackProvider0');
+    select.vm.$emit('update:modelValue', SPARK_LING);
+    await flushPromises();
+    const call = dispatched.find(
+      (d) => d.type === 'aiProvider/fetchProviderModels' && d.payload?.provider === SPARK_LING,
+    );
+    expect(call).toBeTruthy();
+  });
+
+  it('loads the custom provider list on mount', async () => {
+    const { dispatched } = await mountTab({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+    });
+    expect(dispatched.some((d) => d.type === 'aiProvider/fetchCustomProviders')).toBe(true);
+  });
+});
+
+describe('ConfigureTab — saving a per-agent chain with custom tiers', () => {
+  it('saves a complete custom tier verbatim', async () => {
+    const { wrapper } = await mountTab({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+      allModels: { [SPARK_LING]: ['ling-mini'] },
+      agent: { fallbackProviders: [{ provider: SPARK_LING, model: 'ling-mini' }] },
+    });
+    const payload = await saveAndGetPayload(wrapper);
+    expect(payload.fallbackProviders).toEqual([{ provider: SPARK_LING, model: 'ling-mini' }]);
+  });
+
+  it('drops a custom tier with no model, because the backend would', async () => {
+    const { wrapper } = await mountTab({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+      agent: { fallbackProviders: [{ provider: SPARK_LING, model: '' }] },
+    });
+    const payload = await saveAndGetPayload(wrapper);
+    expect(payload.fallbackProviders).toEqual([]);
+  });
+
+  it('tells the user which custom tier was dropped', async () => {
+    // Dropping it silently is the same failure in a new place: the chain the
+    // user configured is not the chain that gets saved, and nothing says so.
+    // This component's channel for that is the terminal line it already emits
+    // for other user-facing errors.
+    const { wrapper } = await mountTab({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+      agent: { fallbackProviders: [{ provider: SPARK_LING, model: '' }] },
+    });
+    await saveAndGetPayload(wrapper);
+    const lines = (wrapper.emitted('add-terminal-line') || []).map((e) => e[0]).join('\n');
+    expect(lines).toMatch(/spark-ling/);
+    expect(lines).toMatch(/model/i);
+  });
+
+  it('says nothing when every tier is complete', async () => {
+    const { wrapper } = await mountTab({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+      allModels: { [SPARK_LING]: ['ling-mini'] },
+      agent: { fallbackProviders: [{ provider: SPARK_LING, model: 'ling-mini' }] },
+    });
+    await saveAndGetPayload(wrapper);
+    const lines = (wrapper.emitted('add-terminal-line') || []).map((e) => e[0]).join('\n');
+    expect(lines).not.toMatch(/spark-ling/);
+  });
+
+  it('still saves a built-in tier with no model as a provider default', async () => {
+    const { wrapper } = await mountTab({
+      agent: { fallbackProviders: [{ provider: 'OpenAI', model: '' }] },
+    });
+    const payload = await saveAndGetPayload(wrapper);
+    expect(payload.fallbackProviders).toEqual([{ provider: 'OpenAI', model: null }]);
+  });
+
+  it('keeps a mixed chain in configured order, minus the incomplete custom tier', async () => {
+    const { wrapper } = await mountTab({
+      customProviders: [
+        { id: SPARK_LING, provider_name: 'spark-ling' },
+        { id: SPARK_QWEN, provider_name: 'spark-qwen' },
+      ],
+      allModels: { [SPARK_LING]: ['ling-mini'] },
+      agent: {
+        fallbackProviders: [
+          { provider: SPARK_LING, model: 'ling-mini' },
+          { provider: 'OpenAI', model: 'gpt-4o' },
+          { provider: SPARK_QWEN, model: '' },
+        ],
+      },
+    });
+    const payload = await saveAndGetPayload(wrapper);
+    expect(payload.fallbackProviders).toEqual([
+      { provider: SPARK_LING, model: 'ling-mini' },
+      { provider: 'OpenAI', model: 'gpt-4o' },
+    ]);
+  });
+});

--- a/frontend/src/views/Terminal/CenterPanel/screens/Agents/components/AgentDetails/tabs/ConfigureTab.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Agents/components/AgentDetails/tabs/ConfigureTab.vue
@@ -115,7 +115,7 @@
                 v-model="row.model"
                 :options="fallbackModelOptions(row.provider)"
                 :disabled="!row.provider"
-                placeholder="Provider default"
+                :placeholder="fallbackModelPlaceholder(row.provider)"
                 maxHeight="200px"
               />
               <button type="button" class="fallback-remove" :aria-label="`Remove fallback ${index + 1}`" @click="removeFallback(index)">
@@ -284,7 +284,7 @@
 </template>
 
 <script setup>
-import { ref, watch, computed } from 'vue';
+import { ref, watch, computed, onMounted } from 'vue';
 import { useStore } from 'vuex';
 import BaseSelect from '@/views/Terminal/_components/BaseSelect.vue';
 import ListWithSearch from '@/views/Terminal/_components/ListWithSearch.vue';
@@ -374,32 +374,73 @@ const modelOptions = computed(() => [
   })),
 ]);
 
+// Custom OpenAI-compatible providers, keyed by UUID. They are candidates for
+// the FALLBACK chain only -- the primary select above renders its option values
+// as display names, so a custom provider would show there as a raw UUID.
+const customProviders = computed(() => store.state.aiProvider?.customProviders || []);
+const customProviderIds = computed(
+  () => new Set(customProviders.value.map((p) => String(p.id).toLowerCase())),
+);
+function isCustomProviderId(value) {
+  return !!value && customProviderIds.value.has(String(value).toLowerCase());
+}
+function customProviderName(id) {
+  const hit = customProviders.value.find((p) => String(p.id).toLowerCase() === String(id).toLowerCase());
+  return hit?.provider_name || id;
+}
+
+// Every provider that may serve as a fallback tier, as { value, label }. A
+// built-in is identified by its display name; a custom provider by its id, with
+// its friendly name as the label.
+const fallbackCandidates = computed(() => [
+  ...aiProviders.value.map((provider) => ({ value: provider, label: provider })),
+  ...customProviders.value
+    .filter((p) => p && p.id)
+    .map((p) => ({ value: p.id, label: p.provider_name || p.id })),
+]);
+
+const sameProvider = (a, b) => String(a || '').toLowerCase() === String(b || '').toLowerCase();
+
 function fallbackProviderOptions(index) {
   const primary = agentConfig.value.provider;
+  const own = agentConfig.value.fallbackProviders[index]?.provider;
   const chosenElsewhere = new Set(
     agentConfig.value.fallbackProviders
       .filter((_, rowIndex) => rowIndex !== index)
-      .map((entry) => entry.provider)
+      .map((entry) => String(entry.provider || '').toLowerCase())
       .filter(Boolean),
   );
-  return aiProviders.value
-    .filter((provider) => provider !== primary)
-    .filter((provider) => !chosenElsewhere.has(provider) || provider === agentConfig.value.fallbackProviders[index]?.provider)
-    .map((provider) => ({ value: provider, label: provider }));
+  return fallbackCandidates.value
+    .filter((option) => !sameProvider(option.value, primary))
+    .filter((option) => !chosenElsewhere.has(String(option.value).toLowerCase()) || sameProvider(option.value, own));
 }
 
 function fallbackModelOptions(provider) {
   if (!provider) return [];
-  return [
-    { value: '', label: 'Provider default' },
-    ...(store.state.aiProvider.allModels[provider] || []).map((model) => ({ value: model, label: model })),
-  ];
+  const models = (store.state.aiProvider.allModels[provider] || []).map((model) => ({ value: model, label: model }));
+  // "Provider default" is a real choice for a built-in: buildProviderChain
+  // substitutes the provider's first text model. A custom provider has no
+  // static model list, so the backend drops a modelless custom tier -- offering
+  // the option here would invite the user to build a tier that never fires.
+  if (isCustomProviderId(provider)) return models;
+  return [{ value: '', label: 'Provider default' }, ...models];
+}
+
+function fallbackModelPlaceholder(provider) {
+  if (provider && isCustomProviderId(provider)) {
+    return (store.state.aiProvider.allModels[provider] || []).length ? 'Select model' : 'No models found';
+  }
+  return 'Provider default';
 }
 
 const hasFallbackCandidates = computed(() => {
   const primary = agentConfig.value.provider;
-  const chosen = new Set(agentConfig.value.fallbackProviders.map((entry) => entry.provider).filter(Boolean));
-  return aiProviders.value.some((provider) => provider !== primary && !chosen.has(provider));
+  const chosen = new Set(
+    agentConfig.value.fallbackProviders.map((entry) => String(entry.provider || '').toLowerCase()).filter(Boolean),
+  );
+  return fallbackCandidates.value.some(
+    (option) => !sameProvider(option.value, primary) && !chosen.has(String(option.value).toLowerCase()),
+  );
 });
 
 function addFallback() {
@@ -431,6 +472,12 @@ watch(
     }
   },
 );
+
+// The fallback dropdown cannot list custom providers the store has never
+// loaded, and nothing guarantees a sibling screen fetched them first.
+onMounted(() => {
+  store.dispatch('aiProvider/fetchCustomProviders').catch(() => {});
+});
 
 watch(
   () => agentConfig.value.fallbackProviders.map((entry) => entry.provider),
@@ -526,6 +573,7 @@ const saveConfiguration = async () => {
       fallbackEnabled: agentConfig.value.fallbackEnabled,
       fallbackProviders: agentConfig.value.fallbackProviders
         .filter((entry) => entry.provider)
+        .filter((entry) => !(isCustomProviderId(entry.provider) && !entry.model))
         .slice(0, MAX_FALLBACKS)
         .map((entry) => ({ provider: entry.provider, model: entry.model || null })),
       toolAccessMode: agentConfig.value.toolAccessMode,
@@ -539,6 +587,18 @@ const saveConfiguration = async () => {
       autoRestart: agentConfig.value.autoRestart,
       maxRetries: agentConfig.value.maxRetries,
     };
+
+    // buildProviderChain drops a custom tier with no model, so saying nothing
+    // would persist a chain that differs from the one on screen.
+    const droppedCustom = agentConfig.value.fallbackProviders
+      .filter((entry) => entry.provider && isCustomProviderId(entry.provider) && !entry.model)
+      .map((entry) => customProviderName(entry.provider));
+    if (droppedCustom.length) {
+      emit(
+        'add-terminal-line',
+        `[Agents] Skipped fallback ${droppedCustom.join(', ')}: a custom provider needs an explicit model.`,
+      );
+    }
 
     emit('save-configuration', payload);
 

--- a/frontend/src/views/Terminal/CenterPanel/screens/Connectors/components/FallbackProviders.customProviders.spec.js
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Connectors/components/FallbackProviders.customProviders.spec.js
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import FallbackProviders from './FallbackProviders.vue';
+
+/**
+ * Custom OpenAI-compatible providers as user-global fallback tiers.
+ *
+ * The backend now admits a custom provider into the failover chain when the
+ * caller supplies the user's active custom-provider ids (see
+ * ProviderFallback.js). This component is the surface that WRITES that chain,
+ * and it filtered custom providers out entirely:
+ *
+ *   AI_PROVIDERS_WITH_API.includes(key) && connectedLower.includes(key)
+ *
+ * Custom providers are keyed by UUID so they are in neither list, and both
+ * conditions fail.
+ *
+ * These tests mount the component and assert on `providerOptionsFor()` — the
+ * function that actually feeds the dropdown — rather than grepping the source,
+ * so they fail if the option list is wrong for any reason, not just if a
+ * particular line of code goes missing.
+ */
+
+const SPARK_LING = '2d6a62f5-b7e9-4cfe-92cc-d4bede6e9202';
+const SPARK_QWEN = '56515f9f-92ca-4456-b9cf-72bfdc30277e';
+
+/** Records props so a test can read what the dropdown was actually handed. */
+const SelectStub = {
+  name: 'CustomSelect',
+  props: ['options', 'modelValue', 'placeholder'],
+  emits: ['option-selected'],
+  template: '<div class="select-stub"></div>',
+};
+
+const ButtonStub = {
+  name: 'BaseButton',
+  props: ['variant', 'size', 'disabled'],
+  template: '<button><slot /></button>',
+};
+
+function makeStore({
+  providers = ['Anthropic', 'OpenAI'],
+  customProviders = [],
+  connectedApps = [],
+  selectedProvider = 'Anthropic',
+  allModels = {},
+} = {}) {
+  const dispatched = [];
+  const store = createStore({
+    modules: {
+      aiProvider: {
+        namespaced: true,
+        state: () => ({ selectedProvider, allModels, customProviders }),
+        getters: { filteredProviders: (state) => providers },
+        actions: {
+          fetchCustomProviders: () => Promise.resolve([]),
+          fetchProviderModels: () => Promise.resolve([]),
+          fetchAnthropicModels: () => Promise.resolve([]),
+          fetchOpenAIModels: () => Promise.resolve([]),
+        },
+      },
+      appAuth: {
+        namespaced: true,
+        state: () => ({ connectedApps }),
+        actions: { fetchConnectedApps: () => Promise.resolve([]) },
+      },
+    },
+  });
+  const realDispatch = store.dispatch.bind(store);
+  store.dispatch = (type, payload) => {
+    dispatched.push({ type, payload });
+    return realDispatch(type, payload);
+  };
+  return { store, dispatched };
+}
+
+/** Settings responses for load(); PUT bodies are captured for assertions. */
+function mockFetch({ fallbackProviders = [], fallbackEnabled = true } = {}) {
+  const puts = [];
+  global.fetch = vi.fn((url, opts = {}) => {
+    if ((opts.method || 'GET').toUpperCase() === 'PUT') {
+      puts.push(JSON.parse(opts.body));
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }) });
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ fallbackEnabled, fallbackProviders }),
+    });
+  });
+  return puts;
+}
+
+async function mountComponent(storeOpts = {}, fetchOpts = {}) {
+  const { store, dispatched } = makeStore(storeOpts);
+  const puts = mockFetch(fetchOpts);
+  const wrapper = mount(FallbackProviders, {
+    global: {
+      plugins: [store],
+      stubs: { CustomSelect: SelectStub, BaseButton: ButtonStub },
+    },
+  });
+  await flushPromises();
+  return { wrapper, store, dispatched, puts };
+}
+
+beforeEach(() => {
+  localStorage.setItem('token', 'test-token');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  localStorage.clear();
+});
+
+describe('FallbackProviders — custom providers in the dropdown', () => {
+  it('offers an active custom provider as a fallback option', async () => {
+    const { wrapper } = await mountComponent({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+    });
+    const opts = wrapper.vm.providerOptionsFor(0);
+    expect(opts).toContainEqual({ label: 'spark-ling', value: SPARK_LING });
+  });
+
+  it('uses the provider id as the option value — the chain is matched on id, not name', async () => {
+    const { wrapper } = await mountComponent({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+    });
+    const opt = wrapper.vm.providerOptionsFor(0).find((o) => o.label === 'spark-ling');
+    expect(opt.value).toBe(SPARK_LING);
+  });
+
+  it('does not require a connectedApps entry for a custom provider', async () => {
+    // A custom provider's row in custom_openai_providers IS its connection —
+    // it carries base_url + api_key. connectedApps only tracks OAuth/API-key
+    // links for built-ins, so gating custom providers on it excludes them all.
+    const { wrapper } = await mountComponent({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+      connectedApps: [],
+    });
+    expect(wrapper.vm.providerOptionsFor(0).some((o) => o.value === SPARK_LING)).toBe(true);
+  });
+
+  it('still hides a built-in provider that is not connected', async () => {
+    const { wrapper } = await mountComponent({
+      providers: ['Anthropic', 'OpenAI'],
+      connectedApps: [],
+      selectedProvider: 'Anthropic',
+    });
+    expect(wrapper.vm.providerOptionsFor(0).some((o) => o.value === 'OpenAI')).toBe(false);
+  });
+
+  it('excludes the custom provider that is currently the default', async () => {
+    const { wrapper } = await mountComponent({
+      customProviders: [
+        { id: SPARK_LING, provider_name: 'spark-ling' },
+        { id: SPARK_QWEN, provider_name: 'spark-qwen' },
+      ],
+      selectedProvider: SPARK_LING,
+    });
+    const values = wrapper.vm.providerOptionsFor(0).map((o) => o.value);
+    expect(values).not.toContain(SPARK_LING);
+    expect(values).toContain(SPARK_QWEN);
+  });
+
+  it('does not offer the same custom provider twice across rows', async () => {
+    const { wrapper } = await mountComponent(
+      {
+        customProviders: [
+          { id: SPARK_LING, provider_name: 'spark-ling' },
+          { id: SPARK_QWEN, provider_name: 'spark-qwen' },
+        ],
+      },
+      { fallbackProviders: [{ provider: SPARK_LING, model: 'ling-mini' }] }
+    );
+    // Row 0 holds spark-ling; a second row must not be able to pick it again.
+    wrapper.vm.addRow();
+    const values = wrapper.vm.providerOptionsFor(1).map((o) => o.value);
+    expect(values).not.toContain(SPARK_LING);
+    expect(values).toContain(SPARK_QWEN);
+  });
+
+  it('passes the custom option through to the rendered dropdown', async () => {
+    const { wrapper } = await mountComponent(
+      { customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }] },
+      { fallbackProviders: [{ provider: SPARK_LING, model: 'ling-mini' }] }
+    );
+    const selects = wrapper.findAllComponents(SelectStub);
+    expect(selects.length).toBeGreaterThanOrEqual(1);
+    const values = selects[0].props('options').map((o) => o.value);
+    expect(values).toContain(SPARK_LING);
+  });
+});
+
+describe('FallbackProviders — models for a custom provider', () => {
+  it('loads models through fetchProviderModels, which routes custom ids correctly', async () => {
+    // PROVIDER_FETCH_ACTIONS is keyed by built-in display name, so a UUID finds
+    // no action and the model list stays empty forever.
+    const { wrapper, dispatched } = await mountComponent({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+    });
+    wrapper.vm.addRow();
+    await wrapper.vm.onProviderChange(0, SPARK_LING);
+    await flushPromises();
+    const call = dispatched.find((d) => d.type === 'aiProvider/fetchProviderModels');
+    expect(call).toBeTruthy();
+    expect(call.payload).toMatchObject({ provider: SPARK_LING });
+  });
+
+  it('fetches the custom provider list on mount', async () => {
+    // Without this the dropdown is empty on a fresh load of the Connectors
+    // screen unless some sibling component happened to populate the store.
+    const { dispatched } = await mountComponent({
+      customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+    });
+    expect(dispatched.some((d) => d.type === 'aiProvider/fetchCustomProviders')).toBe(true);
+  });
+});
+
+describe('FallbackProviders — saving a custom tier', () => {
+  it('saves a complete custom row verbatim', async () => {
+    const { wrapper, puts } = await mountComponent(
+      {
+        customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }],
+        allModels: { [SPARK_LING]: ['ling-mini'] },
+      },
+      { fallbackProviders: [{ provider: SPARK_LING, model: 'ling-mini' }] }
+    );
+    await wrapper.vm.save();
+    await flushPromises();
+    expect(puts[0].fallbackProviders).toEqual([{ provider: SPARK_LING, model: 'ling-mini' }]);
+  });
+
+  it('omits a custom row with no model, because the backend would drop it', async () => {
+    // buildProviderChain drops a custom tier with no model (no static model
+    // list to default from). Sending one anyway means the UI shows a tier that
+    // silently never fires — the exact failure this feature exists to remove.
+    const { wrapper, puts } = await mountComponent(
+      { customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }] },
+      { fallbackProviders: [{ provider: SPARK_LING, model: null }] }
+    );
+    await wrapper.vm.save();
+    await flushPromises();
+    expect(puts[0].fallbackProviders).toEqual([]);
+  });
+
+  it('explains why an incomplete custom row was dropped', async () => {
+    const { wrapper } = await mountComponent(
+      { customProviders: [{ id: SPARK_LING, provider_name: 'spark-ling' }] },
+      { fallbackProviders: [{ provider: SPARK_LING, model: null }] }
+    );
+    await wrapper.vm.save();
+    await flushPromises();
+    expect(wrapper.vm.statusMsg).toMatch(/spark-ling/);
+    expect(wrapper.vm.statusMsg).toMatch(/model/i);
+  });
+
+  it('still sends a built-in row with no model (provider default is valid there)', async () => {
+    const { wrapper, puts } = await mountComponent(
+      { providers: ['Anthropic', 'OpenAI'], connectedApps: ['openai'], selectedProvider: 'Anthropic' },
+      { fallbackProviders: [{ provider: 'OpenAI', model: null }] }
+    );
+    await wrapper.vm.save();
+    await flushPromises();
+    expect(puts[0].fallbackProviders).toEqual([{ provider: 'OpenAI', model: null }]);
+  });
+});

--- a/frontend/src/views/Terminal/CenterPanel/screens/Connectors/components/FallbackProviders.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Connectors/components/FallbackProviders.vue
@@ -37,7 +37,7 @@
             class="fb-select"
             :options="modelOptionsFor(row.provider)"
             :model-value="row.model"
-            :placeholder="modelsFor(row.provider).length ? 'Select model…' : (row.provider ? 'Provider default' : '—')"
+            :placeholder="modelPlaceholderFor(row.provider)"
             @option-selected="(opt) => onModelChange(idx, opt.value)"
           />
         </div>
@@ -118,8 +118,28 @@ export default {
       String(store.state.aiProvider?.selectedProvider || '').toLowerCase()
     );
 
+    // Custom OpenAI-compatible providers, keyed by UUID rather than by a
+    // registry key. They are deliberately NOT gated on connectedApps: that list
+    // tracks OAuth / API-key links for built-in providers, and a custom
+    // provider carries its own base_url and api_key in custom_openai_providers,
+    // so its presence there (is_active = 1) IS its connection. Gating on
+    // connectedApps would exclude every custom provider unconditionally.
+    const customProviders = computed(() => store.state.aiProvider?.customProviders || []);
+    const customProviderIds = computed(
+      () => new Set(customProviders.value.map((p) => String(p.id).toLowerCase()))
+    );
+    function isCustomProviderId(value) {
+      return !!value && customProviderIds.value.has(String(value).toLowerCase());
+    }
+    function customProviderName(id) {
+      const hit = customProviders.value.find(
+        (p) => String(p.id).toLowerCase() === String(id).toLowerCase()
+      );
+      return hit?.provider_name || id;
+    }
+
     const connectableProviders = computed(() => {
-      return providerNames.value
+      const builtIn = providerNames.value
         .filter((name) => {
           const key = resolveProviderKey(name);
           const lower = String(name).toLowerCase();
@@ -128,6 +148,13 @@ export default {
           return AI_PROVIDERS_WITH_API.includes(key) && connectedLower.value.includes(key);
         })
         .map((name) => ({ key: name, label: PROVIDER_DISPLAY_NAMES[name] || name }));
+
+      const custom = customProviders.value
+        .filter((p) => p && p.id)
+        .filter((p) => String(p.id).toLowerCase() !== defaultProviderLower.value)
+        .map((p) => ({ key: p.id, label: p.provider_name || p.id }));
+
+      return [...builtIn, ...custom];
     });
 
     function modelsFor(providerName) {
@@ -135,9 +162,29 @@ export default {
       return store.state.aiProvider?.allModels?.[providerName] || [];
     }
 
+    function modelPlaceholderFor(providerName) {
+      if (!providerName) return '—';
+      if (modelsFor(providerName).length) return 'Select model…';
+      // "Provider default" is true for a built-in (the chain builder falls back
+      // to its first text model) but a lie for a custom provider: there is no
+      // static model list, so the backend drops a modelless custom tier.
+      if (isCustomProviderId(providerName)) return 'No models found — check the endpoint';
+      return 'Provider default';
+    }
+
     async function ensureModels(providerName) {
       if (!providerName) return;
       if (modelsFor(providerName).length > 0) return;
+      // PROVIDER_FETCH_ACTIONS is keyed by built-in display name, so a custom
+      // UUID finds no action and the model list would stay empty forever.
+      // fetchProviderModels already routes custom ids to the per-provider
+      // /custom-providers/:id/models endpoint.
+      if (isCustomProviderId(providerName)) {
+        try {
+          await store.dispatch('aiProvider/fetchProviderModels', { provider: providerName });
+        } catch (e) { /* non-fatal */ }
+        return;
+      }
       const action = PROVIDER_FETCH_ACTIONS[providerName];
       if (!action) return;
       try { await store.dispatch(action); } catch (e) { /* non-fatal */ }
@@ -208,8 +255,17 @@ export default {
       saving.value = true;
       statusMsg.value = '';
       try {
+        // A custom tier with no model is dropped by buildProviderChain, so
+        // sending one would persist a tier the UI displays as configured and
+        // that can never fire. Drop it here instead and say so, rather than
+        // letting the two layers disagree silently.
+        const skipped = rows.value
+          .filter((r) => r.provider && isCustomProviderId(r.provider) && !r.model)
+          .map((r) => customProviderName(r.provider));
+
         const payload = rows.value
           .filter((r) => r.provider)
+          .filter((r) => !(isCustomProviderId(r.provider) && !r.model))
           .slice(0, MAX)
           .map((r) => ({ provider: r.provider, model: r.model || null }));
         const res = await fetch('/api/users/settings', {
@@ -224,8 +280,15 @@ export default {
           }),
         });
         if (!res.ok) throw new Error('HTTP ' + res.status);
-        statusOk.value = true;
-        statusMsg.value = 'Fallback providers saved.';
+        if (skipped.length) {
+          statusOk.value = false;
+          statusMsg.value =
+            `Saved, but skipped ${skipped.join(', ')}: a custom provider needs an ` +
+            'explicit model, so it was left out of the chain.';
+        } else {
+          statusOk.value = true;
+          statusMsg.value = 'Fallback providers saved.';
+        }
         dirty.value = false;
         await load();
       } catch (e) {
@@ -237,7 +300,10 @@ export default {
     }
 
     onMounted(async () => {
+      // Both lists feed the dropdown, and neither is guaranteed to have been
+      // loaded by a sibling component on a cold open of this screen.
       try { await store.dispatch('appAuth/fetchConnectedApps'); } catch (e) { /* ignore */ }
+      try { await store.dispatch('aiProvider/fetchCustomProviders'); } catch (e) { /* ignore */ }
       await load();
     });
 
@@ -245,6 +311,7 @@ export default {
       MAX,
       enabled, rows, dirty, saving, statusMsg, statusOk,
       connectableProviders, modelsFor, providerOptionsFor, modelOptionsFor, hasCandidates,
+      modelPlaceholderFor, isCustomProviderId,
       markDirty, addRow, removeRow, onProviderChange, onModelChange, save,
     };
   },


### PR DESCRIPTION
## The bug

Custom OpenAI-compatible providers could not be used as failover tiers, and the way they failed was worse than being unsupported: a chain configured through the API **saved successfully and then silently never fired**.

Custom providers are keyed by UUID and live in `custom_openai_providers`, not in `ProviderRegistry`. Two independent gates dropped them:

1. **Backend** — `isKnownProvider()` tests membership in `ProviderRegistry.PROVIDER_CAPABILITIES`, so `buildProviderChain()` hit `if (!isKnownProvider(cand.provider)) continue;` and discarded the tier with no error and no warning.
2. **Frontend** — `connectableProviders` required `AI_PROVIDERS_WITH_API.includes(key) && connectedApps.includes(key)`. A UUID is in neither list, so both conditions failed and custom providers never appeared in either fallback dropdown.

Demonstrated against the real module before any changes:

```
isKnownProvider("2d6a62f5-…") = false
isKnownProvider("openai")     = true

chain built from [custom, openai]:
  tier 0  claude-code / claude-opus-5   (primary)
  tier 1  openai / gpt-4o                    ← custom tier silently gone
```

The execution layer already supported these providers. `createLlmAdapter` resolves a custom provider *first* and returns `OpenAiLikeAdapter` (`llmAdapters.js`). Only the two validation gates blocked it — this looks like the failover feature having been built against the static registry, with custom providers never wired in.

## The fix

`buildProviderChain` is synchronous and runs on every turn, while the custom-provider lookup is a DB call. Rather than make the chain builder async, callers pass the user's active custom-provider IDs in:

```js
isKnownProvider(provider, customProviderIds?)
buildProviderChain({ …, customProviderIds })
```

**Omitting the argument preserves the previous behaviour exactly**, so no existing caller changes semantics.

A custom tier with **no model is dropped**. Built-ins fall back to `textModels[0]`; a custom provider has no static model list, so a null model would reach the adapter and fail at request time. Both UIs mirror that rule and *name* the dropped tier rather than discarding it quietly — otherwise the two layers disagree and the user sees a configured tier that cannot fire, which is the exact failure this PR removes.

### Call sites

There are two turn paths — interactive (`OrchestratorService`) and autonomous follow-ups (`AutonomousMessageService`) — and each builds **two** chains (the agent's own chain and the user's global chain). All four are fed. The ID lookup sits in its own `try/catch` so a failure costs the custom tiers, not the turn.

### UI

- **Connectors → Fallback AI Providers** (user-global chain)
- **Agents → Configure → Enable provider fallback** (per-agent chain, overrides the global one)

Two deliberate differences in the per-agent editor:

- Its model select offers `{ value: '', label: 'Provider default' }`. That is valid for a built-in and invalid for a custom provider, so it is omitted for custom providers.
- The **primary** provider select is unchanged. Its option values are display names, so a custom provider would render as a raw UUID and be saved as the agent's primary by that ID. Custom providers are fallback candidates only.

Custom providers are deliberately **not** gated on `connectedApps`: that list tracks OAuth / API-key links for built-ins, whereas a custom provider carries its own `base_url` and `api_key`, so its active row *is* its connection.

Also fixed as a consequence: `ensureModels` routed custom IDs through `PROVIDER_FETCH_ACTIONS`, which is keyed by built-in display name — a UUID found no action and the model list stayed empty forever. It now goes through `fetchProviderModels`, which already routes to `/custom-providers/:id/models`.

## Result

```
BEFORE:  tier 0  claude-code / claude-opus-5   (primary)
         tier 1  openai / gpt-4o

AFTER:   tier 0  claude-code / claude-opus-5   (primary)
         tier 1  2d6a62f5-… / ling-mini             ← custom provider
         tier 2  openai / gpt-4o
```

## Tests

Written test-first; each group was observed failing for the right reason before implementation.

| Suite | Count |
|---|---|
| `ProviderFallback.test.mjs` (chain builder + lazy resolver) | 24 new |
| `ProviderFallback.customProviders.wiring.test.mjs` | 16 |
| `FallbackProviders.customProviders.spec.js` | 13 |
| `ConfigureTab.customProviders.spec.js` | 20 |
| `CustomOpenAIProviderService.urlTrim.test.js` | 12 |

The wiring test is a source contract asserting **all four** call sites pass the IDs and resolve them before first use. Unit-testing the chain builder proves the logic; it proves nothing about whether the callers actually pass the argument — and missing one reintroduces the same silent-drop bug one layer up.

The UI tests mount the components and assert on the options each select is actually rendered with and on the emitted/PUT payload, rather than grepping source, so they fail if the dropdown or payload is wrong for any reason.

Every test was mutation-checked: each part of the feature was individually removed and the corresponding tests confirmed to fail (including an over-reach guard that catches custom providers leaking into the primary provider dropdown).

Full suites: frontend **199 files / 3634 tests, 0 failures**; backend **3333 passed**, with 2 pre-existing failures from files untracked in this repo (`docs/BYOH-ACP.md`, `buzz-cli-plugin`) and unrelated to this change.


---

## Also included: whitespace in `base_url`

Found while configuring a custom provider as a fallback tier, in the same code path, so it travels with this PR rather than separately.

A `base_url` pasted with a trailing space produced a request to `…/v1%20/v1/models`. The space survived normalization, so the `endsWith('/v1')` check failed against `"…/v1 "`, a **second** `/v1` was appended, and the space was percent-encoded on the way out. The provider 404s and the only clue is a mangled URL in a log line.

Trimming is applied at all four points a `base_url` is handled, which is two genuinely distinct halves:

- **Write** (`createProvider`, `updateProvider`) protects new and edited rows.
- **Read** (`testConnection`, `fetchModels`) repairs rows saved *before* this change. Trimming on write alone cannot heal a value already in the database, so existing providers would have stayed broken until the user happened to re-save them by hand.

`String(base_url || '')` also removes a TypeError path: the old code called `.endsWith()` straight on the argument, so a `null` threw `Cannot read properties of null`, which the surrounding `try/catch` then reported as a connection failure.

`createProvider` validates with `new URL(base_url)` *before* trimming. That remains correct — the WHATWG parser already strips leading and trailing spaces, so a padded URL was never rejected, it just wasn't cleaned.

The 12 tests assert the exact URL handed to `fetch` (no `%20`, no `/v1/v1`), the persisted value after real create and update round-trips against the test database, and a legacy row inserted with the untrimmed value to prove reads heal what writes cannot.

Mutation-checked in three directions, each producing a distinct failure set — full revert (9 failed), write-side trimming only (6 failed), read-side trimming only (3 failed) — which confirms the read half and the write half are independently covered rather than one masking the other.

