### PR TITLE
Make a run visible to every client, and survive a restart

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,116 @@ jobs:
       - name: Build frontend
         run: npm --prefix frontend run build
 
+  # The fifth gate, and the only one that runs a BROWSER.
+  #
+  # WHY IT EARNS A JOB
+  # ──────────────────
+  # The four jobs above mock, stub or read source. That is the right shape for
+  # almost everything, and it has a blind spot with a name: a run:started
+  # announcement was attached to correctly and then LOGGED from a promise that
+  # only settles when the run ends — so attaching to a ten-minute task printed
+  # nothing for ten minutes. Every one of the 3,600 unit tests passed. Nothing
+  # that mocks a store can see that, because nothing there has a clock, a
+  # console and a second tab. This suite has all three, and caught it on its
+  # first real run.
+  #
+  # WHY `--grep @ci` AND NOT `npm run test:e2e`
+  # ───────────────────────────────────────────
+  # tests/e2e holds eleven specs and ONE of them still cannot run here.
+  # Verified by reading what it actually does, not by its name:
+  #   async-tools          → spawns `npm start` (the whole Electron app), then
+  #                          sends "roll me a dice every minute for the next
+  #                          hour" and waits for an assistant reply and tool
+  #                          cards. That needs a REAL MODEL, which is slow,
+  #                          costly and nondeterministic — none of which a gate
+  #                          can carry. Its CSS selectors are all still valid;
+  #                          the model is the blocker. It also hardcodes
+  #                          localhost:3333, so running it on a developer's
+  #                          machine drives their live install.
+  # And ONE test is ungated on purpose rather than for lack of capability:
+  # workflows.spec.js's 'can create a new workflow' is skipped, because it is
+  # simply wrong about how creation works today — it only ever "passed" by not
+  # finding the button at all.
+  #
+  # (settings and tools used to be here too: they asserted that a thing
+  # labelled X was visible after clicking the thing labelled X, which the
+  # sidebar button itself satisfies. Measured, 'Settings' and 'Tools' appear as
+  # text on all four screens sampled, so neither check could go red. Both now
+  # assert something screen-specific and behavioural, and are gated.)
+  #
+  # Running the whole directory would therefore be permanently red, and this
+  # workflow exists precisely because a permanently-red job teaches everyone to
+  # ignore the ✗ (see the header, and the node-test job).
+  #
+  # The selector is a TAG rather than a filename so the gate extends itself: a
+  # future headless suite is covered by tagging @ci, not by remembering to edit
+  # this file. See the tag contract in cross-client-runs.spec.js for what a
+  # suite must be true of to claim it. When one of the nine above becomes
+  # runnable, tag it and it joins this job automatically.
+  #
+  # The obvious objection to selecting by tag is that a typo silently selects
+  # NOTHING and the gate goes green having run zero tests — the worst possible
+  # failure for a check. It cannot happen here: `playwright test --grep` with no
+  # matches prints "Error: No tests found" and exits 1. Verified, not assumed.
+  cross-client:
+    name: Browser suite (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Same --ignore-scripts reasoning as the backend job, and the same
+      # exception: the harness backend mounts the REAL OrchestratorRoutes, whose
+      # import chain loads backend/src/models/database at module scope. Without
+      # the binding every route module fails to load and the browser sees a dead
+      # server — a failure that looks like a product bug and is not.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Build the sqlite3 native binding
+        run: npm rebuild sqlite3
+      - name: Verify native bindings load
+        run: node -e "require('sqlite3'); console.log('sqlite3 binding OK')"
+
+      # Two different frontends are needed, for two different reasons.
+      #
+      # The cross-client harness page is served by VITE and imports real
+      # frontend modules, so it needs vue, vuex, socket.io-client and
+      # @vitejs/plugin-vue from the frontend tree.
+      - name: Install frontend dependencies
+        run: npm --prefix frontend ci --ignore-scripts
+
+      # The UI specs (app, navigation, agents, chat, workflows) drive the REAL
+      # app, which backend/server.js serves from frontend/dist. Without this
+      # the backend starts in "backend-only mode" and every one of them fails
+      # on a blank page — so the fixture checks for dist and says exactly that
+      # rather than letting them time out mysteriously.
+      - name: Build the frontend the UI specs drive
+        run: npm --prefix frontend run build
+
+      # Explicit, because nothing else fetches a browser: root postinstall sets
+      # PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1, and --ignore-scripts skips
+      # postinstall entirely. Chromium only — no spec here uses another engine,
+      # and the other two would be a download this job never opens.
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run the tagged browser suite
+        run: npx playwright test --grep @ci
+
+      # A browser failure that cannot be reproduced locally is worth very little
+      # without its trace. playwright.config.js already records one on the first
+      # retry and a screenshot on failure; this is what carries them off the
+      # runner. Only on failure, so a green run uploads nothing.
+      - name: Upload traces and screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: browser-suite-playwright-traces
+          path: test-results/
+          retention-days: 7
+
   # NOT a gate yet — this job reports; it does not block.
   #
   # tests/unit/** uses the node:test runner rather than vitest, so it was never

--- a/backend/server.js
+++ b/backend/server.js
@@ -289,6 +289,46 @@ dbReady.then(() => {
     console.error('[Scheduler] Failed to start:', err);
   });
 });
+
+// Restore turns that were still generating when the last process died.
+//
+// The sibling of the stale-run sweep in models/database/index.js, and for the
+// same reason: the orchestrator's finally block cannot fire across a restart.
+// The sweep marks those executions 'interrupted' so the UI stops lying about
+// them; this puts the ANSWER back, from the on-disk replay journal, into the
+// conversation where the user will look for it.
+//
+// Main process only, matching the sweep — the workflow child sets
+// AGNT_SKIP_DB_INIT=1 and has no runs of its own to recover.
+//
+// Deliberately not awaited: recovery reads files and writes a handful of rows,
+// and no request depends on it having finished. A failure inside is logged and
+// swallowed by the function itself.
+if (process.env.AGNT_SKIP_DB_INIT !== '1') {
+  dbReady.then(async () => {
+    try {
+      const { recoverJournaledRuns } = await import('./src/services/orchestrator/recoverJournaledRuns.js');
+      await recoverJournaledRuns();
+    } catch (err) {
+      console.error('[RunRecovery] Boot recovery failed (non-fatal):', err);
+    }
+
+    // Safety net for the journal. The event-driven throttle already gets every
+    // published event to disk within seconds; what it cannot do is retry a
+    // write that FAILED, because it only ever schedules work when the next
+    // event arrives — and during a long synchronous tool call none does. This
+    // sweeps for runs whose journal is behind, and skips silently when none is.
+    try {
+      const [{ startJournalHeartbeat }, { liveRuns }] = await Promise.all([
+        import('./src/services/orchestrator/runJournal.js'),
+        import('./src/services/orchestrator/activeRuns.js'),
+      ]);
+      startJournalHeartbeat(liveRuns);
+    } catch (err) {
+      console.warn('[RunJournal] Heartbeat not started (non-fatal):', err?.message || err);
+    }
+  });
+}
 // Version + update-check endpoints share a one-time cached package.json read
 // (PRD-084-R2 §0.5) — the app version cannot change without a restart, so
 // re-reading and re-parsing the file on every request was wasted I/O.
@@ -781,7 +821,32 @@ function startServer() {
     // process.exit and left an orphan holding this port.
     const gracefulShutdown = createGracefulShutdown({
       server,
-      drain: () => WorkflowProcessBridge.shutdown(),
+      drain: async () => {
+        // FIRST, and synchronously: write every in-flight turn to disk.
+        //
+        // SIGTERM is what `launchctl kickstart -k`, systemd, Ctrl-C and an app
+        // quit all send, so the ordinary restart is not a crash at all — the
+        // process is still alive and holds the only copy of a turn that has
+        // not reached conversation_logs yet. Saving it here is the difference
+        // between losing an answer and keeping it.
+        //
+        // Sync, and before the drain proper, because this path has a hard
+        // deadline: an awaited write can lose the race to process.exit.
+        try {
+          const [{ liveRuns }, { flushAllSync, stopJournalHeartbeat }] = await Promise.all([
+            import('./src/services/orchestrator/activeRuns.js'),
+            import('./src/services/orchestrator/runJournal.js'),
+          ]);
+          // Stop the heartbeat FIRST: an async write it started could still be
+          // in flight, and letting it race the synchronous flush below is the
+          // one way to have two writers for the same run at once.
+          stopJournalHeartbeat();
+          flushAllSync(liveRuns());
+        } catch (err) {
+          console.warn('[RunJournal] Shutdown flush skipped:', err?.message || err);
+        }
+        return WorkflowProcessBridge.shutdown();
+      },
     });
     process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
     // SIGINT too: Ctrl-C in a dev terminal produced exactly the same orphan.

--- a/backend/src/models/ContentOutputModel.js
+++ b/backend/src/models/ContentOutputModel.js
@@ -358,11 +358,72 @@ class ContentOutputModel {
     });
   }
 
+  /**
+   * THE CANONICAL ROW FOR A CONVERSATION.
+   *
+   * `conversation_id` has no unique constraint, and for most of this table's
+   * life nothing enforced one row per conversation: dedupe happened only on
+   * the output `id`, which lives in a single tab's memory. So a conversation
+   * opened in a second browser saved itself as a SECOND row, and the sidebar
+   * showed one chat three times.
+   *
+   * Saving now reuses this row (see RunService.saveOrUpdateContentOutput), so
+   * new duplicates are not created. Rows that already exist still need a
+   * deterministic WINNER, because `db.get` with no ORDER BY returns whichever
+   * row SQLite happens to visit first — which is how a client could open a
+   * 1KB stub of a conversation whose full 74KB transcript sat in the next row.
+   *
+   * Longest content wins. A transcript only grows during a conversation, so
+   * the longest row is the most complete one; `updated_at` would pick the most
+   * RECENTLY TOUCHED row, which can easily be a stub saved by a tab that
+   * joined at the end. Recency breaks ties.
+   */
   static findByConversationId(conversationId, userId) {
     return new Promise((resolve, reject) => {
-      db.get('SELECT * FROM content_outputs WHERE conversation_id = ? AND user_id = ?', [conversationId, userId], (err, output) => {
+      db.get(
+        `SELECT * FROM content_outputs
+         WHERE conversation_id = ? AND user_id = ?
+         ORDER BY LENGTH(COALESCE(content, '')) DESC, updated_at DESC, id ASC
+         LIMIT 1`,
+        [conversationId, userId],
+        (err, output) => {
+          if (err) reject(err);
+          else resolve(output);
+        }
+      );
+    });
+  }
+
+  /**
+   * The same canonical pick, WITHOUT the content column.
+   *
+   * Used on the save path purely to answer "does a row already exist, and is
+   * it mine?". `findOne` selects *, so using it there read an entire
+   * transcript (~0.5MB typical, ~28MB worst case on a real install) off disk
+   * on every ~5s autosave just to look at two identity columns.
+   */
+  static findMetaByConversationId(conversationId, userId) {
+    return new Promise((resolve, reject) => {
+      db.get(
+        `SELECT ${LIST_COLUMNS} FROM content_outputs
+         WHERE conversation_id = ? AND user_id = ?
+         ORDER BY LENGTH(COALESCE(content, '')) DESC, updated_at DESC, id ASC
+         LIMIT 1`,
+        [conversationId, userId],
+        (err, row) => {
+          if (err) reject(err);
+          else resolve(row || null);
+        }
+      );
+    });
+  }
+
+  /** Identity of one row — ownership check on the save path, no content read. */
+  static findIdentityById(id) {
+    return new Promise((resolve, reject) => {
+      db.get('SELECT id, user_id, conversation_id FROM content_outputs WHERE id = ?', [id], (err, row) => {
         if (err) reject(err);
-        else resolve(output);
+        else resolve(row || null);
       });
     });
   }

--- a/backend/src/models/database/index.js
+++ b/backend/src/models/database/index.js
@@ -354,6 +354,14 @@ function createTables() {
       createIndex(`CREATE INDEX IF NOT EXISTS idx_content_outputs_user_updated ON content_outputs(user_id, updated_at DESC)`);
       createIndex(`CREATE INDEX IF NOT EXISTS idx_content_outputs_group_id ON content_outputs(group_id)`);
       createIndex(`CREATE INDEX IF NOT EXISTS idx_content_outputs_channel ON content_outputs(user_id, channel_key)`);
+      // Saving a chat transcript now looks the conversation up by id to decide
+      // whether it already has a row (RunService.saveOrUpdateContentOutput),
+      // and that runs on every ~3s autosave of every streaming conversation.
+      // Unindexed, each one is a full scan of a table whose rows average ~0.5MB
+      // — and the lookup orders by LENGTH(content), so the scan would read
+      // those blobs too. With this index it touches only the handful of rows
+      // that share the conversation.
+      createIndex(`CREATE INDEX IF NOT EXISTS idx_content_outputs_conversation ON content_outputs(user_id, conversation_id)`);
 
       db.run(
         `CREATE TABLE IF NOT EXISTS user_data (

--- a/backend/src/routes/OrchestratorRoutes.js
+++ b/backend/src/routes/OrchestratorRoutes.js
@@ -6,8 +6,9 @@ import { authenticateToken } from './Middleware.js';
 import multer from 'multer';
 
 import universalChatHandler, { getAvailableTools } from '../services/OrchestratorService.js';
-import { attachSubscriber, cancelRun, getRunStatus } from '../services/orchestrator/activeRuns.js';
+import { attachSubscriber, cancelRun, getRunStatus, listRunsForUser } from '../services/orchestrator/activeRuns.js';
 import ConversationLogModel from '../models/ConversationLogModel.js';
+import ContentOutputModel from '../models/ContentOutputModel.js';
 
 const router = express.Router();
 
@@ -52,6 +53,54 @@ router.post('/artifact-chat', authenticateToken, upload.array('files'), universa
  * different intentions and now have different mechanisms.
  * ---------------------------------------------------------------------------
  */
+
+// What is running for ME?
+//
+// Declared before '/runs/:conversationId' — house rule for this codebase: a
+// literal segment goes above the parameter that could swallow it. Express
+// happens to distinguish these two by depth, but the rule is not conditional
+// on that, and the next literal added here might not be so lucky.
+//
+// This is the route that makes a run findable from a device that did not start
+// it. Every other run route needs a conversationId the caller must already
+// hold, and the only record of one was a localStorage marker — so a run
+// started in Chrome was invisible to Safari and to the Mac app, even though it
+// was alive and reattachable the entire time.
+router.get('/runs', authenticateToken, async (req, res) => {
+  const runs = listRunsForUser(req.user?.id);
+
+  // Enrich with the two facts the registry cannot know, because they belong to
+  // the saved transcript rather than to the run: which surface owns the
+  // conversation (channelKey — main list vs a workspace/artifact/widget
+  // channel), and what it is called.
+  //
+  // channelKey never reaches this process on the chat request, so deriving it
+  // from the stored row is the only authoritative answer available; the
+  // alternative is making every client guess, and a wrong guess reattaches a
+  // workspace turn into the main chat window.
+  //
+  // Best-effort by design: a conversation younger than its first autosave has
+  // no row yet. That is a null channelKey, not an error — the run is still
+  // perfectly reattachable, which is the point of the endpoint.
+  try {
+    const enriched = await Promise.all(
+      runs.map(async (run) => {
+        try {
+          const row = await ContentOutputModel.findMetaByConversationId(run.conversationId, req.user?.id);
+          return { ...run, channelKey: row?.channel_key || null, title: row?.title || null, outputId: row?.id || null };
+        } catch {
+          return { ...run, channelKey: null, title: null, outputId: null };
+        }
+      })
+    );
+    return res.json({ runs: enriched });
+  } catch (e) {
+    // The registry answer is the valuable half. Losing the decoration must not
+    // cost the caller the list itself.
+    console.warn('[Runs] listing could not be enriched:', e?.message || e);
+    return res.json({ runs: runs.map((r) => ({ ...r, channelKey: null, title: null, outputId: null })) });
+  }
+});
 
 // Is a turn still generating for this conversation?
 router.get('/runs/:conversationId', authenticateToken, (req, res) => {

--- a/backend/src/routes/OrchestratorRoutes.runs.test.js
+++ b/backend/src/routes/OrchestratorRoutes.runs.test.js
@@ -219,4 +219,99 @@ describe('status and cancel over HTTP', () => {
     const res = await req('GET', '/orchestrator/runs/nope');
     expect(res.json).toEqual({ active: false, known: false });
   });
+
+  /**
+   * The discovery route.
+   *
+   * Every test above names a conversation up front. That is the assumption
+   * this route breaks: a client that never started the run has no id to name,
+   * and the localStorage marker that used to be the only record is
+   * per-browser. So a task started in Chrome was invisible to Safari and to
+   * the Mac app — alive and reattachable the whole time, and undiscoverable.
+   */
+  describe('listing what is running for me', () => {
+    it('finds a run this client never started and knows nothing about', async () => {
+      startRun({ conversationId: 'c-elsewhere', userId: 'u1', chatType: 'orchestrator', userMessage: 'long task' });
+
+      const res = await req('GET', '/orchestrator/runs');
+
+      expect(res.status).toBe(200);
+      expect(res.json.runs).toHaveLength(1);
+      expect(res.json.runs[0]).toMatchObject({
+        conversationId: 'c-elsewhere',
+        chatType: 'orchestrator',
+        active: true,
+        userMessage: 'long task',
+      });
+    });
+
+    it('shows only MY runs', async () => {
+      startRun({ conversationId: 'c-mine-list', userId: 'u1' });
+      startRun({ conversationId: 'c-theirs-list', userId: 'someone-else' });
+
+      const res = await req('GET', '/orchestrator/runs', 'u1');
+
+      expect(res.json.runs.map((r) => r.conversationId)).toEqual(['c-mine-list']);
+    });
+
+    it('still lists a run that just FINISHED, flagged as ended', async () => {
+      // Retained runs are the "...or finished one" half of picking a task up
+      // from another device: a client arriving seconds after the last token
+      // must still be able to collect the answer, which is the whole reason
+      // activeRuns keeps ended runs around for a minute.
+      startRun({ conversationId: 'c-just-done', userId: 'u1' });
+      endRun('c-just-done', 'completed');
+
+      const res = await req('GET', '/orchestrator/runs');
+      const run = res.json.runs.find((r) => r.conversationId === 'c-just-done');
+
+      expect(run).toMatchObject({ active: false, ended: true, status: 'completed' });
+    });
+
+    it('orders newest first', async () => {
+      const older = startRun({ conversationId: 'c-older', userId: 'u1' });
+      older.startedAt = Date.now() - 60_000;
+      startRun({ conversationId: 'c-newer', userId: 'u1' });
+
+      const res = await req('GET', '/orchestrator/runs');
+
+      expect(res.json.runs.map((r) => r.conversationId)).toEqual(['c-newer', 'c-older']);
+    });
+
+    it('answers with an empty list, not an error, when nothing is running', async () => {
+      const res = await req('GET', '/orchestrator/runs');
+      expect(res.status).toBe(200);
+      expect(res.json.runs).toEqual([]);
+    });
+
+    it('carries the routing fields a client needs, even when unsaved', async () => {
+      // channelKey decides WHICH chat surface reattaches. A conversation too
+      // young to have been autosaved has no stored row to derive it from, and
+      // that must degrade to null rather than failing the whole listing — the
+      // run is still perfectly reattachable.
+      startRun({ conversationId: 'c-unsaved', userId: 'u1' });
+
+      const res = await req('GET', '/orchestrator/runs');
+      const run = res.json.runs.find((r) => r.conversationId === 'c-unsaved');
+
+      expect(run).toHaveProperty('channelKey', null);
+      expect(run).toHaveProperty('title', null);
+      expect(run).toHaveProperty('outputId', null);
+    });
+
+    it('is not reachable without authentication', async () => {
+      // The mocked middleware admits everyone, so this asserts the route is
+      // GUARDED rather than that the guard works (auth is covered elsewhere).
+      const source = await import('fs').then((fs) =>
+        fs.readFileSync(new URL('./OrchestratorRoutes.js', import.meta.url), 'utf8'));
+      expect(source).toMatch(/router\.get\(\s*'\/runs'\s*,\s*authenticateToken/);
+    });
+
+    it('is declared BEFORE the :conversationId route it could be swallowed by', async () => {
+      const source = await import('fs').then((fs) =>
+        fs.readFileSync(new URL('./OrchestratorRoutes.js', import.meta.url), 'utf8'));
+      expect(source.indexOf("router.get('/runs',")).toBeLessThan(
+        source.indexOf("router.get('/runs/:conversationId'"));
+    });
+  });
 });

--- a/backend/src/services/OrchestratorService.js
+++ b/backend/src/services/OrchestratorService.js
@@ -40,6 +40,7 @@ import db from '../models/database/index.js';
 import { getRawTextFromPDFBuffer, getRawTextFromDocxBuffer } from '../stream/utils.js';
 import { broadcastToUser, RealtimeEvents } from '../utils/realtimeSync.js';
 import { startRun, publish as publishToRun, endRun } from './orchestrator/activeRuns.js';
+import { persistTurnTranscript } from './orchestrator/persistTurnTranscript.js';
 import { isGlobalFrontendEvent } from './orchestrator/globalFrontendEvents.js';
 import * as ProviderRegistry from './ai/ProviderRegistry.js';
 import asyncToolQueue from './AsyncToolQueue.js';
@@ -1114,6 +1115,36 @@ async function universalChatHandler(req, res, context = {}) {
       return null;
     })(),
   });
+
+  // Tell this user's OTHER clients that a turn now exists to attach to.
+  //
+  // Everything else about resume is pull-based: a client discovers runs when it
+  // boots (GET /orchestrator/runs) or when it reconnects. A client that was
+  // already open and idle does neither, so a task started in one browser stayed
+  // invisible in another until someone reloaded it. This is the push half.
+  //
+  // Deliberately announces EXISTENCE, not content: the receiver reattaches over
+  // the SSE replay path and gets the whole turn. The chat:* delta mirror below
+  // cannot do that — it has no replay, so a client that arrives mid-run has
+  // already missed the beginning.
+  //
+  // Emitted right after the run is registered and BEFORE the first event, so
+  // there is no window in which a run is attachable but unannounced.
+  //
+  // originClientId is what stops the SENDER from attaching to its own run. For
+  // a new conversation the sender's local slot is still keyed by a temp id at
+  // this instant, so it cannot recognise the announcement by conversation id,
+  // and MIGRATE_CONVERSATION_ID would then overwrite its own live slot with the
+  // reattached one. Identity is carried explicitly rather than inferred from
+  // the order two transports happen to deliver in.
+  if (userId) {
+    broadcastToUser(userId, RealtimeEvents.RUN_STARTED, {
+      conversationId,
+      chatType,
+      startedAt: activeRun?.startedAt || Date.now(),
+      originClientId: req?.headers?.['x-agnt-client-id'] || null,
+    });
+  }
 
   // --- unfirehose/1.0 integration ---
   let sendEvent = rawSendEvent;
@@ -3679,6 +3710,31 @@ IMPORTANT: The image data is already available in the system context. You don't 
     if (logRaceResult === '__log_write_timeout__') {
       console.warn(`Conversation-log write for ${conversationId} exceeded ${LOG_WRITE_TIMEOUT_MS}ms — run already finalized; leaving the write to land in the background.`);
     }
+
+    // Mirror the finished turn into the conversation's SAVED row.
+    //
+    // Everything above persists the run for the system: conversation_logs for
+    // the model's own history, the execution record for the trace. None of it
+    // updates what the user sees in their conversation list — that row has
+    // exactly one writer, an HTTP endpoint a client must call. When the last
+    // client went away mid-answer, nothing ever called it again, so a complete
+    // answer on disk still showed as a truncated one on screen.
+    //
+    // `messages` is the sanitized provider history written to full_history on
+    // the line above, which is byte-for-byte what a reconnecting client
+    // receives from GET /orchestrator/conversations/:id — so this projects the
+    // same input through the same conversion the client would have applied.
+    //
+    // Fire-and-forget, and update-only: see persistTurnTranscript.js. The turn
+    // is already complete and already durable; mirroring it must never be able
+    // to delay or fail the response.
+    persistTurnTranscript({ conversationId, userId, providerMessages: messages })
+      .then((result) => {
+        if (result.written) console.log(`[TurnTranscript] Updated saved transcript for ${conversationId}`);
+      })
+      .catch((err) => {
+        console.warn('[TurnTranscript] Unexpected failure (turn unaffected):', err?.message || err);
+      });
 
     // Store conversation context for autonomous messages
     // This allows async tools to trigger AI responses later

--- a/backend/src/services/OrchestratorService.runAnnouncement.test.js
+++ b/backend/src/services/OrchestratorService.runAnnouncement.test.js
@@ -1,0 +1,90 @@
+/**
+ * A run must announce itself, and announce itself in time.
+ *
+ * WHY SOURCE ASSERTIONS
+ * ---------------------
+ * Same reason as OrchestratorService.streamLifetime and .turnTranscript: the
+ * property is about a CALL SITE inside a 3,700-line handler that no unit test
+ * drives end to end. The behaviour on the receiving end is covered by
+ * runResume.spec.js; what cannot be checked there is whether the server ever
+ * speaks.
+ *
+ * Four properties, each protecting a different way of being subtly useless:
+ *   1. it is announced at all;
+ *   2. AFTER the run is registered — announcing a run that cannot yet be
+ *      attached to invites a reattach that 204s, and the client gives up;
+ *   3. BEFORE the first event is emitted, so there is no window in which a run
+ *      is attachable but unannounced;
+ *   4. it carries the originating client's id, which is the only thing that
+ *      stops the sender attaching to its own run.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const CODE = fs.readFileSync(
+  fileURLToPath(new URL('./OrchestratorService.js', import.meta.url)),
+  'utf8',
+);
+
+const announceIdx = CODE.indexOf('RealtimeEvents.RUN_STARTED');
+
+describe('announcing a started run', () => {
+  it('broadcasts RUN_STARTED exactly once', () => {
+    expect(CODE.match(/RealtimeEvents\.RUN_STARTED/g) || []).toHaveLength(1);
+    expect(CODE.slice(announceIdx - 200, announceIdx)).toMatch(/broadcastToUser\(\s*userId,\s*$/m);
+  });
+
+  it('announces only after the run is registered', () => {
+    // Announced first, a client could reattach before activeRuns knows the
+    // conversation, get a 204, and conclude nothing is running.
+    expect(CODE.indexOf('activeRun = startRun(')).toBeLessThan(announceIdx);
+  });
+
+  it('announces before the first event reaches anyone', () => {
+    // The inverse gap: a run that is attachable but silent is one a client can
+    // only find by reloading, which is the bug being fixed.
+    expect(announceIdx).toBeLessThan(CODE.indexOf("sendEvent('conversation_started'"));
+  });
+
+  it('carries the conversation, its type, and who started it', () => {
+    const payload = CODE.slice(announceIdx, announceIdx + 400);
+    expect(payload).toMatch(/conversationId,/);
+    expect(payload).toMatch(/chatType,/);
+    // Without the origin, the sender cannot recognise its own announcement for
+    // a NEW conversation (its slot is still keyed by a temp id), reattaches to
+    // itself, and MIGRATE_CONVERSATION_ID then overwrites its own live slot.
+    expect(payload).toMatch(/originClientId:\s*req\?\.headers\?\.\['x-agnt-client-id'\]/);
+  });
+
+  it('does not announce for an unidentified user', () => {
+    // broadcastToUser targets room `user:<id>`; a null id would address a room
+    // nobody is in at best, and a shared one at worst.
+    expect(CODE.slice(announceIdx - 300, announceIdx)).toMatch(/if \(userId\) \{/);
+  });
+
+  it('sends no transcript content in the announcement', () => {
+    // Deliberately an existence notice, not a payload: the replay is the
+    // delivery mechanism. userMessage can be 20KB and would be broadcast to
+    // every client on every turn.
+    const payload = CODE.slice(announceIdx, announceIdx + 400);
+    expect(payload).not.toMatch(/userMessage/);
+    expect(payload).not.toMatch(/messages/);
+  });
+});
+
+describe('the event itself', () => {
+  it('is declared in the shared catalogue', async () => {
+    const { RealtimeEvents } = await import('../utils/realtimeSync.js');
+    expect(RealtimeEvents.RUN_STARTED).toBe('run:started');
+  });
+
+  it('is not silenced — one line per turn is signal, not noise', async () => {
+    const src = fs.readFileSync(
+      fileURLToPath(new URL('../utils/realtimeSync.js', import.meta.url)),
+      'utf8',
+    );
+    const silent = src.slice(src.indexOf('SILENT_BROADCAST_EVENTS'), src.indexOf(']);'));
+    expect(silent).not.toMatch(/run:started/);
+  });
+});

--- a/backend/src/services/OrchestratorService.turnTranscript.test.js
+++ b/backend/src/services/OrchestratorService.turnTranscript.test.js
@@ -1,0 +1,59 @@
+/**
+ * The turn-end transcript write must be WIRED, and wired harmlessly.
+ *
+ * persistTurnTranscript.test.js proves the write behaves. It cannot prove the
+ * orchestrator calls it — and an unreferenced module is a fix that exists only
+ * in the test suite. This is the same reason OrchestratorService.streamLifetime
+ * asserts on source: the property is about the CALL SITE, and the call site
+ * lives inside a 3,700-line handler that no unit test drives end to end.
+ *
+ * Three properties, each protecting a different failure:
+ *   1. it is called at all;
+ *   2. it is called with the SANITIZED provider history — the same array
+ *      written to full_history, not the raw pre-sanitize one, or the stored
+ *      transcript would contain orphaned tool calls the client's parser has to
+ *      cope with;
+ *   3. it is NOT awaited, so a slow or wedged write cannot delay the tail of a
+ *      turn the user is waiting on. The conversation-log write immediately
+ *      above it needed a 30s timeout race for exactly that reason; this one
+ *      avoids the problem rather than mitigating it.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const CODE = fs.readFileSync(
+  fileURLToPath(new URL('./OrchestratorService.js', import.meta.url)),
+  'utf8',
+);
+
+describe('turn-end transcript persistence', () => {
+  it('is imported and called exactly once', () => {
+    expect(CODE).toMatch(/import \{ persistTurnTranscript \} from '\.\/orchestrator\/persistTurnTranscript\.js'/);
+    expect(CODE.match(/persistTurnTranscript\(\{/g) || []).toHaveLength(1);
+  });
+
+  it('is handed the same history that goes into the conversation log', () => {
+    const call = CODE.slice(CODE.indexOf('persistTurnTranscript({'));
+    expect(call.slice(0, 200)).toMatch(/providerMessages:\s*messages/);
+
+    // `messages` is reassigned by the sanitizers; the call has to come after
+    // them or it stores a transcript the log itself would not accept.
+    expect(CODE.indexOf('sanitizeEmptyAssistantMessages(messages)'))
+      .toBeLessThan(CODE.indexOf('persistTurnTranscript({'));
+  });
+
+  it('is fire-and-forget, never awaited', () => {
+    const idx = CODE.indexOf('persistTurnTranscript({');
+    expect(CODE.slice(idx - 20, idx)).not.toMatch(/await\s*$/);
+    // A floating promise with no rejection handler surfaces as an
+    // unhandledRejection and can take the process down.
+    expect(CODE.slice(idx, idx + 700)).toMatch(/\.catch\(/);
+  });
+
+  it('runs after the conversation log, which owns the authoritative copy', () => {
+    // If this ever ran first, a crash between the two would leave the sidebar
+    // showing an answer the system has no record of.
+    expect(CODE.indexOf('const logRaceResult')).toBeLessThan(CODE.indexOf('persistTurnTranscript({'));
+  });
+});

--- a/backend/src/services/RunService.conversationIdentity.test.js
+++ b/backend/src/services/RunService.conversationIdentity.test.js
@@ -1,0 +1,244 @@
+/**
+ * One conversation is one row — no matter how many clients are saving it.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * A conversation's saved row was identified by the output `id` alone. That id
+ * is minted on the FIRST save and then remembered only in the saving tab's
+ * memory (`savedOutputId` in the chat store). So the same conversation open in
+ * a second browser, or in the Mac app, had no id to send — the save looked
+ * "new", minted another row, and the sidebar listed one chat three times.
+ *
+ * Observed on a real install: conversation 5f8b5337 had FOUR rows, two of them
+ * created one second apart by two clients autosaving at once, and a fourth
+ * carrying a DIFFERENT title because the client that wrote it joined midway
+ * and derived the name from the middle of the conversation.
+ *
+ * The fix keys identity on the conversation, which is the thing that is
+ * actually durable. These tests pin the rules that follow from that:
+ *
+ *   1. A save naming a conversation with no id ADOPTS that conversation's row.
+ *   2. Adoption is scoped to the caller — it can never touch another user's row.
+ *   3. Rows that already exist resolve DETERMINISTICALLY to the fullest one,
+ *      so a client can't open a 1KB stub of a 74KB conversation.
+ *   4. Non-conversation outputs (no conversationId) keep the old behaviour.
+ *
+ * Runs against a throwaway AGNT_HOME — never touches the user's database.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import fsp from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+// The save path broadcasts to connected clients; irrelevant here and it would
+// reach for a socket server that does not exist in this process.
+vi.mock('../utils/realtimeSync.js', () => ({
+  broadcastToUser: () => {},
+  RealtimeEvents: { CONTENT_CREATED: 'content_created', CONTENT_UPDATED: 'content_updated' },
+}));
+
+let db;
+let RunService;
+let ContentOutputModel;
+let TMP;
+const savedEnv = {};
+
+const USER = 'user-identity-1';
+const OTHER_USER = 'user-identity-2';
+
+const countRows = (conversationId) => new Promise((resolve, reject) => {
+  db.get(
+    'SELECT COUNT(*) AS n FROM content_outputs WHERE conversation_id = ?',
+    [conversationId],
+    (err, row) => (err ? reject(err) : resolve(row.n)),
+  );
+});
+
+const getRow = (id) => new Promise((resolve, reject) => {
+  db.get('SELECT * FROM content_outputs WHERE id = ?', [id], (err, row) => (err ? reject(err) : resolve(row)));
+});
+
+/** Drive the real Express handler and capture what it answered. */
+const save = (body, userId = USER) => new Promise((resolve, reject) => {
+  const res = {
+    json: (payload) => resolve(payload),
+    status: () => ({ json: (payload) => reject(new Error(`save failed: ${JSON.stringify(payload)}`)) }),
+  };
+  RunService.saveOrUpdateContentOutput({ body, user: { userId } }, res).catch(reject);
+});
+
+/** A transcript of `n` messages — stands in for a conversation growing. */
+const transcript = (n) => JSON.stringify({
+  messages: Array.from({ length: n }, (_, i) => ({ role: i % 2 ? 'assistant' : 'user', content: `m${i}` })),
+});
+
+beforeAll(async () => {
+  TMP = await fsp.mkdtemp(path.join(os.tmpdir(), 'agnt-identity-'));
+  for (const k of ['AGNT_HOME', 'USER_DATA_PATH', 'DOCKER_CONTAINER']) savedEnv[k] = process.env[k];
+  delete process.env.USER_DATA_PATH;
+  delete process.env.DOCKER_CONTAINER;
+  process.env.AGNT_HOME = TMP;
+
+  // Pre-create an empty agnt.db: the bootstrap treats "AGNT_HOME set but no
+  // agnt.db" as a fresh install that should inherit an orphaned database, and
+  // would try to copy the developer's real database into temp.
+  const dataDir = path.join(TMP, '.agnt', 'data');
+  await fsp.mkdir(dataDir, { recursive: true });
+  await fsp.writeFile(path.join(dataDir, 'agnt.db'), '');
+
+  const dbMod = await import('../models/database/index.js');
+  db = dbMod.default;
+  await dbMod.dbReady;
+
+  RunService = (await import('./RunService.js')).default;
+  ContentOutputModel = (await import('../models/ContentOutputModel.js')).default;
+
+  for (const uid of [USER, OTHER_USER]) {
+    await new Promise((resolve, reject) => {
+      db.run('INSERT INTO users (id, email) VALUES (?, ?)', [uid, `${uid}@test.local`], (err) => (err ? reject(err) : resolve()));
+    });
+  }
+}, 120000);
+
+afterAll(async () => {
+  await new Promise((r) => db.close(r));
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  await fsp.rm(TMP, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('a second client saving the same conversation', () => {
+  it('reuses the row instead of creating a duplicate — the reported bug', async () => {
+    const conversationId = 'conv-three-clients';
+
+    // Browser A: first save. No id yet, so this one legitimately creates.
+    const a = await save({
+      content: transcript(2), contentType: 'conversation', conversationId, title: 'run some long running task',
+    });
+
+    // Browser B and the Mac app: same conversation, NO id — they never saw A's
+    // response. This is exactly the payload that used to mint new rows.
+    const b = await save({ content: transcript(4), contentType: 'conversation', conversationId, title: 'run some long running task' });
+    const c = await save({ content: transcript(6), contentType: 'conversation', conversationId, title: 'run some long running task' });
+
+    expect(b.id).toBe(a.id);
+    expect(c.id).toBe(a.id);
+    expect(await countRows(conversationId)).toBe(1);
+  });
+
+  it('reports the adopted row as an UPDATE, not a creation', async () => {
+    const conversationId = 'conv-update-semantics';
+    const first = await save({ content: transcript(2), contentType: 'conversation', conversationId, title: 't' });
+    const second = await save({ content: transcript(3), contentType: 'conversation', conversationId, title: 't' });
+
+    // The message drives which realtime event fires. Announcing CONTENT_CREATED
+    // for a row that already exists would make every other tab insert a second
+    // sidebar entry for it — the same duplicate, one layer up.
+    expect(first.message).toMatch(/created/i);
+    expect(second.message).toMatch(/updated/i);
+  });
+
+  it('keeps the newest content — the adopting save is a real write', async () => {
+    const conversationId = 'conv-content-wins';
+    const { id } = await save({ content: transcript(2), contentType: 'conversation', conversationId, title: 't' });
+    await save({ content: transcript(9), contentType: 'conversation', conversationId, title: 't' });
+
+    expect(JSON.parse((await getRow(id)).content).messages).toHaveLength(9);
+  });
+
+  it('still honours an explicit id when the client has one', async () => {
+    const conversationId = 'conv-explicit-id';
+    const { id } = await save({ content: transcript(2), contentType: 'conversation', conversationId, title: 't' });
+    const again = await save({ id, content: transcript(3), contentType: 'conversation', conversationId, title: 't' });
+
+    expect(again.id).toBe(id);
+    expect(await countRows(conversationId)).toBe(1);
+  });
+});
+
+describe('the blast radius of adopting a row', () => {
+  it('never adopts another user\'s row', async () => {
+    const conversationId = 'conv-shared-id';
+    const mine = await save({ content: transcript(2), contentType: 'conversation', conversationId, title: 'mine' }, USER);
+    const theirs = await save({ content: transcript(2), contentType: 'conversation', conversationId, title: 'theirs' }, OTHER_USER);
+
+    // Same conversation id, two users, two rows. Adoption is scoped by user, so
+    // one person's autosave can never overwrite another's transcript.
+    expect(theirs.id).not.toBe(mine.id);
+    expect((await getRow(mine.id)).user_id).toBe(USER);
+    expect((await getRow(theirs.id)).user_id).toBe(OTHER_USER);
+  });
+
+  it('forks rather than writes when handed an id belonging to someone else', async () => {
+    const conversationId = 'conv-foreign-id';
+    const theirs = await save({ content: transcript(2), contentType: 'conversation', conversationId: 'conv-theirs-only', title: 'theirs' }, OTHER_USER);
+
+    // Pre-existing behaviour, deliberately preserved: saving onto a row you do
+    // not own produces a copy of your own, never a write to theirs.
+    const forked = await save({ id: theirs.id, content: transcript(5), contentType: 'conversation', conversationId, title: 'mine now' }, USER);
+
+    expect(forked.id).not.toBe(theirs.id);
+    expect(JSON.parse((await getRow(theirs.id)).content).messages).toHaveLength(2);
+  });
+
+  it('leaves non-conversation outputs alone — they have no conversation to key on', async () => {
+    // Two ordinary outputs with no conversationId must stay two rows; the new
+    // lookup must not collapse everything that shares a NULL conversation_id.
+    // (No workflowId: content_outputs.workflow_id is a FOREIGN KEY, and this
+    // test is about conversation identity, not about workflows existing.)
+    const one = await save({ content: '<p>one</p>', contentType: 'html' });
+    const two = await save({ content: '<p>two</p>', contentType: 'html' });
+
+    expect(two.id).not.toBe(one.id);
+  });
+});
+
+describe('resolving a conversation that ALREADY has duplicates', () => {
+  // Tom's install has these. New ones are no longer created, but until the old
+  // rows are cleared up, "which one do you get?" must not be luck.
+  const conversationId = 'conv-legacy-duplicates';
+  let stub;
+  let full;
+
+  beforeAll(async () => {
+    // Written directly through the model to reproduce the pre-fix state.
+    stub = 'legacy-stub';
+    full = 'legacy-full';
+    await ContentOutputModel.createOrUpdate(stub, USER, null, null, transcript(2), false, 'conversation', conversationId, 'stub');
+    await ContentOutputModel.createOrUpdate(full, USER, null, null, transcript(40), false, 'conversation', conversationId, 'full');
+    // The stub is touched LAST, so "most recent" would pick the wrong row.
+    await ContentOutputModel.createOrUpdate(stub, USER, null, null, transcript(2), false, 'conversation', conversationId, 'stub');
+  });
+
+  it('returns the fullest transcript, not whichever row SQLite reached first', async () => {
+    const row = await ContentOutputModel.findByConversationId(conversationId, USER);
+    expect(row.id).toBe(full);
+  });
+
+  it('makes the choice stable across repeated reads', async () => {
+    const ids = [];
+    for (let i = 0; i < 5; i++) {
+      ids.push((await ContentOutputModel.findByConversationId(conversationId, USER)).id);
+    }
+    expect(new Set(ids)).toEqual(new Set([full]));
+  });
+
+  it('converges further saves onto that same row, so duplicates stop multiplying', async () => {
+    const before = await countRows(conversationId);
+    const saved = await save({ content: transcript(50), contentType: 'conversation', conversationId, title: 'full' });
+
+    expect(saved.id).toBe(full);
+    expect(await countRows(conversationId)).toBe(before);
+  });
+
+  it('does not read the content column to decide ownership on the save path', async () => {
+    // findMetaByConversationId exists so a ~3s autosave doesn't drag a
+    // multi-megabyte transcript off disk just to read two identity columns.
+    const meta = await ContentOutputModel.findMetaByConversationId(conversationId, USER);
+    expect(meta.id).toBe(full);
+    expect(meta).not.toHaveProperty('content');
+  });
+});

--- a/backend/src/services/RunService.js
+++ b/backend/src/services/RunService.js
@@ -61,20 +61,35 @@ class RunService {
       const { id, content, workflowId, toolId, isShareable, contentType, conversationId, title, channelKey } = req.body;
       const userId = req.user.userId;
 
-      // Check if the output already exists
-      const existingOutput = id ? await ContentOutputModel.findOne(id) : null;
-      let isNewOutput = !existingOutput;
+      // WHICH ROW DOES THIS SAVE BELONG TO?
+      //
+      // Identity was the output `id` alone. That id is minted on a
+      // conversation's FIRST save and then remembered in the saving tab's
+      // memory (`savedOutputId` in the chat store) — nowhere else. A second
+      // browser, or the Mac app, holding the same conversation has no id to
+      // send, so this method saw `id: undefined`, concluded "new", and minted
+      // another row. Same conversation, three clients, three sidebar entries.
+      //
+      // A conversation is the durable identity here, so it is what we key on:
+      // when the caller names a conversation but no row, adopt the row that
+      // conversation already has. `conversationId` is set only for chat
+      // transcripts, so nothing else changes behaviour.
+      //
+      // Identity lookups only — neither read the content column (see
+      // ContentOutputModel.findIdentityById).
+      let existingOutput = id ? await ContentOutputModel.findIdentityById(id) : null;
 
-      let outputId;
-      if (isNewOutput) {
-        outputId = generateUUID(); // Generate a new UUID for the new output
-      } else if (existingOutput.user_id !== userId) {
-        // If the user is not the creator, create a new output with a new ID
-        outputId = generateUUID();
-        isNewOutput = true;
-      } else {
-        outputId = id; // Use the existing ID
+      // Ownership is checked BEFORE adopting: a row belonging to someone else
+      // is not a row we may write to, and falling through to the conversation
+      // lookup with another user's id would be a second chance to get that
+      // wrong. Scoped by userId, so it can only ever adopt the caller's row.
+      if (existingOutput && existingOutput.user_id !== userId) existingOutput = null;
+      else if (!existingOutput && conversationId) {
+        existingOutput = await ContentOutputModel.findMetaByConversationId(conversationId, userId);
       }
+
+      const isNewOutput = !existingOutput;
+      const outputId = isNewOutput ? generateUUID() : existingOutput.id;
 
       await ContentOutputModel.createOrUpdate(
         outputId,

--- a/backend/src/services/orchestrator/activeRuns.js
+++ b/backend/src/services/orchestrator/activeRuns.js
@@ -34,6 +34,14 @@
  * The whole buffer is freed when the run ends and its retention window lapses.
  */
 
+// The ONLY import in this file, and it earns its place: the replay log below
+// is the sole record of a turn until conversation_logs is written at turn END,
+// so a process that dies mid-turn used to destroy the answer outright rather
+// than merely losing the socket. runJournal mirrors the log to disk. It cannot
+// resume generation — the provider connection lives in this process — and its
+// header is explicit about that.
+import { journalRun, discardJournal } from './runJournal.js';
+
 /** Live runs, keyed by conversationId. */
 const runs = new Map();
 
@@ -145,6 +153,10 @@ export function publish(run, eventName, data) {
   if (!run || run.ended) return;
 
   appendToLog(run, eventName, data);
+
+  // Throttled, best-effort, never throws. Deliberately after appendToLog so a
+  // snapshot can only ever describe a log the in-memory copy already has.
+  journalRun(run);
 
   if (run.subscribers.size === 0) return;
   const frame = `event: ${eventName}\ndata: ${safeStringify(data)}\n\n`;
@@ -321,6 +333,13 @@ function finalizeRun(run, status) {
   run.endedAt = Date.now();
   run.endStatus = run.cancelled ? 'cancelled' : status;
 
+  // The turn is over, so its answer is already durable somewhere better:
+  // OrchestratorService writes conversation_logs AND the saved transcript
+  // before it calls endRun. Keeping the journal past this point would only buy
+  // a pointless recovery pass on the next boot. (Recovery is idempotent, so
+  // losing this race is harmless either way.)
+  discardJournal(run.conversationId);
+
   for (const res of run.subscribers) {
     try {
       writeFrame(res, 'run_ended', { conversationId: run.conversationId, status: run.endStatus });
@@ -358,6 +377,63 @@ export function getRunStatus(conversationId, userId) {
   };
 }
 
+/**
+ * Every run this user currently owns.
+ *
+ * WHY A LIST ENDPOINT HAS TO EXIST:
+ *
+ * Every other function here is keyed by conversationId — you can only ask
+ * about a run whose id you already hold. The only place that id was recorded
+ * is `inflightRuns.js`, which writes it to localStorage. localStorage is
+ * per-browser-profile, so the tab that STARTED a run could find it again, and
+ * nothing else could: not a second browser, not the Mac app. The run itself
+ * was alive and reattachable the whole time (that is the invariant at the top
+ * of this file) — it was simply undiscoverable from anywhere else.
+ *
+ * This is the missing question: "what is running for ME?", asked with no prior
+ * knowledge. Ended-but-retained runs are included and flagged rather than
+ * hidden, because a client that arrives inside RETAIN_ENDED_MS still wants the
+ * tail — the same reason the retention window exists at all.
+ *
+ * Deliberately NOT included: the replay log, the abort controller, the
+ * subscriber set. This answers "which conversations are live", and reattaching
+ * to one is a separate, explicit request.
+ */
+export function listRunsForUser(userId) {
+  if (userId == null) return [];
+  const out = [];
+  for (const run of runs.values()) {
+    if (run.userId == null || String(run.userId) !== String(userId)) continue;
+    out.push({
+      conversationId: run.conversationId,
+      chatType: run.chatType,
+      active: !run.ended,
+      ended: run.ended,
+      status: run.endStatus,
+      startedAt: run.startedAt,
+      endedAt: run.endedAt,
+      truncated: run.truncated,
+      userMessage: run.userMessage,
+    });
+  }
+  // Newest first: when a client shows "still running", the most recent turn is
+  // the one the user is most likely looking for.
+  out.sort((a, b) => b.startedAt - a.startedAt);
+  return out;
+}
+
+/**
+ * Every live run, for the shutdown flush.
+ *
+ * SIGTERM is the COMMON restart — `launchctl kickstart -k`, systemd, Ctrl-C, an
+ * app quit — and it is not a crash: the process still exists and can save what
+ * it has. Handing the runs out lets the shutdown path journal them in full
+ * rather than leaving whatever the last throttled snapshot caught.
+ */
+export function liveRuns() {
+  return [...runs.values()].filter((run) => !run.ended);
+}
+
 /** Test/introspection helper. */
 export function _runCount() {
   return runs.size;
@@ -378,4 +454,6 @@ export default {
   cancelRun,
   endRun,
   getRunStatus,
+  listRunsForUser,
+  liveRuns,
 };

--- a/backend/src/services/orchestrator/chatStreamReducer.mirror.js
+++ b/backend/src/services/orchestrator/chatStreamReducer.mirror.js
@@ -1,0 +1,561 @@
+/**
+ * chatStreamReducer.mirror.js — a VERBATIM copy of
+ * frontend/src/services/chatStreamReducer.js.
+ *
+ * WHY A COPY, AND NOT AN IMPORT
+ * -----------------------------
+ * The backend has to project a provider transcript into UI messages at turn
+ * end (see transcriptProjection.js), and that projection MUST agree with the
+ * one the client applies when it reconciles a dead stream. Two hand-written
+ * implementations of that conversion would drift, and the file being copied
+ * documents what drift costs: two user-visible bugs in a row, one rendering
+ * "[object Object]" for every tool-using turn, the next shattering every
+ * tool-using answer into three bubbles.
+ *
+ * Importing the original across the tree boundary is not available:
+ *   - The backend runtime does not HAVE frontend/src. Docker copies backend/,
+ *     scripts/ and frontend/dist; electron-builder ships backend/** and
+ *     frontend/dist/**. Neither carries frontend sources.
+ *   - The Docker frontend-build stage is the mirror image: WORKDIR /app/frontend
+ *     with only frontend/ copied in, so the frontend cannot reach out either.
+ * A shared/ directory would therefore have to be threaded through two
+ * Dockerfiles and the electron manifest — release plumbing that cannot be
+ * verified from a dev machine, for an internal refactor.
+ *
+ * So the code is duplicated and the AGREEMENT is made executable instead,
+ * which is this repo's existing answer to the same problem (see
+ * frontend/src/services/chatTranscriptParity.spec.js). Two tests hold it:
+ *   - chatStreamReducer.mirror.test.js asserts this file is byte-identical to
+ *     its source below the sentinel, so drift is impossible rather than
+ *     unlikely;
+ *   - transcriptProjection.parity.spec.js asserts the backend projection and
+ *     the client's own reconcile produce the same transcript.
+ *
+ * TO UPDATE: never edit below the sentinel. Re-copy the source file:
+ *   cat <header> frontend/src/services/chatStreamReducer.js > this file
+ * The mirror test prints this instruction when it fails.
+ */
+// --- MIRRORED SOURCE BELOW - DO NOT EDIT BY HAND ---------------------------
+/**
+ * chatStreamReducer — the single translation from orchestrator SSE events into
+ * the message model that MessageItem renders.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Every chat surface used to hand-roll this switch (Chat.vue, store/features/
+ * chat.js, chatUnified.js, the five *ChatContainer panels, and MobileChat).
+ * Each copy drifted from the wire protocol independently:
+ *
+ *   - The orchestrator sends `{ toolCall: { id, name, args } }`. MobileChat read
+ *     `data.name`, which is always undefined, so every tool chip on the phone
+ *     read the literal string "tool".
+ *   - Only the store built `contentParts`, so interleaved text/tool ordering —
+ *     the thing that makes a multi-tool answer readable — existed on desktop
+ *     only. Every other surface concatenated text and lost the ordering.
+ *
+ * A surface that hand-rolls the switch cannot inherit a protocol change. This
+ * module owns the semantics; chatStreamReducer.spec.js pins them, and
+ * mobileChatRender.spec.js pins that the mobile surface routes through here.
+ *
+ * The shape produced is exactly what MessageItem consumes:
+ *   { id, role, content, contentParts[], toolCalls[], reasoning, timestamp }
+ *
+ * Mutation is deliberately IN PLACE: callers hold the message inside a Vue ref
+ * (deeply reactive) or a Vuex state tree, and both track nested writes. Cloning
+ * per delta would allocate once per token.
+ */
+
+/** Event names this reducer understands. Anything else is ignored (and reported). */
+export const HANDLED_STREAM_EVENTS = Object.freeze([
+  'content_delta',
+  'reasoning_delta',
+  'tool_pending',
+  'tool_start',
+  'tool_end',
+  'final_content',
+  'error',
+  'done',
+]);
+
+/**
+ * Create an empty assistant message in the shape MessageItem renders.
+ * @param {{ id?: string, timestamp?: number }} [init]
+ */
+export function createAssistantMessage(init = {}) {
+  return {
+    id: init.id || `msg-asst-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    role: 'assistant',
+    content: '',
+    contentParts: [],
+    toolCalls: [],
+    reasoning: '',
+    timestamp: init.timestamp || Date.now(),
+  };
+}
+
+function ensureParts(message) {
+  if (!Array.isArray(message.contentParts)) message.contentParts = [];
+  return message.contentParts;
+}
+
+function ensureToolCalls(message) {
+  if (!Array.isArray(message.toolCalls)) message.toolCalls = [];
+  return message.toolCalls;
+}
+
+/**
+ * Append streamed text. Consecutive deltas coalesce into the trailing text part
+ * so a paragraph split across 400 tokens stays ONE part — otherwise every token
+ * becomes its own <div> and the markdown pipeline can never see a whole fence.
+ */
+function appendText(message, delta) {
+  if (typeof delta !== 'string' || delta === '') return false;
+  message.content = (message.content || '') + delta;
+  const parts = ensureParts(message);
+  const last = parts[parts.length - 1];
+  if (last && last.type === 'text') last.text += delta;
+  else parts.push({ type: 'text', text: delta });
+  return true;
+}
+
+/**
+ * Register a tool call and record its position in the interleave.
+ * Idempotent by id: `tool_pending` announces the call as soon as the model has
+ * named it, `tool_start` follows with the parsed arguments. Both events arrive
+ * for the same id, and only the first may push a content part.
+ */
+function upsertToolCall(message, incoming, defaultStatus) {
+  const id = incoming?.id;
+  if (!id) return false;
+  const toolCalls = ensureToolCalls(message);
+  const existing = toolCalls.find((tc) => tc.id === id);
+
+  if (existing) {
+    if (incoming.name !== undefined) existing.name = incoming.name;
+    if (incoming.args !== undefined) existing.args = incoming.args;
+    if (defaultStatus) existing.status = defaultStatus;
+    return true;
+  }
+
+  toolCalls.push({
+    id,
+    name: incoming.name || 'tool',
+    args: incoming.args,
+    status: defaultStatus || 'pending',
+  });
+  ensureParts(message).push({ type: 'tool_call', toolCallId: id });
+  return true;
+}
+
+function completeToolCall(message, incoming) {
+  const id = incoming?.id;
+  if (!id) return false;
+  const toolCalls = ensureToolCalls(message);
+  const index = toolCalls.findIndex((tc) => tc.id === id);
+  if (index === -1) {
+    // A tool that failed argument parsing emits tool_end with no preceding
+    // tool_start. Surface it rather than dropping the error on the floor.
+    upsertToolCall(message, { id, name: incoming.name }, 'pending');
+    return completeToolCall(message, incoming);
+  }
+  // Replace rather than mutate so identity changes for consumers that memoize
+  // on the tool-call object (MessageItem keys its expansion rows by index but
+  // recomputes its render signature from these fields).
+  toolCalls.splice(index, 1, {
+    ...toolCalls[index],
+    ...(incoming.name !== undefined ? { name: incoming.name } : {}),
+    result: incoming.result,
+    error: incoming.error,
+    status: incoming.error ? 'error' : 'completed',
+  });
+  return true;
+}
+
+/**
+ * Apply one SSE event to a message.
+ *
+ * @param {object} message  message object created by createAssistantMessage()
+ * @param {string} eventName
+ * @param {object} [data]   the event payload as sent by OrchestratorService
+ * @returns {{ handled: boolean, changed: boolean, status: string|null, done: boolean, error: string|null }}
+ *   `status` is a human status line for the composer ('' clears it, null leaves
+ *   the current one alone).
+ */
+export function applyStreamEvent(message, eventName, data = {}) {
+  const out = { handled: true, changed: false, status: null, done: false, error: null };
+  if (!message) return { ...out, handled: false };
+
+  switch (eventName) {
+    case 'content_delta':
+      out.changed = appendText(message, data?.delta);
+      // Text is the answer arriving — any "using tool…" line is now stale.
+      if (out.changed) out.status = '';
+      break;
+
+    case 'reasoning_delta':
+      if (typeof data?.delta === 'string' && data.delta) {
+        message.reasoning = (message.reasoning || '') + data.delta;
+        out.changed = true;
+      }
+      out.status = 'Reasoning…';
+      break;
+
+    case 'tool_pending':
+      out.changed = upsertToolCall(message, data?.toolCall, 'pending');
+      if (out.changed) out.status = `Using ${data.toolCall.name || 'tool'}…`;
+      break;
+
+    case 'tool_start':
+      out.changed = upsertToolCall(message, data?.toolCall, 'running');
+      if (out.changed) out.status = `Using ${data.toolCall.name || 'tool'}…`;
+      break;
+
+    case 'tool_end':
+      out.changed = completeToolCall(message, data?.toolCall);
+      if (out.changed) out.status = 'Working…';
+      break;
+
+    case 'final_content':
+      // The accumulated deltas ARE the answer; final_content is a duplicate of
+      // the same text for logging. Only adopt it when nothing streamed at all
+      // (non-streaming providers, or a run recovered from an error).
+      if (!message.content && typeof data?.content === 'string' && data.content) {
+        out.changed = appendText(message, data.content);
+      }
+      out.status = '';
+      break;
+
+    case 'error':
+      out.error = data?.error || data?.message || 'Stream error';
+      out.status = '';
+      break;
+
+    case 'done':
+      out.done = true;
+      out.status = '';
+      break;
+
+    default:
+      out.handled = false;
+      break;
+  }
+
+  return out;
+}
+
+/**
+ * PROVIDER CONTENT IS NOT ALWAYS A STRING
+ * ---------------------------------------
+ * conversation_logs.full_history stores the RAW PROVIDER transcript, not a UI
+ * one. The moment a turn calls a tool, `content` stops being a string and
+ * becomes a block array:
+ *
+ *   assistant: [ {type:'thinking'}, {type:'text',text}, {type:'tool_use',id,name,input} ]
+ *   user:      [ {type:'tool_result', tool_use_id, content} ]
+ *
+ * This module used to reach that array and call String() on it, which yields
+ * "[object Object],[object Object]" — so a restarted chat rendered every
+ * tool-using turn as literal garbage. The words were never lost; they sit in
+ * the `text` blocks and were simply never read. A String() cast reads like a
+ * defensive guard and is in fact the thing that destroys the content: it turns
+ * "I don't know this shape" into "this is definitely junk", silently.
+ *
+ * Every provider block shape is flattened HERE, at the one seam both chat
+ * surfaces load through, so no surface can drift from the wire format again.
+ */
+const TEXT_BLOCK_TYPES = new Set(['text', 'input_text', 'output_text']);
+const THINKING_BLOCK_TYPES = new Set(['thinking', 'redacted_thinking', 'reasoning']);
+const TOOL_USE_BLOCK_TYPES = new Set(['tool_use', 'tool_call', 'function_call']);
+const TOOL_RESULT_BLOCK_TYPES = new Set(['tool_result', 'function_call_output']);
+
+/**
+ * Reduce any provider payload (string | block array | object) to display text.
+ * Used for message bodies and for tool_result contents, which are themselves
+ * sometimes a nested block array.
+ */
+function flattenBlockText(content) {
+  if (typeof content === 'string') return content;
+  if (content == null) return '';
+  if (Array.isArray(content)) {
+    return content
+      .map((b) => (typeof b === 'string' ? b : (b && typeof b.text === 'string' ? b.text : '')))
+      .filter(Boolean)
+      .join('\n');
+  }
+  if (typeof content === 'object') {
+    if (typeof content.text === 'string') return content.text;
+    try { return JSON.stringify(content); } catch { return ''; }
+  }
+  return String(content);
+}
+
+/**
+ * Normalize one tool call into the shape MessageItem reads
+ * ({ id, name, args, status, result?, error? }), accepting the Anthropic block
+ * form, the OpenAI `{ id, function: { name, arguments } }` form, and a message
+ * already saved by the UI.
+ */
+function normalizeToolCall(tc) {
+  if (!tc || typeof tc !== 'object') return null;
+  const id = tc.id || tc.tool_use_id || tc.tool_call_id || tc.toolCallId || tc.call_id;
+  if (!id) return null;
+
+  const fn = tc.function || tc.function_call || null;
+  let args = tc.args !== undefined ? tc.args : (tc.input !== undefined ? tc.input : fn?.arguments);
+  // OpenAI ships arguments as a JSON string; keep the raw text if it is not JSON
+  // (a truncated stream) rather than throwing away the only record of the call.
+  if (typeof args === 'string' && args) {
+    try { args = JSON.parse(args); } catch { /* keep the raw string */ }
+  }
+
+  const hasOutcome = tc.result !== undefined || tc.error !== undefined;
+  return {
+    id,
+    name: tc.name || fn?.name || 'tool',
+    args,
+    status: tc.status || (hasOutcome ? 'completed' : 'pending'),
+    ...(tc.result !== undefined ? { result: tc.result } : {}),
+    ...(tc.error !== undefined ? { error: tc.error } : {}),
+  };
+}
+
+/**
+ * Split one raw message into its renderable pieces.
+ *
+ * @returns {{ text: string, reasoning: string, toolCalls: object[],
+ *             contentParts: object[], toolResults: object[] }}
+ *   `toolResults` are NOT renderable on their own — they belong to a tool call
+ *   announced by an EARLIER message, and serverMessagesToUi joins them there.
+ */
+export function flattenProviderMessage(raw = {}) {
+  const contentParts = [];
+  const toolCalls = [];
+  const toolResults = [];
+  let text = '';
+  let reasoning = '';
+
+  const addText = (chunk) => {
+    if (!chunk) return;
+    text = text ? `${text}\n${chunk}` : chunk;
+    const last = contentParts[contentParts.length - 1];
+    if (last && last.type === 'text') last.text += `\n${chunk}`;
+    else contentParts.push({ type: 'text', text: chunk });
+  };
+
+  const addToolCall = (candidate) => {
+    const tc = normalizeToolCall(candidate);
+    if (!tc || toolCalls.some((x) => x.id === tc.id)) return;
+    toolCalls.push(tc);
+    contentParts.push({ type: 'tool_call', toolCallId: tc.id });
+  };
+
+  if (Array.isArray(raw.content)) {
+    for (const block of raw.content) {
+      if (typeof block === 'string') { addText(block); continue; }
+      if (!block || typeof block !== 'object') continue;
+
+      if (THINKING_BLOCK_TYPES.has(block.type)) {
+        const thought = block.thinking || block.text || '';
+        if (thought) reasoning = reasoning ? `${reasoning}\n${thought}` : thought;
+      } else if (TOOL_USE_BLOCK_TYPES.has(block.type)) {
+        addToolCall(block);
+      } else if (TOOL_RESULT_BLOCK_TYPES.has(block.type)) {
+        const id = block.tool_use_id || block.tool_call_id || block.call_id || block.id;
+        if (id) {
+          const body = flattenBlockText(block.content !== undefined ? block.content : block.output);
+          toolResults.push(block.is_error ? { id, error: body } : { id, result: body });
+        }
+      } else if (TEXT_BLOCK_TYPES.has(block.type) || typeof block.text === 'string') {
+        addText(block.text || '');
+      }
+    }
+  } else {
+    addText(flattenBlockText(raw.content));
+  }
+
+  // Providers that keep tool calls beside the content rather than inside it.
+  const declared = Array.isArray(raw.toolCalls) ? raw.toolCalls
+    : (Array.isArray(raw.tool_calls) ? raw.tool_calls : []);
+  for (const d of declared) addToolCall(d);
+
+  return { text, reasoning, toolCalls, contentParts, toolResults };
+}
+
+/**
+ * Normalize a persisted/loaded message into the render shape. Conversations
+ * saved before contentParts existed carry only `content`; without a text part
+ * MessageItem would render an empty bubble.
+ */
+export function hydrateMessage(raw = {}) {
+  const flat = flattenProviderMessage(raw);
+  // A message the UI itself saved already knows its interleave order; never
+  // rebuild it (and never break identity for consumers that memoize on it).
+  const explicitParts = Array.isArray(raw.contentParts) && raw.contentParts.length
+    ? raw.contentParts
+    : flat.contentParts;
+
+  return {
+    id: raw.id || `msg-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    role: raw.role === 'user' ? 'user' : 'assistant',
+    content: flat.text,
+    contentParts: explicitParts,
+    toolCalls: flat.toolCalls,
+    reasoning: raw.reasoning || flat.reasoning || '',
+    timestamp: raw.timestamp || Date.now(),
+  };
+}
+
+/**
+ * A PROVIDER ROW IS NOT A MESSAGE
+ * -------------------------------
+ * Live, one answer is ONE message: text and tool cards interleave inside a
+ * single bubble via contentParts. The provider transcript stores that same
+ * answer as a CHAIN of rows — assistant(text + tool_use), user(tool_result),
+ * assistant(tool_use), user(tool_result), assistant(text) — because every
+ * tool round-trip has to re-enter the model as a new turn.
+ *
+ * Mapping one row to one bubble therefore shattered every tool-using answer on
+ * reload: three bubbles for the turn above, the middle one with no words at
+ * all, just orphaned tool cards. The rule is that an assistant TURN runs until
+ * the next thing the USER actually said, so the rows are folded back together
+ * here.
+ *
+ * Fold at the read seam, not at the write: full_history must stay the exact
+ * provider transcript (it is replayed back to the model on the next turn, and
+ * a doctored one would break tool_use/tool_result pairing).
+ */
+function mergeAssistantTurn(target, next) {
+  if (next.text) target.content = target.content ? `${target.content}\n\n${next.text}` : next.text;
+  if (next.reasoning) {
+    target.reasoning = target.reasoning ? `${target.reasoning}\n${next.reasoning}` : next.reasoning;
+  }
+
+  for (const part of next.contentParts) {
+    const last = target.contentParts[target.contentParts.length - 1];
+    // Prose split across two provider rows is one passage, not two paragraphs
+    // of one part and one of another — keep it in a single text part so the
+    // markdown pipeline sees whole fences and lists.
+    if (part.type === 'text' && last && last.type === 'text') last.text += `\n\n${part.text}`;
+    else target.contentParts.push(part);
+  }
+
+  for (const tc of next.toolCalls) {
+    if (!target.toolCalls.some((x) => x.id === tc.id)) target.toolCalls.push(tc);
+  }
+}
+
+/**
+ * Convert server conversation_logs messages into UI message shapes.
+ *
+ * Shared by chatUnified's workspace hydration and the main chat's
+ * stream-death reconciliation — one conversion, or the two surfaces
+ * silently drift on tool-call / content-part handling.
+ *
+ * Three provider-transcript facts are handled here and nowhere else:
+ *   1. A tool's OUTPUT comes back on a synthetic `user` turn carrying only
+ *      tool_result blocks. That is protocol bookkeeping, not something the user
+ *      said — it is joined onto the tool card that asked for it and then
+ *      dropped, so it never renders as an empty user bubble.
+ *   2. One assistant turn spans every row up to the next REAL user message —
+ *      see mergeAssistantTurn() above.
+ *   3. Because of (1) and (2), the provider transcript has MORE rows than the
+ *      UI one for the same conversation. Callers must therefore never compare
+ *      the two by length — see transcriptSubstance().
+ */
+export function serverMessagesToUi(messages) {
+  if (!Array.isArray(messages)) return [];
+
+  const out = [];
+  const callsById = new Map();
+  const stamp = Date.now().toString(36);
+  let openTurn = null;
+
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i];
+    if (!m || (m.role !== 'user' && m.role !== 'assistant')) continue;
+
+    const flat = flattenProviderMessage(m);
+
+    for (const r of flat.toolResults) {
+      const tc = callsById.get(r.id);
+      if (!tc) continue;
+      if (r.error !== undefined) { tc.error = r.error; tc.status = 'error'; }
+      else { tc.result = r.result; tc.status = 'completed'; }
+    }
+
+    // Nothing but tool plumbing — the results above were its entire payload.
+    // It carries no utterance, so it must NOT close the open assistant turn.
+    if (flat.toolResults.length > 0 && !flat.text && flat.toolCalls.length === 0) continue;
+
+    if (m.role === 'user') {
+      openTurn = null;
+      out.push(hydrateMessage({ ...m, id: m.id || `srv-${i}-${stamp}` }));
+      continue;
+    }
+
+    // An assistant row with neither words nor tool calls has nothing to show.
+    if (!flat.text && flat.toolCalls.length === 0) continue;
+
+    if (openTurn) {
+      mergeAssistantTurn(openTurn, flat);
+    } else {
+      openTurn = hydrateMessage({ ...m, id: m.id || `srv-${i}-${stamp}` });
+      // Own every array and part this turn will grow into: hydrateMessage may
+      // hand back the CALLER's contentParts when the message already had them,
+      // and merging appends to (and rewrites the text of) these objects.
+      openTurn.contentParts = openTurn.contentParts.map((p) => ({ ...p }));
+      openTurn.toolCalls = [...openTurn.toolCalls];
+      out.push(openTurn);
+    }
+
+    for (const tc of openTurn.toolCalls) callsById.set(tc.id, tc);
+  }
+
+  return out;
+}
+
+/**
+ * The fingerprint of a failed object→string coercion. `[object Object]` is not
+ * a thing a user types or a model writes; wherever it appears, some conversion
+ * upstream gave up and stringified a structure it did not understand. Counted
+ * as zero content — see transcriptSubstance().
+ */
+const COERCION_ARTIFACT = /\[object \w+\]/g;
+
+/**
+ * How much a transcript actually SAYS.
+ *
+ * Row count is not fidelity: a provider transcript legitimately has more rows
+ * than the UI's (every tool round-trip adds two), so `remote.length >=
+ * local.length` handed the win to whichever side had more PLUMBING — which is
+ * how a transcript that had lost its text to a coercion bug came to overwrite
+ * good local history.
+ *
+ * Character count alone is not fidelity either, and the test that pins this
+ * caught me assuming it was: "[object Object],[object Object],[object Object]"
+ * is 44 characters and would have beaten 40 characters of real writing. A
+ * proxy for meaning has to exclude the one string we KNOW carries none.
+ */
+export function transcriptSubstance(messages) {
+  if (!Array.isArray(messages)) return 0;
+  let substance = 0;
+  for (const m of messages) {
+    if (!m) continue;
+    if (typeof m.content === 'string') {
+      substance += m.content.replace(COERCION_ARTIFACT, '').length;
+    }
+    // A turn can be pure tool work with no prose; that is still substance.
+    if (Array.isArray(m.toolCalls)) substance += m.toolCalls.length * 32;
+  }
+  return substance;
+}
+
+export default {
+  HANDLED_STREAM_EVENTS,
+  createAssistantMessage,
+  applyStreamEvent,
+  flattenProviderMessage,
+  hydrateMessage,
+  serverMessagesToUi,
+  transcriptSubstance,
+};

--- a/backend/src/services/orchestrator/chatStreamReducer.mirror.test.js
+++ b/backend/src/services/orchestrator/chatStreamReducer.mirror.test.js
@@ -1,0 +1,64 @@
+/**
+ * The mirror is a COPY, so the only thing worth testing is that it is still a
+ * copy.
+ *
+ * Backend and frontend cannot import each other at runtime — neither tree is
+ * shipped to the other (see the header of chatStreamReducer.mirror.js) — so
+ * the transcript conversion exists twice. Duplication is tolerable only while
+ * the two copies are provably identical; the moment someone "just tweaks" one,
+ * the server starts storing a different transcript from the one the client
+ * renders, and that divergence is invisible until a user sees a mangled
+ * conversation.
+ *
+ * Byte equality is deliberately chosen over behavioural sampling. A parity
+ * test over example transcripts can only cover the shapes its author imagined,
+ * which is exactly how the two bugs quoted in that header shipped. Byte
+ * equality has no blind spot.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const SENTINEL = '// --- MIRRORED SOURCE BELOW - DO NOT EDIT BY HAND ---------------------------\n';
+
+const mirrorPath = fileURLToPath(new URL('./chatStreamReducer.mirror.js', import.meta.url));
+const sourcePath = fileURLToPath(
+  new URL('../../../../frontend/src/services/chatStreamReducer.js', import.meta.url),
+);
+
+const RECOPY = [
+  'The mirror has drifted from its source.',
+  'Do not hand-edit below the sentinel. Regenerate it:',
+  '',
+  '  cat <the header block> frontend/src/services/chatStreamReducer.js \\',
+  '    > backend/src/services/orchestrator/chatStreamReducer.mirror.js',
+].join('\n');
+
+describe('chatStreamReducer.mirror.js', () => {
+  it('carries the sentinel that separates header from mirrored source', () => {
+    expect(fs.readFileSync(mirrorPath, 'utf8')).toContain(SENTINEL);
+  });
+
+  it('is byte-identical to frontend/src/services/chatStreamReducer.js', () => {
+    const mirror = fs.readFileSync(mirrorPath, 'utf8');
+    const source = fs.readFileSync(sourcePath, 'utf8');
+    const mirrored = mirror.slice(mirror.indexOf(SENTINEL) + SENTINEL.length);
+
+    expect(mirrored === source ? 'identical' : RECOPY).toBe('identical');
+    expect(mirrored).toBe(source);
+  });
+
+  it('exports everything the projection depends on', async () => {
+    const mod = await import('./chatStreamReducer.mirror.js');
+    expect(typeof mod.serverMessagesToUi).toBe('function');
+    expect(typeof mod.transcriptSubstance).toBe('function');
+  });
+
+  it('exposes the same public surface as its source', async () => {
+    const [mirror, source] = await Promise.all([
+      import('./chatStreamReducer.mirror.js'),
+      import('../../../../frontend/src/services/chatStreamReducer.js'),
+    ]);
+    expect(Object.keys(mirror).sort()).toEqual(Object.keys(source).sort());
+  });
+});

--- a/backend/src/services/orchestrator/persistTurnTranscript.js
+++ b/backend/src/services/orchestrator/persistTurnTranscript.js
@@ -33,6 +33,21 @@
  *    than real prose. `>=` matches the client's own reconcile in
  *    recoverInterruptedStream, so both paths resolve a tie the same way.
  *
+ * 2b. A MERGED FRAGMENT NEVER DROPS A USER TURN — a separate rule, and not
+ *    implied by (2). Substance is ONE number for the whole transcript, so it
+ *    cannot tell a long conversation from one long answer: a 16KB interrupted
+ *    answer scores higher than five short earlier turns and takes the row.
+ *    Shape is therefore checked on its own, stored's user turns having to be a
+ *    PREFIX of what is written — but only on the fragment path, because there
+ *    the input is a guess about where a turn belongs. On the turn-end path the
+ *    caller holds the authoritative history and a false refusal would freeze
+ *    the sidebar, i.e. re-create the bug in (1)'s paragraph.
+ *
+ * 2c. A CALLER SAYS WHAT IT IS HANDING OVER — see `mode` on writeTranscript.
+ *    A whole conversation and a single recovered turn are both "an array of
+ *    messages", and nothing in the array says which one it is. Guessing is
+ *    what made (2b) necessary.
+ *
  * 3. EVERY OTHER COLUMN IS CARRIED OVER, NOT DEFAULTED.
  *    ContentOutputModel.createOrUpdate is a full-row upsert: workflow_id,
  *    tool_id, is_shareable and title are assigned from `excluded`, so passing
@@ -54,19 +69,95 @@ import { deriveTitle, serializeTranscript, transcriptSubstance } from './transcr
 import { serverMessagesToUi } from './chatStreamReducer.mirror.js';
 
 /**
- * How much the client's already-saved copy actually says.
+ * The messages the client has already saved, or [] when the column will not
+ * parse.
  *
- * A row whose content will not parse scores 0, so a good projection replaces
- * it. That is the right direction: unparseable content renders as nothing at
- * all, and there is no reading in which keeping it beats replacing it.
+ * Treating unparseable content as empty is the right direction: it renders as
+ * nothing at all, and there is no reading in which keeping it beats replacing
+ * it. It also scores 0 substance, exactly as before.
  */
-function storedSubstance(rawContent) {
+function parseStoredMessages(rawContent) {
   try {
     const parsed = JSON.parse(rawContent);
-    return transcriptSubstance(Array.isArray(parsed?.messages) ? parsed.messages : []);
+    return Array.isArray(parsed?.messages) ? parsed.messages : [];
   } catch {
-    return 0;
+    return [];
   }
+}
+
+/**
+ * The sequence of things the USER said — a conversation's skeleton.
+ *
+ * Assistant turns are legitimately rewritten on every pass: merged across
+ * provider rows, compacted, re-projected. User turns are not. They are
+ * therefore the one part of a transcript a write can be held against.
+ */
+function userTurnKeys(messages) {
+  return (messages || [])
+    .filter((m) => m && m.role === 'user' && typeof m.content === 'string')
+    .map((m) => m.content.trim());
+}
+
+/**
+ * May `incoming` replace `stored` without losing anything the user said?
+ *
+ * The never-shrink rule below compares SUBSTANCE, which is one number for the
+ * whole transcript and therefore cannot tell "a longer conversation" from "one
+ * longer answer". A 16KB interrupted answer outscores five short earlier turns
+ * and takes the row — measured, not hypothesised. So substance alone is not
+ * enough: the SHAPE has to hold too, and the invariant is that stored's user
+ * turns are a PREFIX of incoming's.
+ *
+ * Exported because it is the invariant, not an implementation detail — a test
+ * that cannot state it cannot defend it.
+ */
+export function preservesUserTurns(stored, incoming) {
+  const before = userTurnKeys(stored);
+  const after = userTurnKeys(incoming);
+  if (before.length > after.length) return false;
+  return before.every((key, i) => key === after[i]);
+}
+
+/**
+ * Merge a recovered TURN into the transcript that is already saved.
+ *
+ * Recovery replays ONE turn out of a journal — the user's message and the
+ * answer that was in flight when the process died. That is a fragment, not a
+ * conversation, and a full-row write handed a fragment replaces everything
+ * else with it.
+ *
+ * Returns null when there is nothing worth adding, i.e. the saved copy already
+ * holds a better version of this same turn.
+ */
+export function mergeRecoveredTurn(stored, turn) {
+  if (!Array.isArray(turn) || turn.length === 0) return null;
+
+  const turnUser = turn.find((m) => m && m.role === 'user' && typeof m.content === 'string');
+  // Answer-only journal — nothing to anchor on, so it can only be appended.
+  if (!turnUser) return [...stored, ...turn];
+
+  // Match on what the user said. The journal's own message id is minted during
+  // recovery (`msg-user-recovered-<now>`) and so can never match a stored one.
+  const key = turnUser.content.trim();
+  let at = -1;
+  for (let i = stored.length - 1; i >= 0; i--) {
+    const m = stored[i];
+    if (m && m.role === 'user' && typeof m.content === 'string' && m.content.trim() === key) {
+      at = i;
+      break;
+    }
+  }
+
+  // The row never saw this turn — the client died before it autosaved.
+  if (at === -1) return [...stored, ...turn];
+
+  // The row has this turn already. Generation carried on after the client
+  // stopped listening, so the journal's copy is normally the longer one — but
+  // not always, and the TAIL is the only part the two disagree about, so the
+  // tail is what gets compared.
+  const storedTail = stored.slice(at);
+  if (transcriptSubstance(turn) < transcriptSubstance(storedTail)) return null;
+  return [...stored.slice(0, at), ...turn];
 }
 
 /**
@@ -79,15 +170,26 @@ function storedSubstance(rawContent) {
  * carry-every-column reasoning would drift, and the failure mode of drift here
  * is silently deleting somebody's conversation.
  *
+ * A caller must say WHICH of those two it is handing over, because they are
+ * not interchangeable and the difference is invisible from the array alone.
+ * Turn-end passes the whole conversation, which is always a superset of what
+ * is stored. Recovery passes one turn. The never-shrink rule was derived for
+ * the first case, and inheriting it silently for the second is what let a
+ * fragment take the row.
+ *
  * @param {object} args
  * @param {string} args.conversationId
  * @param {string} args.userId
  * @param {Array}  args.messages   UI-shaped messages, as the client renders them
+ * @param {'whole'|'appendTurn'} [args.mode]
+ *                                 'whole' — `messages` IS the conversation.
+ *                                 'appendTurn' — `messages` is a single turn to
+ *                                 be merged into what is already saved.
  * @param {string} [args.logTag]   prefix for log lines, so recovery is
  *                                 distinguishable from the normal path
  * @returns {Promise<{written: boolean, reason?: string, outputId?: string}>}
  */
-export async function writeTranscript({ conversationId, userId, messages, logTag = 'TurnTranscript' } = {}) {
+export async function writeTranscript({ conversationId, userId, messages, mode = 'whole', logTag = 'TurnTranscript' } = {}) {
   if (!conversationId || !userId) return { written: false, reason: 'not_identified' };
   if (!Array.isArray(messages) || messages.length === 0) return { written: false, reason: 'empty_projection' };
 
@@ -100,11 +202,38 @@ export async function writeTranscript({ conversationId, userId, messages, logTag
     if (!existing) return { written: false, reason: 'no_saved_row' };
     if (existing.content_type !== 'conversation') return { written: false, reason: 'not_a_transcript' };
 
-    // Existing title wins: deriving one here would rename a conversation the
-    // user may have named themselves.
-    const title = existing.title || deriveTitle(messages);
+    const stored = parseStoredMessages(existing.content);
 
-    if (transcriptSubstance(messages) < storedSubstance(existing.content)) {
+    // A fragment is merged onto what is already saved; a whole transcript
+    // stands on its own.
+    let incoming = messages;
+    if (mode === 'appendTurn') {
+      incoming = mergeRecoveredTurn(stored, messages);
+      if (!incoming) return { written: false, reason: 'saved_copy_is_richer' };
+
+      // Anchoring can still lose ground: when the journal's turn matches
+      // part-way UP a conversation that has since moved on, everything after
+      // the anchor is replaced by it. Reachable in practice — a journal whose
+      // write throws is deliberately kept and retried on a LATER boot, by
+      // which time the user may have carried on talking.
+      //
+      // Scoped to this path deliberately. In 'whole' mode the caller is the
+      // turn itself, holding the authoritative history, and a false refusal
+      // there would freeze the sidebar mid-answer — which is the very bug this
+      // file exists to fix. A guard whose failure mode is the original bug does
+      // not belong on that path.
+      if (!preservesUserTurns(stored, incoming)) {
+        return { written: false, reason: 'would_drop_user_turns' };
+      }
+    }
+
+    // Existing title wins: deriving one here would rename a conversation the
+    // user may have named themselves. Derived from the MERGED transcript, never
+    // from a fragment — a title is the first thing the user said in the
+    // conversation, not the first thing they said in the recovered turn.
+    const title = existing.title || deriveTitle(incoming);
+
+    if (transcriptSubstance(incoming) < transcriptSubstance(stored)) {
       return { written: false, reason: 'saved_copy_is_richer' };
     }
 
@@ -113,7 +242,7 @@ export async function writeTranscript({ conversationId, userId, messages, logTag
       userId,
       existing.workflow_id,
       existing.tool_id,
-      serializeTranscript({ conversationId, title, messages }),
+      serializeTranscript({ conversationId, title, messages: incoming }),
       !!existing.is_shareable,
       'conversation',
       conversationId,

--- a/backend/src/services/orchestrator/persistTurnTranscript.js
+++ b/backend/src/services/orchestrator/persistTurnTranscript.js
@@ -1,0 +1,176 @@
+/**
+ * persistTurnTranscript.js — write the conversation's saved row at turn end,
+ * with no client involved.
+ *
+ * THE GAP THIS CLOSES
+ * -------------------
+ * A run's lifetime stopped depending on a browser socket when activeRuns.js
+ * landed: generation continues, conversation_logs keeps growing, and any
+ * client may reattach. The SAVED row did not get the same treatment.
+ * content_outputs has exactly one writer — an HTTP handler a client must call
+ * — so the conversation list only ever shows what some browser was awake to
+ * report. Close the laptop on a long task and the answer is complete on disk
+ * and truncated on screen.
+ *
+ * That is a strictly worse failure than losing the work, because it looks
+ * exactly like losing the work.
+ *
+ * THE RULES, AND WHY EACH ONE IS NARROW
+ * -------------------------------------
+ * 1. UPDATE ONLY — never create.
+ *    A row exists because some client decided this conversation belongs in the
+ *    list. Creating one here would enrol conversations that no client ever
+ *    chose to save: agent chats (the main store deliberately skips autosave
+ *    when agentId is set), suggestion calls, and every embedded surface that
+ *    has its own persistence rules. Getting that wrong fills the user's
+ *    sidebar with entries they never asked for, which is a worse bug than the
+ *    one being fixed. The reported case — a row saved early, then abandoned
+ *    mid-answer — is entirely covered by updating.
+ *
+ * 2. NEVER SHRINK what a client saved.
+ *    Compared by SUBSTANCE, not length or row count, for the reason
+ *    transcriptSubstance() documents: "[object Object]" repeated is longer
+ *    than real prose. `>=` matches the client's own reconcile in
+ *    recoverInterruptedStream, so both paths resolve a tie the same way.
+ *
+ * 3. EVERY OTHER COLUMN IS CARRIED OVER, NOT DEFAULTED.
+ *    ContentOutputModel.createOrUpdate is a full-row upsert: workflow_id,
+ *    tool_id, is_shareable and title are assigned from `excluded`, so passing
+ *    a null for any of them WIPES it. title especially — that is where a
+ *    user's rename lives, and a background write must never rename their
+ *    conversation. (channel_key is COALESCEd by the model and so is sticky on
+ *    its own; it is passed anyway rather than relying on that from a distance.)
+ *
+ * 4. IT CANNOT BREAK THE TURN.
+ *    Fire-and-forget at the call site, and every path here resolves rather
+ *    than throws. The turn is already finished and its answer is already in
+ *    conversation_logs; a failure to mirror it into the sidebar is a log line,
+ *    not an error the user should ever meet.
+ */
+
+import ContentOutputModel from '../../models/ContentOutputModel.js';
+import { broadcastToUser, RealtimeEvents } from '../../utils/realtimeSync.js';
+import { deriveTitle, serializeTranscript, transcriptSubstance } from './transcriptProjection.js';
+import { serverMessagesToUi } from './chatStreamReducer.mirror.js';
+
+/**
+ * How much the client's already-saved copy actually says.
+ *
+ * A row whose content will not parse scores 0, so a good projection replaces
+ * it. That is the right direction: unparseable content renders as nothing at
+ * all, and there is no reading in which keeping it beats replacing it.
+ */
+function storedSubstance(rawContent) {
+  try {
+    const parsed = JSON.parse(rawContent);
+    return transcriptSubstance(Array.isArray(parsed?.messages) ? parsed.messages : []);
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Write UI messages into a conversation's saved row, under every rule above.
+ *
+ * Extracted so there is exactly ONE implementation of "how a transcript is
+ * safely written", because there are now two callers with different inputs:
+ * the end of a turn (provider messages) and journal recovery after a restart
+ * (a reduced replay log). Two copies of the update-only / never-shrink /
+ * carry-every-column reasoning would drift, and the failure mode of drift here
+ * is silently deleting somebody's conversation.
+ *
+ * @param {object} args
+ * @param {string} args.conversationId
+ * @param {string} args.userId
+ * @param {Array}  args.messages   UI-shaped messages, as the client renders them
+ * @param {string} [args.logTag]   prefix for log lines, so recovery is
+ *                                 distinguishable from the normal path
+ * @returns {Promise<{written: boolean, reason?: string, outputId?: string}>}
+ */
+export async function writeTranscript({ conversationId, userId, messages, logTag = 'TurnTranscript' } = {}) {
+  if (!conversationId || !userId) return { written: false, reason: 'not_identified' };
+  if (!Array.isArray(messages) || messages.length === 0) return { written: false, reason: 'empty_projection' };
+
+  try {
+    // The canonical row for this conversation (longest content wins — see
+    // ContentOutputModel.findByConversationId). Content is needed here, not
+    // just metadata, because the never-shrink rule compares against what it
+    // actually says.
+    const existing = await ContentOutputModel.findByConversationId(conversationId, userId);
+    if (!existing) return { written: false, reason: 'no_saved_row' };
+    if (existing.content_type !== 'conversation') return { written: false, reason: 'not_a_transcript' };
+
+    // Existing title wins: deriving one here would rename a conversation the
+    // user may have named themselves.
+    const title = existing.title || deriveTitle(messages);
+
+    if (transcriptSubstance(messages) < storedSubstance(existing.content)) {
+      return { written: false, reason: 'saved_copy_is_richer' };
+    }
+
+    await ContentOutputModel.createOrUpdate(
+      existing.id,
+      userId,
+      existing.workflow_id,
+      existing.tool_id,
+      serializeTranscript({ conversationId, title, messages }),
+      !!existing.is_shareable,
+      'conversation',
+      conversationId,
+      title,
+      { channelKey: existing.channel_key || null },
+    );
+
+    // Same event-carried-state contract as the HTTP save: hand back the row's
+    // metadata so open clients patch this one row instead of refetching the
+    // whole list. Without it, a tab that is open elsewhere shows the stale
+    // preview until something else makes it refetch.
+    try {
+      const output = await ContentOutputModel.findMetaById(existing.id);
+      broadcastToUser(userId, RealtimeEvents.CONTENT_UPDATED, {
+        id: existing.id,
+        title,
+        contentType: 'conversation',
+        userId,
+        output,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (broadcastError) {
+      // The row is already correct on disk; failing to announce it is not a
+      // reason to report the write as failed.
+      console.warn(`[${logTag}] Saved, but could not broadcast:`, broadcastError?.message || broadcastError);
+    }
+
+    return { written: true, outputId: existing.id };
+  } catch (error) {
+    console.warn(`[${logTag}] Could not persist ${conversationId}:`, error?.message || error);
+    return { written: false, reason: 'error' };
+  }
+}
+
+/**
+ * Mirror the completed turn into the conversation's saved row.
+ *
+ * @param {object} args
+ * @param {string} args.conversationId
+ * @param {string} args.userId
+ * @param {Array}  args.providerMessages  the sanitized provider history — the
+ *                                        same array written to
+ *                                        conversation_logs.full_history
+ * @returns {Promise<{written: boolean, reason?: string, outputId?: string}>}
+ *          Always resolves. `reason` names the skip, so the common no-ops are
+ *          distinguishable from failures in a log.
+ */
+export async function persistTurnTranscript({ conversationId, userId, providerMessages } = {}) {
+  if (!conversationId || !userId) return { written: false, reason: 'not_identified' };
+  if (!Array.isArray(providerMessages) || providerMessages.length === 0) {
+    return { written: false, reason: 'no_history' };
+  }
+  return writeTranscript({
+    conversationId,
+    userId,
+    messages: serverMessagesToUi(providerMessages),
+  });
+}
+
+export default persistTurnTranscript;

--- a/backend/src/services/orchestrator/persistTurnTranscript.recoveryMerge.test.js
+++ b/backend/src/services/orchestrator/persistTurnTranscript.recoveryMerge.test.js
@@ -1,0 +1,341 @@
+/**
+ * A recovered turn is merged into the conversation, not written over it.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * writeTranscript has two callers that hand it different KINDS of input, and
+ * nothing in an array of messages says which kind it is:
+ *
+ *   - turn end passes the whole provider history. That is always a superset of
+ *     what is stored, so replacing the row with it is correct.
+ *   - journal recovery passes ONE TURN — the user's message and the answer
+ *     that was in flight when the process died.
+ *
+ * The never-shrink guard was derived for the first case and inherited by the
+ * second. It compares SUBSTANCE, which is one number for the whole transcript,
+ * so it cannot tell "a whole conversation" from "one big turn": a 16KB
+ * interrupted answer outscores several short earlier turns and takes the row.
+ * Measured against the unfixed code, a six-message conversation came back as
+ * two and four user/assistant pairs were gone.
+ *
+ * conversation_logs still held the history, so this was recoverable by hand —
+ * but recoverInterruptedStream only runs on live stream death in an OPEN TAB,
+ * never on a plain conversation open. In the exact case a journal exists for
+ * (process killed, app restarted, no client alive) nothing re-reads it, so the
+ * truncated row is what the user sees and what the next autosave promotes to
+ * canonical.
+ *
+ * Every test below therefore asserts the DATABASE, not the return value.
+ *
+ * Runs against a throwaway AGNT_HOME — never touches the user's database.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fsp from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { vi } from 'vitest';
+
+vi.mock('../../utils/realtimeSync.js', () => ({
+  broadcastToUser: () => {},
+  RealtimeEvents: { CONTENT_CREATED: 'content_created', CONTENT_UPDATED: 'content_updated' },
+}));
+
+let db;
+let ContentOutputModel;
+let writeTranscript;
+let preservesUserTurns;
+let messagesFromJournal;
+let TMP;
+const savedEnv = {};
+
+const USER = 'user-merge-1';
+
+/** ~16KB of code, the shape of answer that made the aggregate count lose. */
+const BIG_ANSWER = 'export async function runMigrations(db) { /* ... */ }\n'.repeat(300);
+
+/**
+ * A real conversation, several turns deep, with the last user message
+ * unanswered — the client autosaved and then died mid-answer.
+ */
+const priorConversation = () => ([
+  { role: 'user', content: 'hey, can you help me with the deploy script?' },
+  { role: 'assistant', content: 'Sure. What is it doing wrong right now?' },
+  { role: 'user', content: 'it fails on the sqlite rebuild step in CI' },
+  { role: 'assistant', content: 'That is --ignore-scripts skipping the native build. Add npm rebuild sqlite3.' },
+  { role: 'user', content: 'perfect that worked. now write me the full migration runner' },
+  { role: 'assistant', content: 'Sure — starting on that now.' },
+]);
+
+const storedTranscript = (messages, title = 'deploy script') =>
+  JSON.stringify({ conversationId: 'x', title, messages });
+
+const getRow = (id) => new Promise((resolve, reject) => {
+  db.get('SELECT * FROM content_outputs WHERE id = ?', [id], (e, r) => (e ? reject(e) : resolve(r)));
+});
+
+/** The messages actually on disk for a row. */
+const savedMessages = async (id) => JSON.parse((await getRow(id)).content).messages;
+
+/** A journal as runJournal writes it: one turn's worth of SSE events. */
+const journalFor = (userMessage, answer) => ({
+  conversationId: 'c',
+  userId: USER,
+  userMessage,
+  events: [
+    { eventName: 'assistant_message', data: { id: 'a1', timestamp: 1 } },
+    { eventName: 'content_delta', data: { delta: answer } },
+  ],
+});
+
+/** Seed a saved row for a conversation, as a client's autosave would. */
+async function seedRow(id, conversationId, messages, title = 'deploy script') {
+  await ContentOutputModel.createOrUpdate(
+    id, USER, null, null, storedTranscript(messages, title),
+    false, 'conversation', conversationId, title,
+  );
+}
+
+beforeAll(async () => {
+  TMP = await fsp.mkdtemp(path.join(os.tmpdir(), 'agnt-recovmerge-'));
+  for (const k of ['AGNT_HOME', 'USER_DATA_PATH', 'DOCKER_CONTAINER']) savedEnv[k] = process.env[k];
+  delete process.env.USER_DATA_PATH;
+  delete process.env.DOCKER_CONTAINER;
+  process.env.AGNT_HOME = TMP;
+
+  const dataDir = path.join(TMP, '.agnt', 'data');
+  await fsp.mkdir(dataDir, { recursive: true });
+  await fsp.writeFile(path.join(dataDir, 'agnt.db'), '');
+
+  const dbMod = await import('../../models/database/index.js');
+  db = dbMod.default;
+  await dbMod.dbReady;
+
+  ContentOutputModel = (await import('../../models/ContentOutputModel.js')).default;
+  ({ writeTranscript, preservesUserTurns } = await import('./persistTurnTranscript.js'));
+  ({ messagesFromJournal } = await import('./recoverJournaledRuns.js'));
+
+  await new Promise((resolve, reject) => {
+    db.run('INSERT INTO users (id, email) VALUES (?, ?)', [USER, `${USER}@test.local`],
+      (e) => (e ? reject(e) : resolve()));
+  });
+}, 120000);
+
+afterAll(async () => {
+  await new Promise((r) => db.close(r));
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  await fsp.rm(TMP, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('recovering an interrupted turn into a conversation that already has history', () => {
+  it('keeps every earlier turn AND lands the recovered answer — the defect', async () => {
+    const prior = priorConversation();
+    await seedRow('out-defect', 'conv-defect', prior);
+
+    const turn = messagesFromJournal(
+      journalFor('perfect that worked. now write me the full migration runner', BIG_ANSWER),
+    );
+    // The fragment on its own is worth far more than the whole conversation,
+    // which is exactly why substance alone could not defend this.
+    expect(turn).toHaveLength(2);
+
+    const result = await writeTranscript({
+      conversationId: 'conv-defect', userId: USER, messages: turn, mode: 'appendTurn',
+    });
+    expect(result.written).toBe(true);
+
+    const after = await savedMessages('out-defect');
+    expect(after).toHaveLength(prior.length);
+    expect(after.map((m) => m.content)).toEqual([
+      prior[0].content,
+      prior[1].content,
+      prior[2].content,
+      prior[3].content,
+      prior[4].content,
+      // the stub the client saved is replaced by what was really generated
+      expect.stringContaining('runMigrations'),
+    ]);
+  });
+
+  it('appends a turn the saved row never saw, without disturbing the ones it has', async () => {
+    const prior = priorConversation();
+    await seedRow('out-append', 'conv-append', prior);
+
+    const turn = messagesFromJournal(journalFor('a brand new question nobody saved', BIG_ANSWER));
+    const result = await writeTranscript({
+      conversationId: 'conv-append', userId: USER, messages: turn, mode: 'appendTurn',
+    });
+    expect(result.written).toBe(true);
+
+    const after = await savedMessages('out-append');
+    expect(after).toHaveLength(prior.length + 2);
+    expect(after.slice(0, prior.length).map((m) => m.content))
+      .toEqual(prior.map((m) => m.content));
+    expect(after[prior.length].content).toBe('a brand new question nobody saved');
+  });
+
+  it('declines when the saved copy already holds a longer answer for that turn', async () => {
+    const prior = priorConversation();
+    prior[5] = { role: 'assistant', content: `${BIG_ANSWER}${BIG_ANSWER}` };
+    await seedRow('out-richer', 'conv-richer', prior);
+    const before = (await getRow('out-richer')).content;
+
+    const turn = messagesFromJournal(
+      journalFor('perfect that worked. now write me the full migration runner', BIG_ANSWER),
+    );
+    const result = await writeTranscript({
+      conversationId: 'conv-richer', userId: USER, messages: turn, mode: 'appendTurn',
+    });
+
+    expect(result).toEqual({ written: false, reason: 'saved_copy_is_richer' });
+    expect((await getRow('out-richer')).content).toBe(before);
+  });
+
+  it('is idempotent — recovering the same journal twice changes nothing', async () => {
+    await seedRow('out-idem', 'conv-idem', priorConversation());
+    const turn = messagesFromJournal(
+      journalFor('perfect that worked. now write me the full migration runner', BIG_ANSWER),
+    );
+    const args = { conversationId: 'conv-idem', userId: USER, messages: turn, mode: 'appendTurn' };
+
+    await writeTranscript(args);
+    const afterFirst = await savedMessages('out-idem');
+    await writeTranscript(args);
+    const afterSecond = await savedMessages('out-idem');
+
+    expect(afterSecond.map((m) => m.content)).toEqual(afterFirst.map((m) => m.content));
+  });
+
+  it('does not rename an untitled conversation after the recovered turn', async () => {
+    // No title: the row was saved before the client got round to deriving one.
+    await ContentOutputModel.createOrUpdate(
+      'out-untitled', USER, null, null, storedTranscript(priorConversation(), ''),
+      false, 'conversation', 'conv-untitled', '',
+    );
+
+    const turn = messagesFromJournal(
+      journalFor('perfect that worked. now write me the full migration runner', BIG_ANSWER),
+    );
+    await writeTranscript({
+      conversationId: 'conv-untitled', userId: USER, messages: turn, mode: 'appendTurn',
+    });
+
+    // Derived from the whole conversation, so it is the FIRST thing the user
+    // said — not the first thing they said in the turn that was interrupted.
+    expect((await getRow('out-untitled')).title)
+      .toBe('hey, can you help me with the deploy script?');
+  });
+});
+
+describe('the structural guard, for a journal that anchors into a moved-on conversation', () => {
+  it('refuses a stale journal rather than replacing everything after its turn', async () => {
+    // A journal whose write THROWS is deliberately kept and retried on the next
+    // boot (see recoverJournaledRuns — an exception is not a decision). By then
+    // the user can have reopened the conversation and carried on, so the turn
+    // the journal describes is no longer the last one.
+    const movedOn = [
+      ...priorConversation(),
+      { role: 'user', content: 'actually never mind, do it in python instead' },
+      { role: 'assistant', content: 'Sure — here is the Python version.' },
+    ];
+    await seedRow('out-stale', 'conv-stale', movedOn);
+    const before = (await getRow('out-stale')).content;
+
+    // Anchors on the FIFTH message, so a naive replace-from-there would take
+    // the two later turns with it — and its size gets it past the substance
+    // rule.
+    const turn = messagesFromJournal(
+      journalFor('perfect that worked. now write me the full migration runner', BIG_ANSWER),
+    );
+
+    const result = await writeTranscript({
+      conversationId: 'conv-stale', userId: USER, messages: turn, mode: 'appendTurn',
+    });
+
+    expect(result).toEqual({ written: false, reason: 'would_drop_user_turns' });
+    expect((await getRow('out-stale')).content).toBe(before);
+  });
+
+  it('states the invariant directly: stored user turns are a prefix of incoming', () => {
+    const stored = [
+      { role: 'user', content: 'one' },
+      { role: 'assistant', content: 'a' },
+      { role: 'user', content: 'two' },
+    ];
+
+    // Superset — the turn-end case.
+    expect(preservesUserTurns(stored, [...stored, { role: 'assistant', content: 'b' }])).toBe(true);
+    expect(preservesUserTurns(stored, [...stored, { role: 'user', content: 'three' }])).toBe(true);
+    // Same conversation, assistant turns rewritten — legitimate, must pass.
+    expect(preservesUserTurns(stored, [
+      { role: 'user', content: 'one' },
+      { role: 'assistant', content: 'REWRITTEN, merged across provider rows' },
+      { role: 'user', content: 'two' },
+    ])).toBe(true);
+
+    // A user turn dropped, and a user turn changed.
+    expect(preservesUserTurns(stored, [{ role: 'user', content: 'one' }])).toBe(false);
+    expect(preservesUserTurns(stored, [
+      { role: 'user', content: 'one' },
+      { role: 'user', content: 'CHANGED' },
+    ])).toBe(false);
+
+    // Nothing stored yet — anything may be written.
+    expect(preservesUserTurns([], stored)).toBe(true);
+  });
+});
+
+describe('the turn-end path is unchanged', () => {
+  it('still replaces the row when the whole conversation is handed over', async () => {
+    const prior = priorConversation();
+    await seedRow('out-turnend', 'conv-turnend', prior);
+
+    // What turn end passes: the same conversation with the answer completed.
+    const whole = [...prior.slice(0, 5), { role: 'assistant', content: BIG_ANSWER }];
+    const result = await writeTranscript({
+      conversationId: 'conv-turnend', userId: USER, messages: whole, mode: 'whole',
+    });
+
+    expect(result.written).toBe(true);
+    const after = await savedMessages('out-turnend');
+    expect(after).toHaveLength(6);
+    expect(after[5].content).toContain('runMigrations');
+  });
+
+  it('defaults to whole when no mode is given, so existing callers are untouched', async () => {
+    const prior = priorConversation();
+    await seedRow('out-default', 'conv-default', prior);
+
+    const whole = [...prior.slice(0, 5), { role: 'assistant', content: BIG_ANSWER }];
+    const result = await writeTranscript({
+      conversationId: 'conv-default', userId: USER, messages: whole,
+    });
+
+    expect(result.written).toBe(true);
+    expect(await savedMessages('out-default')).toHaveLength(6);
+  });
+
+  it('does NOT apply the structural guard — the scoping is deliberate', async () => {
+    // The saved row and the turn-end projection can legitimately disagree about
+    // user turns: the tool-loop nudge is pushed as a `user` message into the
+    // provider history and the client's copy has never seen it. Refusing here
+    // would stop the sidebar updating, which is the bug this file exists to
+    // fix — so 'whole' trusts its caller and only the substance rule applies.
+    await seedRow('out-scoped', 'conv-scoped', [{ role: 'user', content: 'hi' }]);
+
+    const result = await writeTranscript({
+      conversationId: 'conv-scoped',
+      userId: USER,
+      messages: [
+        { role: 'user', content: 'a completely different opening line' },
+        { role: 'assistant', content: BIG_ANSWER },
+      ],
+      mode: 'whole',
+    });
+
+    expect(result.written).toBe(true);
+  });
+});

--- a/backend/src/services/orchestrator/persistTurnTranscript.test.js
+++ b/backend/src/services/orchestrator/persistTurnTranscript.test.js
@@ -1,0 +1,309 @@
+/**
+ * The saved row finishes the turn even when nobody is watching.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The run already outlives its socket. The SAVED row did not: content_outputs
+ * has one writer, an HTTP handler a client must call, so a conversation
+ * abandoned mid-answer stayed frozen at whatever the last attached browser
+ * managed to report. Measured on a real install: a sidebar row stuck at 5,107
+ * bytes while conversation_logs for the same conversation reached 74,471.
+ *
+ * The write is deliberately narrow, and the narrowness is the interesting
+ * part — each guard below prevents a bug that would be worse than the one
+ * being fixed:
+ *   - creating rows would enrol conversations no client chose to save;
+ *   - a full-row upsert silently nulls every column not passed, including the
+ *     user's own title;
+ *   - a projection that says less than the saved copy must never win.
+ *
+ * Runs against a throwaway AGNT_HOME — never touches the user's database.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import fsp from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+const broadcasts = [];
+vi.mock('../../utils/realtimeSync.js', () => ({
+  broadcastToUser: (...args) => { broadcasts.push(args); },
+  RealtimeEvents: { CONTENT_CREATED: 'content_created', CONTENT_UPDATED: 'content_updated' },
+}));
+
+let db;
+let ContentOutputModel;
+let persistTurnTranscript;
+let TMP;
+const savedEnv = {};
+
+const USER = 'user-turn-1';
+const OTHER_USER = 'user-turn-2';
+
+/** A tool-using turn, in the provider's own shape (what full_history holds). */
+const providerHistory = (closingLine = 'All ten minutes of work are done.') => ([
+  { role: 'user', content: 'run some long running task' },
+  {
+    role: 'assistant',
+    content: [
+      { type: 'text', text: 'Starting now.' },
+      { type: 'tool_use', id: 'call_1', name: 'shell', input: { cmd: 'long-job' } },
+    ],
+  },
+  // Protocol bookkeeping: a tool's OUTPUT arrives on a synthetic user turn.
+  { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call_1', content: 'exit 0' }] },
+  { role: 'assistant', content: [{ type: 'text', text: closingLine }] },
+]);
+
+const getRow = (id) => new Promise((resolve, reject) => {
+  db.get('SELECT * FROM content_outputs WHERE id = ?', [id], (e, r) => (e ? reject(e) : resolve(r)));
+});
+
+const countRows = (conversationId) => new Promise((resolve, reject) => {
+  db.get('SELECT COUNT(*) n FROM content_outputs WHERE conversation_id = ?', [conversationId],
+    (e, r) => (e ? reject(e) : resolve(r.n)));
+});
+
+/** A transcript in the STORED (UI) shape, as a client's autosave would write it. */
+const storedTranscript = (messages) => JSON.stringify({ conversationId: 'x', title: 't', messages });
+
+beforeAll(async () => {
+  TMP = await fsp.mkdtemp(path.join(os.tmpdir(), 'agnt-turnsave-'));
+  for (const k of ['AGNT_HOME', 'USER_DATA_PATH', 'DOCKER_CONTAINER']) savedEnv[k] = process.env[k];
+  delete process.env.USER_DATA_PATH;
+  delete process.env.DOCKER_CONTAINER;
+  process.env.AGNT_HOME = TMP;
+
+  const dataDir = path.join(TMP, '.agnt', 'data');
+  await fsp.mkdir(dataDir, { recursive: true });
+  await fsp.writeFile(path.join(dataDir, 'agnt.db'), '');
+
+  const dbMod = await import('../../models/database/index.js');
+  db = dbMod.default;
+  await dbMod.dbReady;
+
+  ContentOutputModel = (await import('../../models/ContentOutputModel.js')).default;
+  ({ persistTurnTranscript } = await import('./persistTurnTranscript.js'));
+
+  for (const uid of [USER, OTHER_USER]) {
+    await new Promise((resolve, reject) => {
+      db.run('INSERT INTO users (id, email) VALUES (?, ?)', [uid, `${uid}@test.local`],
+        (e) => (e ? reject(e) : resolve()));
+    });
+  }
+}, 120000);
+
+afterAll(async () => {
+  await new Promise((r) => db.close(r));
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  await fsp.rm(TMP, { recursive: true, force: true }).catch(() => {});
+});
+
+beforeEach(() => { broadcasts.length = 0; });
+
+describe('finishing the row a departed client left behind', () => {
+  it('replaces a transcript truncated mid-answer — the reported bug', async () => {
+    const conversationId = 'conv-abandoned';
+    // What the browser managed to save before it went away: the question, and
+    // the first few words of the reply.
+    await ContentOutputModel.createOrUpdate(
+      'out-abandoned', USER, null, null,
+      storedTranscript([
+        { role: 'user', content: 'run some long running task' },
+        { role: 'assistant', content: 'Starting now.' },
+      ]),
+      false, 'conversation', conversationId, 'run some long running task',
+    );
+
+    const result = await persistTurnTranscript({
+      conversationId, userId: USER, providerMessages: providerHistory(),
+    });
+
+    expect(result).toMatchObject({ written: true, outputId: 'out-abandoned' });
+
+    const saved = JSON.parse((await getRow('out-abandoned')).content);
+    const assistant = saved.messages.find((m) => m.role === 'assistant');
+    expect(assistant.content).toContain('All ten minutes of work are done.');
+    // The tool card survives the round trip: a transcript that loses its tool
+    // calls is the failure this projection exists to avoid.
+    expect(assistant.toolCalls.map((t) => t.name)).toEqual(['shell']);
+    expect(assistant.contentParts.some((p) => p.type === 'tool_call')).toBe(true);
+  });
+
+  it('merges the whole answer into ONE assistant turn, not one per provider row', async () => {
+    const conversationId = 'conv-merge';
+    await ContentOutputModel.createOrUpdate('out-merge', USER, null, null,
+      storedTranscript([{ role: 'user', content: 'hi' }]), false, 'conversation', conversationId, 'hi');
+
+    await persistTurnTranscript({ conversationId, userId: USER, providerMessages: providerHistory() });
+
+    const saved = JSON.parse((await getRow('out-merge')).content);
+    // user + one merged assistant. The synthetic tool-result turn must not
+    // render as an empty user bubble.
+    expect(saved.messages.map((m) => m.role)).toEqual(['user', 'assistant']);
+  });
+
+  it('tells other tabs, so an open sidebar stops showing the stale preview', async () => {
+    const conversationId = 'conv-broadcast';
+    await ContentOutputModel.createOrUpdate('out-broadcast', USER, null, null,
+      storedTranscript([{ role: 'user', content: 'hi' }]), false, 'conversation', conversationId, 'hi');
+
+    await persistTurnTranscript({ conversationId, userId: USER, providerMessages: providerHistory() });
+
+    const [userId, event, payload] = broadcasts.at(-1);
+    expect(userId).toBe(USER);
+    expect(event).toBe('content_updated');
+    expect(payload).toMatchObject({ id: 'out-broadcast', contentType: 'conversation' });
+  });
+});
+
+describe('what it refuses to do', () => {
+  it('never CREATES a row — a conversation no client saved stays unlisted', async () => {
+    // Agent chats, suggestion calls and embedded surfaces all deliberately
+    // avoid the main list. Creating rows here would enrol every one of them.
+    const result = await persistTurnTranscript({
+      conversationId: 'conv-never-saved', userId: USER, providerMessages: providerHistory(),
+    });
+
+    expect(result).toEqual({ written: false, reason: 'no_saved_row' });
+    expect(await countRows('conv-never-saved')).toBe(0);
+  });
+
+  it('never shrinks a saved copy that says more', async () => {
+    const conversationId = 'conv-richer';
+    const richer = storedTranscript([
+      { role: 'user', content: 'run some long running task' },
+      { role: 'assistant', content: 'A far longer answer than the projection, '.repeat(40) },
+    ]);
+    await ContentOutputModel.createOrUpdate('out-richer', USER, null, null, richer,
+      false, 'conversation', conversationId, 'title');
+
+    const result = await persistTurnTranscript({
+      conversationId, userId: USER, providerMessages: providerHistory(),
+    });
+
+    expect(result).toEqual({ written: false, reason: 'saved_copy_is_richer' });
+    expect((await getRow('out-richer')).content).toBe(richer);
+  });
+
+  it('keeps a title the user chose', async () => {
+    const conversationId = 'conv-renamed';
+    await ContentOutputModel.createOrUpdate('out-renamed', USER, null, null,
+      storedTranscript([{ role: 'user', content: 'hi' }]), false, 'conversation',
+      conversationId, 'My carefully chosen name');
+
+    await persistTurnTranscript({ conversationId, userId: USER, providerMessages: providerHistory() });
+
+    // createOrUpdate assigns title from `excluded` — passing a derived one
+    // would rename the user's conversation behind their back.
+    expect((await getRow('out-renamed')).title).toBe('My carefully chosen name');
+  });
+
+  it('keeps a scoped row scoped, out of the main conversation list', async () => {
+    const conversationId = 'conv-scoped';
+    await ContentOutputModel.createOrUpdate('out-scoped', USER, null, null,
+      storedTranscript([{ role: 'user', content: 'hi' }]), false, 'conversation',
+      conversationId, 'in a workspace', { channelKey: 'workspace:ws-1' });
+
+    await persistTurnTranscript({ conversationId, userId: USER, providerMessages: providerHistory() });
+
+    expect((await getRow('out-scoped')).channel_key).toBe('workspace:ws-1');
+  });
+
+  it('does not blank the columns it was never asked to change', async () => {
+    // createOrUpdate is a FULL-ROW upsert: is_shareable and tool_id are
+    // assigned from `excluded`, so a background write that omits them wipes
+    // them.
+    const conversationId = 'conv-columns';
+    await ContentOutputModel.createOrUpdate('out-columns', USER, null, 'tool-9',
+      storedTranscript([{ role: 'user', content: 'hi' }]), true, 'conversation', conversationId, 'kept');
+
+    await persistTurnTranscript({ conversationId, userId: USER, providerMessages: providerHistory() });
+
+    const row = await getRow('out-columns');
+    expect(row.tool_id).toBe('tool-9');
+    expect(row.is_shareable).toBe(1);
+  });
+
+  it('leaves the read watermark alone, so a finished run still shows as unread', async () => {
+    const conversationId = 'conv-unread';
+    await ContentOutputModel.createOrUpdate('out-unread', USER, null, null,
+      storedTranscript([{ role: 'user', content: 'hi' }]), false, 'conversation', conversationId, 'hi');
+    await ContentOutputModel.setReadState('out-unread', USER, true);
+    const readAt = (await getRow('out-unread')).last_read_at;
+
+    await persistTurnTranscript({ conversationId, userId: USER, providerMessages: providerHistory() });
+
+    // Unread is "updated_at later than last_read_at". Moving the watermark
+    // here would silently mark the very answer the user has not seen as read.
+    expect((await getRow('out-unread')).last_read_at).toBe(readAt);
+  });
+
+  it('ignores a row that is not a transcript', async () => {
+    const conversationId = 'conv-not-chat';
+    await ContentOutputModel.createOrUpdate('out-not-chat', USER, null, null, '<p>a report</p>',
+      false, 'html', conversationId, 'report');
+
+    const result = await persistTurnTranscript({
+      conversationId, userId: USER, providerMessages: providerHistory(),
+    });
+
+    expect(result).toEqual({ written: false, reason: 'not_a_transcript' });
+    expect((await getRow('out-not-chat')).content).toBe('<p>a report</p>');
+  });
+
+  it('cannot reach another user\'s row', async () => {
+    const conversationId = 'conv-theirs';
+    await ContentOutputModel.createOrUpdate('out-theirs', OTHER_USER, null, null,
+      storedTranscript([{ role: 'user', content: 'private' }]), false, 'conversation',
+      conversationId, 'theirs');
+
+    const result = await persistTurnTranscript({
+      conversationId, userId: USER, providerMessages: providerHistory(),
+    });
+
+    expect(result).toEqual({ written: false, reason: 'no_saved_row' });
+    expect(JSON.parse((await getRow('out-theirs')).content).messages).toHaveLength(1);
+  });
+});
+
+describe('it can never break the turn that produced it', () => {
+  it('resolves rather than throws when the turn is unidentified', async () => {
+    await expect(persistTurnTranscript({})).resolves.toEqual({ written: false, reason: 'not_identified' });
+    await expect(persistTurnTranscript({ conversationId: 'c' }))
+      .resolves.toEqual({ written: false, reason: 'not_identified' });
+  });
+
+  it('resolves on an empty history rather than storing an empty transcript', async () => {
+    await expect(persistTurnTranscript({ conversationId: 'c', userId: USER, providerMessages: [] }))
+      .resolves.toEqual({ written: false, reason: 'no_history' });
+  });
+
+  it('reports a database failure instead of raising it into the run', async () => {
+    const original = ContentOutputModel.findByConversationId;
+    ContentOutputModel.findByConversationId = () => Promise.reject(new Error('disk on fire'));
+    try {
+      await expect(persistTurnTranscript({
+        conversationId: 'c', userId: USER, providerMessages: providerHistory(),
+      })).resolves.toEqual({ written: false, reason: 'error' });
+    } finally {
+      ContentOutputModel.findByConversationId = original;
+    }
+  });
+
+  it('replaces content that will not parse — unparseable renders as nothing', async () => {
+    const conversationId = 'conv-corrupt';
+    await ContentOutputModel.createOrUpdate('out-corrupt', USER, null, null, 'not json at all',
+      false, 'conversation', conversationId, 'corrupt');
+
+    const result = await persistTurnTranscript({
+      conversationId, userId: USER, providerMessages: providerHistory(),
+    });
+
+    expect(result.written).toBe(true);
+    expect(JSON.parse((await getRow('out-corrupt')).content).messages).toHaveLength(2);
+  });
+});

--- a/backend/src/services/orchestrator/recoverJournaledRuns.js
+++ b/backend/src/services/orchestrator/recoverJournaledRuns.js
@@ -23,6 +23,16 @@
  * shrink a richer saved copy, carry every column, leave the read watermark
  * alone. That also makes recovery IDEMPOTENT — running it twice, or running it
  * on a journal whose turn actually did finish, cannot damage anything.
+ *
+ * WHAT A JOURNAL IS NOT
+ * ─────────────────────
+ * A journal holds ONE TURN, not a conversation: the user's message and the
+ * answer that was in flight. The turn-end caller hands writeTranscript the
+ * whole history, so a full-row write is correct there and wrong here — the
+ * fragment would replace every earlier turn with itself, and substance alone
+ * does not notice because one long interrupted answer outscores several short
+ * earlier turns. So the write is made in `appendTurn` mode, which merges the
+ * turn into the saved transcript instead of standing in for it.
  */
 
 import { applyStreamEvent, createAssistantMessage } from './chatStreamReducer.mirror.js';
@@ -141,6 +151,8 @@ export async function recoverJournaledRuns({ now = Date.now() } = {}) {
         conversationId: journal.conversationId,
         userId: journal.userId,
         messages,
+        // One turn, not a conversation — merge it, do not stand in for it.
+        mode: 'appendTurn',
         logTag: 'RunRecovery',
       });
 
@@ -158,7 +170,8 @@ export async function recoverJournaledRuns({ now = Date.now() } = {}) {
         // Discarded once a DECISION has been reached — written or declined.
         // A journal that declined now will decline on the next boot too: the
         // reasons are all permanent (no_saved_row, not_a_transcript,
-        // saved_copy_is_richer), so keeping it would re-decide it forever.
+        // saved_copy_is_richer, would_drop_user_turns), so keeping it would
+        // re-decide it forever.
         await removeJournalFile(journal.file);
       } catch (err) {
         // Deliberately NOT deleted here. An exception is not a decision: at boot

--- a/backend/src/services/orchestrator/recoverJournaledRuns.js
+++ b/backend/src/services/orchestrator/recoverJournaledRuns.js
@@ -1,0 +1,190 @@
+/**
+ * recoverJournaledRuns.js — turn journals left by a dead process back into
+ * saved conversations, at boot.
+ *
+ * A journal exists only for a run that never reached endRun, which means the
+ * process died while it was generating. conversation_logs is written at turn
+ * END, so for those turns there is no other record anywhere: before this, the
+ * work was not merely unreachable, it was gone.
+ *
+ * WHY THE CLIENT'S OWN REDUCER
+ * ────────────────────────────
+ * The journal holds SSE events, which is what a browser consumes — not the
+ * provider transcript that persistTurnTranscript projects from. Rather than
+ * invent a third way to turn a turn into messages, this replays the events
+ * through `applyStreamEvent` from chatStreamReducer.mirror.js: the byte-exact
+ * copy of the reducer the client itself runs, already pinned to the original by
+ * chatStreamReducer.mirror.test.js. A recovered transcript is therefore built
+ * the same way the live one was, by the same code, and cannot render
+ * differently from what the user was watching when the lights went out.
+ *
+ * The write goes through writeTranscript, so recovery inherits every rule the
+ * turn-end path already has: update-only (never invent a conversation), never
+ * shrink a richer saved copy, carry every column, leave the read watermark
+ * alone. That also makes recovery IDEMPOTENT — running it twice, or running it
+ * on a journal whose turn actually did finish, cannot damage anything.
+ */
+
+import { applyStreamEvent, createAssistantMessage } from './chatStreamReducer.mirror.js';
+import { writeTranscript } from './persistTurnTranscript.js';
+import { listJournals, removeJournalFile, MAX_JOURNAL_AGE_MS } from './runJournal.js';
+
+/** Shown on the recovered turn so a truncated answer is never mistaken for the whole one. */
+export const INTERRUPTED_NOTE = 'Interrupted — the backend restarted while this was generating';
+
+/**
+ * Replay a journal's events into UI messages.
+ *
+ * Mirrors the client's own SSE handling: `assistant_message` CREATES a message
+ * (the reducer has no case for it — the client adds it to the transcript), and
+ * every later event is applied to that message.
+ *
+ * Exported for tests, and because this is the interesting half.
+ */
+export function messagesFromJournal({ userMessage, events = [] }) {
+  const messages = [];
+
+  if (typeof userMessage === 'string' && userMessage.trim()) {
+    messages.push({
+      id: `msg-user-recovered-${Date.now()}`,
+      role: 'user',
+      content: userMessage,
+      timestamp: Date.now(),
+      metadata: [],
+      toolCalls: [],
+      contentParts: [],
+    });
+  }
+
+  let current = null;
+  for (const entry of events) {
+    const { eventName, data } = entry || {};
+    if (!eventName) continue;
+
+    if (eventName === 'assistant_message') {
+      // The event payload IS the message, exactly as the client treats it.
+      // Seeded from a canonical shape first so a sparse payload still has the
+      // mutable fields the reducer writes into.
+      current = {
+        ...createAssistantMessage({ id: data?.id, timestamp: data?.timestamp }),
+        ...(data && typeof data === 'object' ? data : {}),
+      };
+      if (typeof current.content !== 'string') current.content = '';
+      if (!Array.isArray(current.contentParts)) current.contentParts = [];
+      if (!Array.isArray(current.toolCalls)) current.toolCalls = [];
+      if (typeof current.reasoning !== 'string') current.reasoning = '';
+      current.role = 'assistant';
+      messages.push(current);
+      continue;
+    }
+
+    if (!current) continue; // telemetry before any assistant turn — nothing to apply it to
+    try {
+      applyStreamEvent(current, eventName, data || {});
+    } catch {
+      // One malformed event must not cost the whole answer.
+    }
+  }
+
+  // Say so, on the turn itself. A partial answer that looks complete is worse
+  // than an obviously partial one.
+  const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant');
+  if (lastAssistant) {
+    lastAssistant.metadata = [...(lastAssistant.metadata || []), INTERRUPTED_NOTE];
+  }
+
+  // Nothing the user would recognise as an answer — drop it rather than write
+  // an empty bubble over whatever is already saved.
+  const hasSubstance = messages.some(
+    (m) => (m.content && m.content.trim()) || (m.toolCalls && m.toolCalls.length),
+  );
+  return hasSubstance ? messages : [];
+}
+
+/**
+ * Recover every journal on disk. Safe to call once per boot.
+ *
+ * Never throws: a failure here must not stop the server starting. Returns a
+ * summary so the caller can log one honest line.
+ */
+export async function recoverJournaledRuns({ now = Date.now() } = {}) {
+  const summary = { found: 0, recovered: 0, skipped: 0, expired: 0 };
+
+  let journals;
+  try {
+    journals = await listJournals();
+  } catch (err) {
+    console.warn('[RunRecovery] Could not read journals:', err?.message || err);
+    return summary;
+  }
+  summary.found = journals.length;
+  if (!journals.length) return summary;
+
+  for (const journal of journals) {
+    try {
+      // A journal this old is not a turn anybody is still waiting for, and
+      // keeping it would mean retrying the same failure on every boot forever.
+      if (journal.journaledAt && now - journal.journaledAt > MAX_JOURNAL_AGE_MS) {
+        summary.expired += 1;
+        await removeJournalFile(journal.file);
+        continue;
+      }
+
+      const messages = messagesFromJournal(journal);
+      if (!messages.length) {
+        summary.skipped += 1;
+        await removeJournalFile(journal.file);
+        continue;
+      }
+
+      const result = await writeTranscript({
+        conversationId: journal.conversationId,
+        userId: journal.userId,
+        messages,
+        logTag: 'RunRecovery',
+      });
+
+      if (result.written) {
+        summary.recovered += 1;
+        console.log(
+          `[RunRecovery] Restored the interrupted turn in ${journal.conversationId} `
+          + `(${messages.length} message(s) from a journal written ${new Date(journal.journaledAt).toISOString()})`,
+        );
+      } else {
+        summary.skipped += 1;
+        console.log(`[RunRecovery] Nothing to restore for ${journal.conversationId}: ${result.reason}`);
+      }
+
+        // Discarded once a DECISION has been reached — written or declined.
+        // A journal that declined now will decline on the next boot too: the
+        // reasons are all permanent (no_saved_row, not_a_transcript,
+        // saved_copy_is_richer), so keeping it would re-decide it forever.
+        await removeJournalFile(journal.file);
+      } catch (err) {
+        // Deliberately NOT deleted here. An exception is not a decision: at boot
+        // it is frequently transient — a database still opening, a locked sqlite
+        // file, a disk that is briefly unhappy — and this file is the ONLY copy
+        // of an interrupted turn. Retrying on the next boot costs one failed
+        // write; deleting costs the user their answer.
+        //
+        // This cannot retry forever: the age check at the top of the loop
+        // expires a journal older than MAX_JOURNAL_AGE_MS before any write is
+        // attempted, so a permanently poisonous journal is still collected.
+        console.warn(
+          `[RunRecovery] Failed on ${journal?.conversationId}, keeping the journal to retry at the next boot:`,
+          err?.message || err,
+        );
+        summary.skipped += 1;
+      }
+  }
+
+  if (summary.recovered > 0 || summary.expired > 0) {
+    console.log(
+      `[RunRecovery] ${summary.recovered} turn(s) restored, `
+      + `${summary.skipped} skipped, ${summary.expired} expired, from ${summary.found} journal(s)`,
+    );
+  }
+  return summary;
+}
+
+export default recoverJournaledRuns;

--- a/backend/src/services/orchestrator/recoverJournaledRuns.test.js
+++ b/backend/src/services/orchestrator/recoverJournaledRuns.test.js
@@ -1,0 +1,125 @@
+/**
+ * What recovery does with the journal FILE, which is the only copy of an
+ * interrupted turn.
+ *
+ * The deletion policy is the whole point of these tests. Deleting after a
+ * decision is correct: the decision will be the same on the next boot, so
+ * keeping the file would mean re-deciding it forever. Deleting after an
+ * EXCEPTION is not, because an exception at boot is frequently transient — a
+ * database still opening, a locked sqlite file, a disk hiccup — and the file
+ * being deleted is the only record that the turn ever happened.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('./runJournal.js', () => ({
+  listJournals: vi.fn(),
+  removeJournalFile: vi.fn(async () => {}),
+  MAX_JOURNAL_AGE_MS: 24 * 60 * 60 * 1000,
+}));
+
+vi.mock('./persistTurnTranscript.js', () => ({
+  writeTranscript: vi.fn(),
+}));
+
+import { recoverJournaledRuns } from './recoverJournaledRuns.js';
+import { listJournals, removeJournalFile, MAX_JOURNAL_AGE_MS } from './runJournal.js';
+import { writeTranscript } from './persistTurnTranscript.js';
+
+/** A journal with enough substance that messagesFromJournal returns messages. */
+function journal(overrides = {}) {
+  return {
+    file: '/tmp/run-journal/conv-abc-1234.json',
+    conversationId: 'conv-abc',
+    userId: 'user-1',
+    journaledAt: Date.now(),
+    userMessage: 'does this survive?',
+    events: [
+      { eventName: 'assistant_message', data: { id: 'msg-1', content: 'a partial answer' } },
+    ],
+    ...overrides,
+  };
+}
+
+describe('recoverJournaledRuns — when the journal file is deleted', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('KEEPS the journal when the write throws, because the failure may be transient', async () => {
+    listJournals.mockResolvedValue([journal()]);
+    // The shape of a boot-time failure: the database is not ready yet.
+    writeTranscript.mockRejectedValue(new Error('SQLITE_BUSY: database is locked'));
+
+    const summary = await recoverJournaledRuns();
+
+    expect(removeJournalFile).not.toHaveBeenCalled();
+    expect(summary.skipped).toBe(1);
+    expect(summary.recovered).toBe(0);
+  });
+
+  it('still does not throw when recovery fails, so a bad journal cannot stop the boot', async () => {
+    listJournals.mockResolvedValue([journal()]);
+    writeTranscript.mockRejectedValue(new Error('kaboom'));
+
+    await expect(recoverJournaledRuns()).resolves.toMatchObject({ found: 1 });
+  });
+
+  it('keeps the journal for one failure but not forever — age expiry still collects it', async () => {
+    const old = journal({ journaledAt: Date.now() - (MAX_JOURNAL_AGE_MS + 60_000) });
+    listJournals.mockResolvedValue([old]);
+
+    const summary = await recoverJournaledRuns();
+
+    // Expiry runs before any write is attempted, so a journal that fails every
+    // boot is still bounded: it is collected once it ages out.
+    expect(writeTranscript).not.toHaveBeenCalled();
+    expect(removeJournalFile).toHaveBeenCalledWith(old.file);
+    expect(summary.expired).toBe(1);
+  });
+
+  it('REMOVES the journal once the transcript is written', async () => {
+    const j = journal();
+    listJournals.mockResolvedValue([j]);
+    writeTranscript.mockResolvedValue({ written: true });
+
+    const summary = await recoverJournaledRuns();
+
+    expect(removeJournalFile).toHaveBeenCalledWith(j.file);
+    expect(summary.recovered).toBe(1);
+  });
+
+  it('REMOVES the journal when the write declines for a permanent reason', async () => {
+    const j = journal();
+    listJournals.mockResolvedValue([j]);
+    writeTranscript.mockResolvedValue({ written: false, reason: 'saved_copy_is_richer' });
+
+    const summary = await recoverJournaledRuns();
+
+    // Not an error: the saved copy already says more. That verdict cannot change
+    // on a later boot, so keeping the file would re-decide it forever.
+    expect(removeJournalFile).toHaveBeenCalledWith(j.file);
+    expect(summary.skipped).toBe(1);
+  });
+
+  it('does not let one failing journal stop the next one from being recovered', async () => {
+    const bad = journal({ file: '/tmp/bad.json', conversationId: 'conv-bad' });
+    const good = journal({ file: '/tmp/good.json', conversationId: 'conv-good' });
+    listJournals.mockResolvedValue([bad, good]);
+    writeTranscript
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValueOnce({ written: true });
+
+    const summary = await recoverJournaledRuns();
+
+    expect(summary.recovered).toBe(1);
+    expect(removeJournalFile).toHaveBeenCalledWith(good.file);
+    expect(removeJournalFile).not.toHaveBeenCalledWith(bad.file);
+  });
+});

--- a/backend/src/services/orchestrator/runJournal.heartbeat.test.js
+++ b/backend/src/services/orchestrator/runJournal.heartbeat.test.js
@@ -1,0 +1,284 @@
+/**
+ * The heartbeat: a safety net for the journal, not a second mechanism.
+ *
+ * WHAT IT IS FOR, AND WHAT IT IS DELIBERATELY NOT FOR
+ * ──────────────────────────────────────────────────
+ * The event-driven throttle already bounds staleness. Measured before writing
+ * any of this: a run that publishes three events and then falls silent for
+ * twelve seconds — which is exactly what a long synchronous tool call looks
+ * like — has its LAST event on disk three seconds in. Nothing is stranded, and
+ * an unconditional periodic flush would rewrite byte-identical files forever.
+ *
+ * What the throttle cannot do is RETRY. `pending` is cleared before the write
+ * is attempted, so a failed write leaves nothing scheduled, and the next
+ * attempt waits for the next event. During a long tool call none arrives.
+ * Measured too: a run whose write failed stayed absent from disk indefinitely.
+ *
+ * So the tests below are mostly about restraint — the heartbeat must do
+ * nothing when there is nothing to do — and about the one case where it must
+ * act.
+ *
+ * Runs against a throwaway AGNT_HOME.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import fsp from 'fs/promises';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+let journal;
+let TMP;
+let DIR;
+const savedEnv = {};
+
+/** Poll until `probe` is truthy — never a bare sleep, which makes flaky gates. */
+async function until(probe, { timeout = 5000, interval = 25, what = 'condition' } = {}) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    const v = await probe();
+    if (v) return v;
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+    await new Promise((r) => setTimeout(r, interval));
+  }
+}
+
+const makeRun = (conversationId, extra = {}) => ({
+  conversationId,
+  userId: 'hb-user',
+  chatType: 'orchestrator',
+  startedAt: Date.now(),
+  userMessage: 'heartbeat test',
+  truncated: false,
+  bytes: 100,
+  ended: false,
+  events: [
+    { eventName: 'conversation_started', data: {} },
+    { eventName: 'assistant_message', data: { id: 'a1', role: 'assistant', content: '' } },
+    { eventName: 'content_delta', data: { assistantMessageId: 'a1', delta: 'partial answer' } },
+  ],
+  latest: new Map(),
+  subscribers: new Set(),
+  ...extra,
+});
+
+const journalFor = async (id) => (await journal.listJournals()).find((j) => j.conversationId === id);
+
+beforeAll(async () => {
+  TMP = await fsp.mkdtemp(path.join(os.tmpdir(), 'agnt-hb-'));
+  for (const k of ['AGNT_HOME', 'USER_DATA_PATH', 'DOCKER_CONTAINER']) savedEnv[k] = process.env[k];
+  delete process.env.USER_DATA_PATH;
+  delete process.env.DOCKER_CONTAINER;
+  process.env.AGNT_HOME = TMP;
+
+  await fsp.mkdir(path.join(TMP, '.agnt', 'data'), { recursive: true });
+  journal = await import('./runJournal.js');
+  DIR = path.join(TMP, '.agnt', 'data', 'run-journal');
+}, 60000);
+
+afterAll(async () => {
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  await fsp.rm(TMP, { recursive: true, force: true }).catch(() => {});
+});
+
+beforeEach(async () => {
+  journal._resetForTests();
+  await fsp.rm(DIR, { recursive: true, force: true }).catch(() => {});
+});
+
+afterEach(() => {
+  journal.stopJournalHeartbeat();
+  // Never leave a directory unwritable behind — the next test would fail for
+  // a reason that has nothing to do with what it is checking.
+  try { fs.chmodSync(DIR, 0o700); } catch { /* may not exist */ }
+});
+
+describe('what the heartbeat is FOR: retrying a write that failed', () => {
+  it('recovers a run whose write failed, with no further events', async () => {
+    // The gap, exactly: a transient disk error, then a long tool call during
+    // which nothing publishes. Before the heartbeat this run stayed uninsured
+    // until the turn produced its next event — potentially minutes later.
+    const run = makeRun('hb-retry');
+    await fsp.mkdir(DIR, { recursive: true });
+    await fsp.chmod(DIR, 0o500); // writes fail
+
+    journal.journalRun(run);
+    await new Promise((r) => setTimeout(r, 3200)); // let the throttled write fail
+    expect(await journalFor('hb-retry')).toBeUndefined();
+
+    // The disk recovers. No new event will ever arrive.
+    await fsp.chmod(DIR, 0o700);
+    journal.startJournalHeartbeat(() => [run], { intervalMs: 50 });
+
+    const found = await until(() => journalFor('hb-retry'), { what: 'the heartbeat to retry' });
+    expect(found.events).toHaveLength(3);
+  }, 20000);
+
+  it('keeps retrying while the failure persists, then succeeds', async () => {
+    const run = makeRun('hb-persistent');
+    await fsp.mkdir(DIR, { recursive: true });
+    await fsp.chmod(DIR, 0o500);
+
+    journal.journalRun(run);
+    journal.startJournalHeartbeat(() => [run], { intervalMs: 40 });
+
+    // Several heartbeat cycles pass with the directory still unwritable.
+    await new Promise((r) => setTimeout(r, 300));
+    expect(await journalFor('hb-persistent')).toBeUndefined();
+
+    await fsp.chmod(DIR, 0o700);
+    const found = await until(() => journalFor('hb-persistent'), { what: 'recovery once writable' });
+    expect(found.conversationId).toBe('hb-persistent');
+  }, 20000);
+});
+
+describe('what the heartbeat must NOT do: churn', () => {
+  it('does not rewrite a journal that is already current', async () => {
+    // An unconditional periodic flush would rewrite byte-identical files. For
+    // an 8MB run on a 30s timer that is megabytes a minute of pointless I/O,
+    // on the same disk as the database, to save data that is already saved.
+    const run = makeRun('hb-clean');
+    expect(journal.flushAllSync([run])).toBe(1);
+
+    const file = path.join(DIR, fs.readdirSync(DIR).find((f) => f.startsWith('hb-clean')));
+    const before = fs.statSync(file).mtimeMs;
+
+    journal.startJournalHeartbeat(() => [run], { intervalMs: 30 });
+    await new Promise((r) => setTimeout(r, 400)); // ~13 cycles
+
+    expect(fs.statSync(file).mtimeMs).toBe(before);
+  }, 20000);
+
+  it('goes clean after a write and dirty again on the next event', async () => {
+    // The full cycle, exercised through the only route that can reach the
+    // heartbeat: write, go quiet, take a new event, have THAT write fail, and
+    // watch the heartbeat carry it. If `written` were recorded before the
+    // write instead of after, the retry here would never happen.
+    const run = makeRun('hb-cycle');
+    journal.flushAllSync([run]);
+    expect((await journalFor('hb-cycle')).events).toHaveLength(3);
+
+    await fsp.chmod(DIR, 0o500); // the next write will fail
+    run.events.push({ eventName: 'content_delta', data: { assistantMessageId: 'a1', delta: ' more' } });
+    journal.journalRun(run);
+    await new Promise((r) => setTimeout(r, 3200)); // throttle fires and fails
+
+    // Still the three-event version: the failed write changed nothing.
+    expect((await journalFor('hb-cycle')).events).toHaveLength(3);
+
+    await fsp.chmod(DIR, 0o700);
+    journal.startJournalHeartbeat(() => [run], { intervalMs: 40 });
+
+    const found = await until(
+      async () => {
+        const j = await journalFor('hb-cycle');
+        return j && j.events.length === 4 ? j : null;
+      },
+      { what: 'the heartbeat to carry the fourth event' },
+    );
+    expect(found.events).toHaveLength(4);
+  }, 25000);
+
+  it('leaves a run alone while its throttled write is still scheduled', async () => {
+    // Two writers for one run is the situation the temp-path sequence makes
+    // harmless; there is still no reason to cause it.
+    const run = makeRun('hb-pending');
+    journal.journalRun(run); // schedules a write ~3s out
+    journal.startJournalHeartbeat(() => [run], { intervalMs: 20 });
+
+    await new Promise((r) => setTimeout(r, 300)); // many cycles, throttle still pending
+    expect(await journalFor('hb-pending')).toBeUndefined();
+
+    // ...and the throttle still delivers on its own schedule.
+    const found = await until(() => journalFor('hb-pending'), { timeout: 6000, what: 'the throttled write' });
+    expect(found.events).toHaveLength(3);
+  }, 20000);
+
+  it('ignores runs with nothing worth saving, and ended runs', async () => {
+    const empty = makeRun('hb-empty', { events: [{ eventName: 'conversation_started', data: {} }] });
+    const ended = makeRun('hb-ended', { ended: true });
+
+    journal.startJournalHeartbeat(() => [empty, ended], { intervalMs: 20 });
+    await new Promise((r) => setTimeout(r, 250));
+
+    expect(await journal.listJournals()).toHaveLength(0);
+  }, 20000);
+});
+
+describe('lifecycle', () => {
+  it('starting twice does not create a second interval', async () => {
+    const first = journal.startJournalHeartbeat(() => [], { intervalMs: 50 });
+    const second = journal.startJournalHeartbeat(() => [], { intervalMs: 50 });
+    expect(second).toBe(first);
+  });
+
+  it('stops cleanly, and stopping twice is safe', async () => {
+    const run = makeRun('hb-stop');
+    journal.startJournalHeartbeat(() => [run], { intervalMs: 20 });
+    journal.stopJournalHeartbeat();
+    journal.stopJournalHeartbeat();
+
+    await new Promise((r) => setTimeout(r, 200));
+    expect(await journalFor('hb-stop')).toBeUndefined();
+  }, 20000);
+
+  it('refuses to start without a run source rather than throwing', () => {
+    expect(journal.startJournalHeartbeat(undefined)).toBeNull();
+  });
+
+  it('survives a run source that throws', async () => {
+    journal.startJournalHeartbeat(() => { throw new Error('registry exploded'); }, { intervalMs: 20 });
+    await new Promise((r) => setTimeout(r, 150));
+    // Still running, still harmless.
+    expect(journal.startJournalHeartbeat(() => [], { intervalMs: 20 })).toBeTruthy();
+  }, 20000);
+});
+
+describe('temp files', () => {
+  it('gives every write its own temp path', async () => {
+    // Was `${target}.${pid}.tmp` — unique per process, not per write, so the
+    // shutdown flush and a throttled write could target the same file.
+    const a = makeRun('hb-tmp-a');
+    const b = makeRun('hb-tmp-b');
+    journal.flushAllSync([a, b, a]);
+
+    const src = fs.readFileSync(new URL('./runJournal.js', import.meta.url), 'utf8');
+    expect(src).toMatch(/\$\{target\}\.\$\{process\.pid\}\.\$\{writeSeq\}\.tmp/);
+  });
+
+  it('sweeps orphaned temp files, but not fresh ones', async () => {
+    await fsp.mkdir(DIR, { recursive: true });
+    const stale = path.join(DIR, 'gone-12345678.json.999.1.tmp');
+    const fresh = path.join(DIR, 'live-87654321.json.999.2.tmp');
+    await fsp.writeFile(stale, '{}');
+    await fsp.writeFile(fresh, '{}');
+    // Backdate the stale one past the 5-minute grace period.
+    const old = new Date(Date.now() - 10 * 60 * 1000);
+    await fsp.utimes(stale, old, old);
+
+    await journal.listJournals();
+
+    expect(fs.existsSync(stale)).toBe(false);
+    expect(fs.existsSync(fresh)).toBe(true); // a write in flight must survive
+  });
+});
+
+describe('bookkeeping', () => {
+  it('releases tracking state when a run is discarded', async () => {
+    // Otherwise the Maps grow by one entry per conversation for the life of
+    // the process and never shrink.
+    const run = makeRun('hb-leak');
+    journal.journalRun(run);
+    journal.discardJournal('hb-leak');
+
+    const src = fs.readFileSync(new URL('./runJournal.js', import.meta.url), 'utf8');
+    const body = src.slice(src.indexOf('export function discardJournal'));
+    const fn = body.slice(0, body.indexOf('\n}'));
+    expect(fn).toMatch(/revisions\.delete/);
+    expect(fn).toMatch(/written\.delete/);
+    expect(fn).toMatch(/failures\.delete/);
+  });
+});

--- a/backend/src/services/orchestrator/runJournal.js
+++ b/backend/src/services/orchestrator/runJournal.js
@@ -1,0 +1,431 @@
+/**
+ * runJournal.js — the replay log, on disk, so a backend restart does not
+ * destroy a turn that was still generating.
+ *
+ * WHAT THIS DOES AND DOES NOT BUY — READ THIS FIRST
+ * ────────────────────────────────────────────────
+ * activeRuns keeps its replay log in a `new Map()`. That is the right shape
+ * for what it was built for: a run outliving its SOCKET. It is the wrong shape
+ * for a run outliving its PROCESS, and the difference had a real cost — kill
+ * the backend mid-turn and the answer was not merely unreachable, it was gone,
+ * because conversation_logs is written at turn END and that end never came.
+ *
+ * This module makes the WORK ALREADY DONE durable. It does NOT, and cannot,
+ * make generation resume. The turn's abort controller is handed to the LLM
+ * adapter as `abortSignal` (OrchestratorService, the `streamAbortController`),
+ * so the connection to the provider lives in this process's memory. When the
+ * process dies that connection dies with it, and no amount of journalling
+ * brings it back — the tokens that were never generated do not exist anywhere
+ * to be recovered from.
+ *
+ * So the honest promise is: after a restart you get everything that had been
+ * produced up to the moment of death, saved into the conversation where you
+ * expect to find it, marked as interrupted. Not a turn that carries on.
+ *
+ * WHY SNAPSHOTS RATHER THAN AN APPEND-ONLY LOG
+ * ────────────────────────────────────────────
+ * The in-memory log is not append-only: appendToLog COALESCES consecutive text
+ * deltas by mutating the previous entry, which is exactly what keeps it
+ * O(answer) instead of O(chunks). An append-only journal would have to write
+ * every raw delta and would throw that property away. So each write is a whole
+ * snapshot, throttled, and the snapshot inherits the log's existing 8MB
+ * ceiling rather than needing one of its own.
+ *
+ * DURABILITY OF THE JOURNAL ITSELF
+ * ────────────────────────────────
+ * Written to a temp file and rename()d into place. rename is atomic, so a
+ * crash mid-write leaves either the previous good snapshot or the new one,
+ * never a half-file that would poison recovery on the next boot — which would
+ * turn a crash-recovery feature into a crash-loop.
+ */
+
+import fs from 'fs';
+import fsp from 'fs/promises';
+import path from 'path';
+import crypto from 'crypto';
+import PathManager from '../../utils/PathManager.js';
+
+/** Journals live under the AGNT data dir, so test isolation redirects them for free. */
+const JOURNAL_DIR = () => PathManager.getDataPath('run-journal');
+
+/** Snapshot cadence for an ordinary run. */
+const INTERVAL_MS = 3000;
+
+/**
+ * Cadence once a run's log is large. The ceiling in activeRuns is 8MB; writing
+ * that every 3s would be megabytes per second of I/O on the same disk the
+ * database is on, to insure a case that is already pathological.
+ */
+const LARGE_RUN_BYTES = 512 * 1024;
+const SLOW_INTERVAL_MS = 15000;
+
+/** A journal older than this is junk — a bug, or a run nobody will ever want. */
+export const MAX_JOURNAL_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How often the heartbeat looks for a run whose journal is behind.
+ *
+ * NOT the primary mechanism, and deliberately much slower than the throttle:
+ * the event-driven path above already guarantees every published event reaches
+ * disk within INTERVAL_MS. Measured, not assumed — a run that publishes and
+ * then falls silent for twelve seconds still has its last event on disk three
+ * seconds in.
+ *
+ * What the throttle CANNOT do is retry. `pending` is cleared before the write
+ * is attempted, so a write that fails leaves nothing scheduled, and the next
+ * attempt only happens when the next event arrives. During a long synchronous
+ * tool call no event arrives for minutes — so a transient EACCES/ENOSPC at
+ * exactly the wrong moment left the run uninsured for the whole tool call.
+ * That is the gap this closes, and it is why the heartbeat is dirty-checked
+ * rather than periodic: when nothing has changed there is nothing to write.
+ */
+const HEARTBEAT_MS = 30000;
+
+/** Per-conversation throttle state: { timer }. */
+const pending = new Map();
+
+/**
+ * Dirty tracking.
+ *
+ * `revisions` counts how many times a run's log has moved; `written` records
+ * the revision of the last SUCCESSFUL write. A run is dirty when they differ,
+ * which makes retry fall out for free: a failed write never updates `written`,
+ * so the run stays dirty and the next heartbeat picks it up.
+ */
+const revisions = new Map();
+const written = new Map();
+
+/** Consecutive write failures per conversation — used only to keep logs quiet. */
+const failures = new Map();
+
+/** Monotonic, so two concurrent writes can never share a temp path. */
+let writeSeq = 0;
+
+/** The heartbeat interval handle, or null when not running. */
+let heartbeatTimer = null;
+
+/**
+ * Filename for a conversation.
+ *
+ * Sanitised for the filesystem AND suffixed with a hash of the raw id, because
+ * sanitising alone is not injective — two different conversation ids could
+ * sanitise to the same name and silently overwrite each other's insurance.
+ */
+function journalPath(conversationId) {
+  const safe = String(conversationId).replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 60);
+  const hash = crypto.createHash('sha1').update(String(conversationId)).digest('hex').slice(0, 8);
+  return path.join(JOURNAL_DIR(), `${safe}-${hash}.json`);
+}
+
+/** The serialisable shape of a run. `latest` is a Map, so it rides as entries. */
+function snapshot(run) {
+  return {
+    version: 1,
+    conversationId: run.conversationId,
+    userId: run.userId ?? null,
+    chatType: run.chatType || 'orchestrator',
+    startedAt: run.startedAt,
+    userMessage: run.userMessage ?? null,
+    truncated: !!run.truncated,
+    events: run.events,
+    latest: [...run.latest.entries()],
+    journaledAt: Date.now(),
+  };
+}
+
+/**
+ * Is there anything worth insuring yet?
+ *
+ * `conversation_started` alone carries no answer, and writing a file for every
+ * turn the instant it opens would be a lot of I/O for nothing. The first
+ * snapshot therefore waits for real output.
+ */
+function worthJournalling(run) {
+  return run?.events?.some((e) => e.eventName !== 'conversation_started');
+}
+
+/**
+ * A temp path no other write can be using.
+ *
+ * Was `${target}.${pid}.tmp`, which is unique per PROCESS but not per WRITE —
+ * so a throttled async write and the synchronous shutdown flush, both for the
+ * same run in the same process, targeted the same file. I could not get that
+ * to corrupt a journal in practice (the writes are far too quick to overlap at
+ * realistic sizes), so this is a latent hazard rather than an observed bug.
+ * The sequence number costs nothing and removes the question.
+ */
+function tempPath(target) {
+  writeSeq += 1;
+  return `${target}.${process.pid}.${writeSeq}.tmp`;
+}
+
+/** Record that the run's log, as of `revision`, is now safely on disk. */
+function markWritten(conversationId, revision) {
+  written.set(conversationId, revision);
+  failures.delete(conversationId);
+}
+
+/**
+ * Report a failed write without flooding the log.
+ *
+ * A full disk during an hour-long tool call would otherwise produce a warning
+ * every 30 seconds. The first failure is always reported, then every tenth, so
+ * a persistent problem stays visible without burying everything else.
+ */
+function noteFailure(conversationId, err) {
+  const n = (failures.get(conversationId) || 0) + 1;
+  failures.set(conversationId, n);
+  if (n === 1 || n % 10 === 0) {
+    console.warn(`[RunJournal] Could not journal ${conversationId} (attempt ${n}):`, err?.message || err);
+  }
+}
+
+function writeSnapshotSync(run) {
+  const revision = revisions.get(run.conversationId) || 0;
+  const dir = JOURNAL_DIR();
+  fs.mkdirSync(dir, { recursive: true });
+  const target = journalPath(run.conversationId);
+  const tmp = tempPath(target);
+  fs.writeFileSync(tmp, JSON.stringify(snapshot(run)));
+  fs.renameSync(tmp, target); // atomic
+  markWritten(run.conversationId, revision);
+}
+
+async function writeSnapshot(run) {
+  // Captured BEFORE serialising: events that arrive while this write is in
+  // flight belong to a later revision, and must leave the run dirty so the
+  // next pass picks them up.
+  const revision = revisions.get(run.conversationId) || 0;
+  const dir = JOURNAL_DIR();
+  await fsp.mkdir(dir, { recursive: true });
+  const target = journalPath(run.conversationId);
+  const tmp = tempPath(target);
+  await fsp.writeFile(tmp, JSON.stringify(snapshot(run)));
+  await fsp.rename(tmp, target); // atomic
+  markWritten(run.conversationId, revision);
+}
+
+/**
+ * Note that a run has produced output. Throttled — safe to call on every event.
+ *
+ * Never throws and never rejects: journalling is insurance layered on top of a
+ * working turn, and insurance that can break the thing it insures is worse than
+ * no insurance.
+ */
+export function journalRun(run) {
+  if (!run || run.ended || !run.conversationId) return;
+
+  // Bumped before the worth-journalling gate, so the very first real event
+  // makes the run dirty even though nothing has been written yet.
+  revisions.set(run.conversationId, (revisions.get(run.conversationId) || 0) + 1);
+
+  if (!worthJournalling(run)) return;
+
+  const state = pending.get(run.conversationId);
+  if (state?.timer) return; // a write is already scheduled; it will pick up the latest
+
+  const delay = run.bytes > LARGE_RUN_BYTES ? SLOW_INTERVAL_MS : INTERVAL_MS;
+  const timer = setTimeout(() => {
+    pending.delete(run.conversationId);
+    // Re-check: the run may have ended (and been discarded) while we waited.
+    if (run.ended) return;
+    writeSnapshot(run).catch((err) => noteFailure(run.conversationId, err));
+  }, delay);
+  // A pending journal write must never hold the process open at exit.
+  if (typeof timer.unref === 'function') timer.unref();
+  pending.set(run.conversationId, { timer });
+}
+
+/** Has this run's log moved since the last successful write? */
+function isDirty(run) {
+  const id = run.conversationId;
+  return (revisions.get(id) || 0) !== (written.get(id) || 0);
+}
+
+/**
+ * Periodically write any run whose journal has fallen behind.
+ *
+ * A SAFETY NET, not the main mechanism — see HEARTBEAT_MS for the measurement
+ * that says so. On a healthy system this finds nothing to do, every time,
+ * because the throttle got there first. It earns its place in exactly two
+ * situations, both of which are invisible to the event-driven path:
+ *
+ *   1. A write FAILED and no further event will arrive to trigger another.
+ *      This is precisely what a long synchronous tool call looks like, and it
+ *      was measured: a run whose write failed stayed absent from disk
+ *      indefinitely, healing only when the next event happened to arrive.
+ *
+ *   2. Staleness is bounded by the clock rather than by traffic. If the
+ *      throttle is ever changed, or a future code path mutates a run without
+ *      going through publish(), the journal still converges.
+ *
+ * Dirty-checked on purpose. An unconditional periodic flush would rewrite
+ * byte-identical files — for an 8MB run on a 30s timer that is megabytes of
+ * pointless I/O per minute, on the same disk as the database, to save data
+ * that is already saved.
+ *
+ * @param {() => Iterable<object>} getLiveRuns  supplied by the caller because
+ *        activeRuns imports THIS module; importing it back would be circular.
+ * @returns {object|null} the interval handle, or null if it could not start.
+ */
+export function startJournalHeartbeat(getLiveRuns, { intervalMs = HEARTBEAT_MS } = {}) {
+  if (heartbeatTimer) return heartbeatTimer; // idempotent: two intervals would double every write
+  if (typeof getLiveRuns !== 'function') {
+    console.warn('[RunJournal] Heartbeat not started: no run source supplied');
+    return null;
+  }
+
+  heartbeatTimer = setInterval(() => {
+    let runs;
+    try {
+      runs = getLiveRuns() || [];
+    } catch (err) {
+      console.warn('[RunJournal] Heartbeat could not list runs:', err?.message || err);
+      return;
+    }
+
+    for (const run of runs) {
+      if (!run || run.ended || !run.conversationId) continue;
+      if (!worthJournalling(run)) continue;
+      // A scheduled write already owns this run; racing it would be the very
+      // double-write the temp-path sequence exists to make harmless, and there
+      // is no reason to cause it.
+      if (pending.has(run.conversationId)) continue;
+      if (!isDirty(run)) continue;
+
+      writeSnapshot(run)
+        .then(() => {
+          console.log(`[RunJournal] Heartbeat checkpointed ${run.conversationId} (a write had not landed)`);
+        })
+        .catch((err) => noteFailure(run.conversationId, err));
+    }
+  }, intervalMs);
+
+  // Must never hold the process open at exit.
+  if (typeof heartbeatTimer.unref === 'function') heartbeatTimer.unref();
+  return heartbeatTimer;
+}
+
+/** Stop the heartbeat. Safe to call when it was never started. */
+export function stopJournalHeartbeat() {
+  if (heartbeatTimer) clearInterval(heartbeatTimer);
+  heartbeatTimer = null;
+}
+
+/**
+ * Write every live run's journal RIGHT NOW, synchronously.
+ *
+ * Called from the shutdown drain. `launchctl kickstart -k`, systemd, Ctrl-C and
+ * an app quit all arrive as SIGTERM/SIGINT, which means the common restart is
+ * not a crash at all — it is a moment where the process still exists and can
+ * save what it has. Sync on purpose: the shutdown path has a hard deadline and
+ * an awaited write can lose the race to process.exit.
+ */
+export function flushAllSync(runsIterable) {
+  let flushed = 0;
+  for (const run of runsIterable) {
+    if (!run || run.ended || !worthJournalling(run)) continue;
+    try {
+      writeSnapshotSync(run);
+      flushed += 1;
+    } catch (err) {
+      console.warn(`[RunJournal] Shutdown flush failed for ${run.conversationId}:`, err?.message || err);
+    }
+  }
+  if (flushed > 0) console.log(`[RunJournal] Flushed ${flushed} in-flight run(s) to disk before shutdown`);
+  return flushed;
+}
+
+/**
+ * The turn is over and its answer is durable elsewhere — drop the insurance.
+ *
+ * Called from finalizeRun. By then OrchestratorService has already written
+ * conversation_logs AND the saved transcript (both happen before endRun), so a
+ * journal surviving past this point would only ever cause a pointless recovery
+ * pass on the next boot.
+ */
+export function discardJournal(conversationId) {
+  if (!conversationId) return;
+  const state = pending.get(conversationId);
+  if (state?.timer) clearTimeout(state.timer);
+  pending.delete(conversationId);
+  // Without this the tracking Maps grow for the life of the process — one
+  // entry per conversation ever run, never released.
+  revisions.delete(conversationId);
+  written.delete(conversationId);
+  failures.delete(conversationId);
+  fsp.rm(journalPath(conversationId), { force: true }).catch(() => {
+    /* best effort — a stale journal is recovered idempotently anyway */
+  });
+}
+
+/** Every journal on disk, newest first. Unreadable files are reported, not thrown. */
+export async function listJournals() {
+  const dir = JOURNAL_DIR();
+  let names;
+  try {
+    names = await fsp.readdir(dir);
+  } catch {
+    return []; // no directory yet = nothing has ever been journalled
+  }
+
+  const out = [];
+  for (const name of names) {
+    if (!name.endsWith('.json')) {
+      // Orphaned temp files: a write that died between open and rename. They
+      // were self-limiting when every write shared one temp path; now that each
+      // write has its own, they would accumulate. Only old ones are removed, so
+      // a write in flight right now is never pulled out from under itself.
+      if (name.includes('.tmp')) {
+        try {
+          const stat = await fsp.stat(path.join(dir, name));
+          if (Date.now() - stat.mtimeMs > 5 * 60 * 1000) {
+            await fsp.rm(path.join(dir, name), { force: true });
+          }
+        } catch {
+          /* already gone */
+        }
+      }
+      continue;
+    }
+    const file = path.join(dir, name);
+    try {
+      const parsed = JSON.parse(await fsp.readFile(file, 'utf8'));
+      if (!parsed?.conversationId || !Array.isArray(parsed.events)) {
+        console.warn(`[RunJournal] Ignoring malformed journal ${name}`);
+        await fsp.rm(file, { force: true });
+        continue;
+      }
+      out.push({ file, ...parsed });
+    } catch (err) {
+      console.warn(`[RunJournal] Ignoring unreadable journal ${name}:`, err?.message || err);
+      await fsp.rm(file, { force: true }).catch(() => {});
+    }
+  }
+  return out.sort((a, b) => (b.journaledAt || 0) - (a.journaledAt || 0));
+}
+
+/** Remove a journal file by its own path (used by recovery). */
+export async function removeJournalFile(file) {
+  await fsp.rm(file, { force: true }).catch(() => {});
+}
+
+/** Test seam. */
+export function _resetForTests() {
+  for (const { timer } of pending.values()) if (timer) clearTimeout(timer);
+  pending.clear();
+  revisions.clear();
+  written.clear();
+  failures.clear();
+  stopJournalHeartbeat();
+}
+
+export default {
+  journalRun,
+  flushAllSync,
+  discardJournal,
+  listJournals,
+  removeJournalFile,
+  startJournalHeartbeat,
+  stopJournalHeartbeat,
+};

--- a/backend/src/services/orchestrator/runJournal.test.js
+++ b/backend/src/services/orchestrator/runJournal.test.js
@@ -1,0 +1,383 @@
+/**
+ * A turn survives the process that was generating it.
+ *
+ * WHAT IS BEING PROTECTED
+ * ───────────────────────
+ * activeRuns keeps its replay log in memory, and conversation_logs is written
+ * at turn END. Between those two facts, killing the backend mid-turn did not
+ * merely make the answer unreachable — it destroyed it. Nothing anywhere held
+ * the tokens that had already been produced.
+ *
+ * These tests pin the journal that closes that hole, and they are careful to
+ * pin the LIMIT as well: recovery restores work already done, and does not and
+ * cannot resume generation, because the provider connection died with the
+ * process. A test suite that quietly implied otherwise would be worse than none.
+ *
+ * Runs against a throwaway AGNT_HOME — never touches the user's database.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import fsp from 'fs/promises';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+vi.mock('../../utils/realtimeSync.js', () => ({
+  broadcastToUser: () => {},
+  RealtimeEvents: { CONTENT_CREATED: 'content_created', CONTENT_UPDATED: 'content_updated' },
+}));
+
+let db;
+let ContentOutputModel;
+let runJournal;
+let recovery;
+let activeRuns;
+let TMP;
+const savedEnv = {};
+
+const USER = 'user-journal-1';
+
+/** A run object shaped exactly as activeRuns builds one. */
+const makeRun = (conversationId, events, extra = {}) => ({
+  conversationId,
+  userId: USER,
+  chatType: 'orchestrator',
+  startedAt: Date.now(),
+  userMessage: 'run something long',
+  truncated: false,
+  bytes: 100,
+  ended: false,
+  events,
+  latest: new Map(),
+  subscribers: new Set(),
+  ...extra,
+});
+
+/** The event sequence a real streaming turn produces. */
+const streamingEvents = (text = 'Half an answer') => ([
+  { eventName: 'conversation_started', data: { conversationId: 'x' } },
+  { eventName: 'assistant_message', data: { id: 'a1', role: 'assistant', content: '' } },
+  { eventName: 'content_delta', data: { assistantMessageId: 'a1', delta: text } },
+]);
+
+const seedRow = (id, conversationId, content, opts = {}) => ContentOutputModel.createOrUpdate(
+  id, USER, null, null, content, false,
+  opts.contentType || 'conversation', conversationId, opts.title || 'a title',
+);
+
+const storedTranscript = (messages) => JSON.stringify({ conversationId: 'x', title: 't', messages });
+
+const getRow = (id) => new Promise((resolve, reject) => {
+  db.get('SELECT * FROM content_outputs WHERE id = ?', [id], (e, r) => (e ? reject(e) : resolve(r)));
+});
+
+beforeAll(async () => {
+  TMP = await fsp.mkdtemp(path.join(os.tmpdir(), 'agnt-journal-'));
+  for (const k of ['AGNT_HOME', 'USER_DATA_PATH', 'DOCKER_CONTAINER']) savedEnv[k] = process.env[k];
+  delete process.env.USER_DATA_PATH;
+  delete process.env.DOCKER_CONTAINER;
+  process.env.AGNT_HOME = TMP;
+
+  const dataDir = path.join(TMP, '.agnt', 'data');
+  await fsp.mkdir(dataDir, { recursive: true });
+  await fsp.writeFile(path.join(dataDir, 'agnt.db'), '');
+
+  const dbMod = await import('../../models/database/index.js');
+  db = dbMod.default;
+  await dbMod.dbReady;
+
+  ContentOutputModel = (await import('../../models/ContentOutputModel.js')).default;
+  runJournal = await import('./runJournal.js');
+  recovery = await import('./recoverJournaledRuns.js');
+  activeRuns = await import('./activeRuns.js');
+
+  await new Promise((resolve, reject) => {
+    db.run('INSERT INTO users (id, email) VALUES (?, ?)', [USER, 'j@test.local'], (e) => (e ? reject(e) : resolve()));
+  });
+}, 120000);
+
+afterAll(async () => {
+  await new Promise((r) => db.close(r));
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  await fsp.rm(TMP, { recursive: true, force: true }).catch(() => {});
+});
+
+beforeEach(async () => {
+  runJournal._resetForTests();
+  // Clear any journals a previous test left behind.
+  for (const j of await runJournal.listJournals()) await runJournal.removeJournalFile(j.file);
+});
+
+describe('writing the journal', () => {
+  it('flushes an in-flight run to disk, synchronously', async () => {
+    const run = makeRun('conv-flush', streamingEvents());
+
+    expect(runJournal.flushAllSync([run])).toBe(1);
+
+    const journals = await runJournal.listJournals();
+    expect(journals).toHaveLength(1);
+    expect(journals[0].conversationId).toBe('conv-flush');
+    expect(journals[0].userMessage).toBe('run something long');
+    // The replay log itself, not a summary of it.
+    expect(journals[0].events.map((e) => e.eventName))
+      .toEqual(['conversation_started', 'assistant_message', 'content_delta']);
+  });
+
+  it('does not journal a run that has produced nothing yet', async () => {
+    // conversation_started carries no answer. Writing a file for every turn the
+    // instant it opens would be a lot of I/O to insure nothing.
+    const run = makeRun('conv-empty', [{ eventName: 'conversation_started', data: {} }]);
+
+    expect(runJournal.flushAllSync([run])).toBe(0);
+    expect(await runJournal.listJournals()).toHaveLength(0);
+  });
+
+  it('does not journal a run that has already ended', async () => {
+    const run = makeRun('conv-ended', streamingEvents(), { ended: true });
+    expect(runJournal.flushAllSync([run])).toBe(0);
+  });
+
+  it('keeps the newest snapshot when a run is flushed repeatedly', async () => {
+    const run = makeRun('conv-grow', streamingEvents('first'));
+    runJournal.flushAllSync([run]);
+    run.events.push({ eventName: 'content_delta', data: { assistantMessageId: 'a1', delta: ' and more' } });
+    runJournal.flushAllSync([run]);
+
+    const journals = await runJournal.listJournals();
+    expect(journals).toHaveLength(1); // one file per conversation, not one per write
+    expect(journals[0].events).toHaveLength(4);
+  });
+
+  it('leaves no temp files behind — a half-written journal must never be recovered', async () => {
+    runJournal.flushAllSync([makeRun('conv-atomic', streamingEvents())]);
+
+    const dir = path.join(TMP, '.agnt', 'data', 'run-journal');
+    expect(fs.readdirSync(dir).filter((f) => f.includes('.tmp'))).toEqual([]);
+  });
+
+  it('discards the journal when the turn ends', async () => {
+    runJournal.flushAllSync([makeRun('conv-discard', streamingEvents())]);
+    expect(await runJournal.listJournals()).toHaveLength(1);
+
+    runJournal.discardJournal('conv-discard');
+    await new Promise((r) => setTimeout(r, 50)); // rm is async, fire-and-forget
+
+    expect(await runJournal.listJournals()).toHaveLength(0);
+  });
+});
+
+describe('reducing a journal back into messages', () => {
+  it('rebuilds the assistant turn with the client\'s own reducer', () => {
+    const messages = recovery.messagesFromJournal({
+      userMessage: 'do the thing',
+      events: streamingEvents('Half an answer'),
+    });
+
+    expect(messages.map((m) => m.role)).toEqual(['user', 'assistant']);
+    expect(messages[0].content).toBe('do the thing');
+    expect(messages[1].content).toBe('Half an answer');
+  });
+
+  it('rebuilds tool calls, so a turn cut off mid-tool still shows its work', () => {
+    // The payload shape here is the SERVER'S, copied from the sendEvent calls in
+    // OrchestratorService — `{ assistantMessageId, toolCall: {...} }`, not a
+    // flattened one. Worth stating because the first version of this test
+    // invented a flatter shape, passed nothing through the reducer, and would
+    // have certified a recovery path that silently dropped every tool call.
+    const messages = recovery.messagesFromJournal({
+      userMessage: 'check the disk',
+      events: [
+        ...streamingEvents('Looking now'),
+        { eventName: 'tool_start', data: { assistantMessageId: 'a1', toolCall: { id: 't1', name: 'shell', args: { cmd: 'df' } } } },
+        { eventName: 'tool_end', data: { assistantMessageId: 'a1', toolCall: { id: 't1', name: 'shell', result: '80% used' } } },
+      ],
+    });
+
+    const assistant = messages.find((m) => m.role === 'assistant');
+    expect(assistant.toolCalls.map((t) => t.name)).toEqual(['shell']);
+    expect(assistant.toolCalls[0].result).toBe('80% used');
+    expect(assistant.toolCalls[0].status).toBe('completed');
+    // The interleave marker, so a recovered turn renders its tool card in the
+    // right place rather than after all the prose.
+    expect(assistant.contentParts.some((p) => p.type === 'tool_call' && p.toolCallId === 't1')).toBe(true);
+  });
+
+  it('surfaces a tool that was still RUNNING when the process died', () => {
+    // The whole point of the feature: the turn was cut off mid-tool.
+    const messages = recovery.messagesFromJournal({
+      userMessage: 'long job',
+      events: [
+        ...streamingEvents('Starting'),
+        { eventName: 'tool_start', data: { assistantMessageId: 'a1', toolCall: { id: 't1', name: 'shell' } } },
+      ],
+    });
+
+    const tool = messages.find((m) => m.role === 'assistant').toolCalls[0];
+    expect(tool).toMatchObject({ name: 'shell', status: 'running' });
+  });
+
+  it('marks the turn as interrupted, so a partial answer never reads as complete', () => {
+    const messages = recovery.messagesFromJournal({ userMessage: 'x', events: streamingEvents() });
+    expect(messages.at(-1).metadata).toContain(recovery.INTERRUPTED_NOTE);
+  });
+
+  it('returns nothing when the turn produced nothing a user would recognise', () => {
+    // An empty bubble written over a real saved conversation would be a
+    // regression dressed as a recovery.
+    expect(recovery.messagesFromJournal({ events: [] })).toEqual([]);
+    expect(recovery.messagesFromJournal({
+      events: [{ eventName: 'assistant_message', data: { id: 'a1', content: '' } }],
+    })).toEqual([]);
+  });
+
+  it('survives a malformed event rather than losing the whole answer', () => {
+    const messages = recovery.messagesFromJournal({
+      userMessage: 'x',
+      events: [
+        ...streamingEvents('kept'),
+        { eventName: 'content_delta', data: null },
+        { /* no eventName at all */ },
+        { eventName: 'tool_end', data: { toolCallId: 'nope' } },
+      ],
+    });
+    expect(messages.find((m) => m.role === 'assistant').content).toBe('kept');
+  });
+});
+
+describe('recovering at boot', () => {
+  it('restores an interrupted turn into the saved conversation', async () => {
+    const conversationId = 'conv-recover';
+    // What the client managed to save before the process died: the question only.
+    await seedRow('out-recover', conversationId, storedTranscript([
+      { role: 'user', content: 'run something long' },
+    ]));
+    runJournal.flushAllSync([makeRun(conversationId, streamingEvents('the partial answer'))]);
+
+    const summary = await recovery.recoverJournaledRuns();
+
+    expect(summary).toMatchObject({ found: 1, recovered: 1 });
+    const saved = JSON.parse((await getRow('out-recover')).content);
+    expect(saved.messages.find((m) => m.role === 'assistant').content).toBe('the partial answer');
+    // ...and the journal is gone, so the next boot does no work.
+    expect(await runJournal.listJournals()).toHaveLength(0);
+  });
+
+  it('never CREATES a conversation that no client had saved', async () => {
+    // Update-only, inherited from writeTranscript. A turn abandoned before its
+    // first autosave has no row, and inventing one would enrol conversations
+    // the user never chose to keep.
+    runJournal.flushAllSync([makeRun('conv-never-saved', streamingEvents())]);
+
+    const summary = await recovery.recoverJournaledRuns();
+
+    expect(summary).toMatchObject({ recovered: 0, skipped: 1 });
+    const rows = await new Promise((res, rej) => db.all(
+      'SELECT id FROM content_outputs WHERE conversation_id = ?', ['conv-never-saved'],
+      (e, r) => (e ? rej(e) : res(r)),
+    ));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('never shrinks a saved copy that says more', async () => {
+    const conversationId = 'conv-richer';
+    const richer = storedTranscript([
+      { role: 'user', content: 'run something long' },
+      { role: 'assistant', content: 'A far more complete answer. '.repeat(40) },
+    ]);
+    await seedRow('out-richer', conversationId, richer);
+    runJournal.flushAllSync([makeRun(conversationId, streamingEvents('tiny'))]);
+
+    await recovery.recoverJournaledRuns();
+
+    expect((await getRow('out-richer')).content).toBe(richer);
+  });
+
+  it('is idempotent — a second pass cannot damage the first', async () => {
+    const conversationId = 'conv-idempotent';
+    await seedRow('out-idem', conversationId, storedTranscript([{ role: 'user', content: 'q' }]));
+    runJournal.flushAllSync([makeRun(conversationId, streamingEvents('answer'))]);
+
+    await recovery.recoverJournaledRuns();
+    const first = JSON.parse((await getRow('out-idem')).content);
+
+    // Re-journal the same turn and recover again, as a crash between write and
+    // discard would produce.
+    runJournal.flushAllSync([makeRun(conversationId, streamingEvents('answer'))]);
+    await recovery.recoverJournaledRuns();
+    const second = JSON.parse((await getRow('out-idem')).content);
+
+    // Compared by what the user would SEE, not byte-for-byte: the recovered
+    // user bubble is stamped with Date.now(), so two passes a millisecond apart
+    // legitimately differ in their ids and timestamps while being the same
+    // conversation. Asserting raw equality would pin the clock, not the
+    // behaviour.
+    const shape = (t) => t.messages.map((m) => ({ role: m.role, content: m.content, metadata: m.metadata }));
+    expect(shape(second)).toEqual(shape(first));
+  });
+
+  it('expires a journal too old to be a turn anyone is waiting for', async () => {
+    await seedRow('out-old', 'conv-old', storedTranscript([{ role: 'user', content: 'q' }]));
+    runJournal.flushAllSync([makeRun('conv-old', streamingEvents('stale'))]);
+
+    // A day and a half later.
+    const summary = await recovery.recoverJournaledRuns({
+      now: Date.now() + runJournal.MAX_JOURNAL_AGE_MS + 60_000,
+    });
+
+    expect(summary).toMatchObject({ expired: 1, recovered: 0 });
+    expect(await runJournal.listJournals()).toHaveLength(0);
+    // The saved conversation is untouched.
+    expect(JSON.parse((await getRow('out-old')).content).messages).toHaveLength(1);
+  });
+
+  it('discards an unreadable journal instead of failing every future boot', async () => {
+    const dir = path.join(TMP, '.agnt', 'data', 'run-journal');
+    await fsp.mkdir(dir, { recursive: true });
+    await fsp.writeFile(path.join(dir, 'corrupt-abcdef12.json'), '{ this is not json');
+
+    await expect(recovery.recoverJournaledRuns()).resolves.toMatchObject({ found: 0 });
+    expect(fs.readdirSync(dir).filter((f) => f.endsWith('.json'))).toEqual([]);
+  });
+
+  it('does nothing, quietly, when there is nothing to recover', async () => {
+    await expect(recovery.recoverJournaledRuns()).resolves.toEqual({
+      found: 0, recovered: 0, skipped: 0, expired: 0,
+    });
+  });
+});
+
+describe('the registry writes the journal itself', () => {
+  it('journals a live run and clears it when the turn ends', async () => {
+    const run = activeRuns.startRun({
+      conversationId: 'conv-wired', userId: USER, chatType: 'orchestrator', userMessage: 'hello',
+    });
+    activeRuns.publish(run, 'conversation_started', { conversationId: 'conv-wired' });
+    activeRuns.publish(run, 'assistant_message', { id: 'a1', role: 'assistant', content: '' });
+    activeRuns.publish(run, 'content_delta', { assistantMessageId: 'a1', delta: 'live text' });
+
+    // The throttle means the disk write is scheduled, not immediate — the
+    // shutdown flush is what makes it certain.
+    expect(runJournal.flushAllSync(activeRuns.liveRuns())).toBe(1);
+    const [journal] = await runJournal.listJournals();
+    expect(journal.conversationId).toBe('conv-wired');
+
+    activeRuns.endRun('conv-wired', 'completed');
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(await runJournal.listJournals()).toHaveLength(0);
+  });
+
+  it('liveRuns excludes runs that have ended', () => {
+    activeRuns.startRun({ conversationId: 'conv-live-a', userId: USER });
+    const b = activeRuns.startRun({ conversationId: 'conv-live-b', userId: USER });
+    activeRuns.publish(b, 'assistant_message', { id: 'a1', content: '' });
+    activeRuns.endRun('conv-live-a', 'completed');
+
+    const ids = activeRuns.liveRuns().map((r) => r.conversationId);
+    expect(ids).toContain('conv-live-b');
+    expect(ids).not.toContain('conv-live-a');
+  });
+});

--- a/backend/src/services/orchestrator/runJournal.wiring.test.js
+++ b/backend/src/services/orchestrator/runJournal.wiring.test.js
@@ -1,0 +1,117 @@
+/**
+ * The journal must be WIRED, at both ends, or it is a feature that exists only
+ * in its own unit tests.
+ *
+ * Two call sites carry the whole thing, and both live inside server.js's boot
+ * and shutdown paths — code no unit test drives end to end. Same approach as
+ * OrchestratorService.streamLifetime and .runAnnouncement: assert on source,
+ * and say precisely why each property matters.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const SERVER = fs.readFileSync(fileURLToPath(new URL('../../../server.js', import.meta.url)), 'utf8');
+const RUNS = fs.readFileSync(fileURLToPath(new URL('./activeRuns.js', import.meta.url)), 'utf8');
+
+describe('shutdown flush', () => {
+  it('flushes in-flight runs from the shutdown drain', () => {
+    // SIGTERM is the ORDINARY restart — launchctl kickstart, systemd, Ctrl-C,
+    // quitting the app. The process is alive and holds the only copy of a turn
+    // that has not reached conversation_logs. Not saving here would leave the
+    // common case relying on the last throttled snapshot.
+    expect(SERVER).toMatch(/drain:\s*async\s*\(\)\s*=>/);
+    expect(SERVER).toMatch(/flushAllSync\(liveRuns\(\)\)/);
+  });
+
+  it('flushes BEFORE the workflow drain, not after', () => {
+    // The shutdown path has a hard deadline (gracefulShutdown's hardDeadlineMs).
+    // Anything after a slow drain risks losing the race to process.exit.
+    const drain = SERVER.slice(SERVER.indexOf('drain: async'));
+    expect(drain.indexOf('flushAllSync')).toBeLessThan(drain.indexOf('WorkflowProcessBridge.shutdown'));
+  });
+
+  it('cannot break shutdown if journalling fails', () => {
+    // A backend that will not exit because its insurance threw is a far worse
+    // bug than the one being insured against.
+    const drain = SERVER.slice(SERVER.indexOf('drain: async'), SERVER.indexOf('process.on(\'SIGTERM\''));
+    expect(drain).toMatch(/try\s*\{/);
+    expect(drain).toMatch(/catch/);
+  });
+});
+
+describe('boot recovery', () => {
+  it('runs recovery once the database is ready', () => {
+    expect(SERVER).toMatch(/recoverJournaledRuns/);
+    expect(SERVER.indexOf('dbReady.then')).toBeLessThan(SERVER.indexOf('recoverJournaledRuns'));
+  });
+
+  it('does not run in the workflow child process', () => {
+    // The child sets AGNT_SKIP_DB_INIT=1 and owns no runs. Recovering there
+    // would race the main process for the same journals.
+    const idx = SERVER.indexOf('recoverJournaledRuns');
+    expect(SERVER.slice(Math.max(0, idx - 1200), idx)).toMatch(/AGNT_SKIP_DB_INIT/);
+  });
+
+  it('cannot stop the server booting', () => {
+    const idx = SERVER.indexOf('recoverJournaledRuns');
+    expect(SERVER.slice(idx - 400, idx + 400)).toMatch(/catch/);
+  });
+});
+
+describe('heartbeat wiring', () => {
+  it('is started at boot, after recovery', () => {
+    // Recovery consumes journals left by the dead process; the heartbeat looks
+    // after journals for runs starting now. Recovery first keeps those two
+    // concerns from overlapping on the same files.
+    expect(SERVER).toMatch(/startJournalHeartbeat\(liveRuns\)/);
+    expect(SERVER.indexOf('recoverJournaledRuns()')).toBeLessThan(SERVER.indexOf('startJournalHeartbeat'));
+  });
+
+  it('is not started in the workflow child process', () => {
+    // Same reasoning as recovery: the child owns no runs, and a second
+    // heartbeat over the same directory is pure contention.
+    const idx = SERVER.indexOf('startJournalHeartbeat');
+    expect(SERVER.slice(Math.max(0, idx - 2000), idx)).toMatch(/AGNT_SKIP_DB_INIT/);
+  });
+
+  it('cannot stop the server booting', () => {
+    const idx = SERVER.indexOf('startJournalHeartbeat');
+    expect(SERVER.slice(idx - 300, idx + 400)).toMatch(/catch/);
+  });
+
+  it('is stopped BEFORE the synchronous shutdown flush', () => {
+    // An async write the heartbeat started could still be in flight. Letting
+    // it run alongside flushAllSync is the one way to get two writers for the
+    // same run at once.
+    const drain = SERVER.slice(SERVER.indexOf('drain: async'));
+    expect(drain).toMatch(/stopJournalHeartbeat\(\)/);
+    // Compared by CALL SITE, not by name: both are named together in the
+    // import destructuring a few lines above, where flushAllSync happens to
+    // come first — so a plain indexOf would compare the imports and pass
+    // whatever the real order turned out to be.
+    expect(drain.indexOf('stopJournalHeartbeat()')).toBeLessThan(drain.indexOf('flushAllSync(liveRuns())'));
+  });
+});
+
+describe('the registry', () => {
+  it('journals on publish, after the log is appended', () => {
+    const publish = RUNS.slice(RUNS.indexOf('export function publish'));
+    const body = publish.slice(0, publish.indexOf('\n}'));
+    expect(body).toMatch(/journalRun\(run\)/);
+    // A snapshot must never describe a log the in-memory copy does not have.
+    expect(body.indexOf('appendToLog')).toBeLessThan(body.indexOf('journalRun'));
+  });
+
+  it('discards the journal when a run is finalized', () => {
+    const finalize = RUNS.slice(RUNS.indexOf('function finalizeRun'));
+    expect(finalize.slice(0, finalize.indexOf('\n}'))).toMatch(/discardJournal\(run\.conversationId\)/);
+  });
+
+  it('exposes only the LIVE runs to the flush', () => {
+    // Flushing ended runs would rewrite journals that were just discarded, and
+    // resurrect them on the next boot.
+    expect(RUNS).toMatch(/export function liveRuns\(\)/);
+    expect(RUNS.slice(RUNS.indexOf('export function liveRuns'))).toMatch(/filter\(\(run\) => !run\.ended\)/);
+  });
+});

--- a/backend/src/services/orchestrator/transcriptProjection.js
+++ b/backend/src/services/orchestrator/transcriptProjection.js
@@ -1,0 +1,147 @@
+/**
+ * transcriptProjection.js — turn a PROVIDER transcript into the transcript the
+ * sidebar stores, server-side.
+ *
+ * WHY THE SERVER NEEDS THIS AT ALL
+ * --------------------------------
+ * content_outputs — the table the conversation list reads — has exactly one
+ * writer: an HTTP handler that a CLIENT must call. So the saved copy of a
+ * conversation is only ever as fresh as the last moment a browser was
+ * listening. Close the tab on a long task and the run itself carries on
+ * perfectly (activeRuns.js keeps generation alive; conversation_logs keeps
+ * growing), but the row the user actually looks at stays frozen mid-answer.
+ * Measured on a real install: a sidebar row stuck at 5,107 bytes while the
+ * backend log for the same conversation went on to 74,471.
+ *
+ * conversation_logs holds the truth, but it holds it in the PROVIDER's shape —
+ * one row per tool round-trip, `content` becoming a block array the moment a
+ * tool is called. That is a wire format, not a storage format, and
+ * conversationTranscript.js records what happened the two times this codebase
+ * treated it as one: every tool-using turn rendered "[object Object]", and
+ * then every tool-using answer shattered into three bubbles.
+ *
+ * So this module does not invent a conversion. It runs the SAME one the client
+ * already runs when it reconciles a dead stream (chat.js →
+ * recoverInterruptedStream → serverMessagesToUi), from a byte-identical mirror
+ * of that module, and serializes the result in the SAME shape
+ * conversationTranscript.js writes and parses back.
+ *
+ * Deliberately PURE — no database, no config, no I/O. That is what lets the
+ * parity spec import it from the frontend test suite and hold it against the
+ * client's own conversion on every build.
+ */
+
+import { serverMessagesToUi, transcriptSubstance } from './chatStreamReducer.mirror.js';
+
+export { transcriptSubstance };
+
+/**
+ * Longest title derived from a first message.
+ * Mirrors TITLE_MAX in frontend/src/services/conversationTranscript.js.
+ */
+const TITLE_MAX = 100;
+
+/**
+ * One stored message.
+ *
+ * Mirrors toStoredMessage() in conversationTranscript.js, including the rule
+ * that matters most: `contentParts` is NOT optional decoration, it carries the
+ * text/tool ORDER. Dropping it re-renders every tool card after all the prose,
+ * so a multi-tool answer reads in an order the model never produced.
+ */
+export function toStoredMessage(msg = {}) {
+  const stored = {
+    id: msg.id,
+    role: msg.role,
+    content: typeof msg.content === 'string' ? msg.content : '',
+    timestamp: msg.timestamp || Date.now(),
+    metadata: msg.metadata || [],
+    toolCalls: msg.toolCalls || [],
+    contentParts: msg.contentParts || [],
+  };
+  // Only carry optional fields when present, so a plain chat's payload stays
+  // small and diffable.
+  if (msg.reasoning) stored.reasoning = msg.reasoning;
+  if (msg.reasoning_content) stored.reasoning_content = msg.reasoning_content;
+  if (msg.files?.length) stored.files = msg.files;
+  if (msg.agentId) stored.agentId = msg.agentId;
+  if (msg.agentName) stored.agentName = msg.agentName;
+  if (msg.agentIcon) stored.agentIcon = msg.agentIcon;
+  return stored;
+}
+
+/**
+ * Serialize for the `content` column. Mirrors serializeTranscript().
+ *
+ * Image refs are stored AS-IS: {{IMAGE_REF:id}} tokens resolve to
+ * /api/images/:id, and inlining base64 made image-heavy conversations ~6x
+ * larger on every save.
+ */
+export function serializeTranscript({
+  conversationId,
+  title,
+  messages = [],
+  agentId = null,
+  agentName = null,
+} = {}) {
+  return JSON.stringify({
+    conversationId,
+    title,
+    agentId,
+    agentName,
+    isAgentChat: !!agentId,
+    messages: messages.map(toStoredMessage),
+    createdAt: messages[0]?.timestamp || Date.now(),
+    updatedAt: Date.now(),
+  });
+}
+
+/**
+ * A conversation's title is the first thing the user said, trimmed at a word
+ * boundary. Mirrors deriveTitle().
+ */
+export function deriveTitle(messages = [], fallback = 'Untitled Conversation') {
+  const firstUser = messages.find((m) => m.role === 'user' && typeof m.content === 'string' && m.content.trim());
+  if (!firstUser) return fallback;
+  const text = firstUser.content.trim().replace(/\s+/g, ' ');
+  if (text.length <= TITLE_MAX) return text;
+  const cut = text.slice(0, TITLE_MAX);
+  const lastSpace = cut.lastIndexOf(' ');
+  return `${(lastSpace > TITLE_MAX * 0.6 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
+}
+
+/**
+ * Project a provider transcript into the stored form.
+ *
+ * @param {object} args
+ * @param {string} args.conversationId
+ * @param {Array}  args.providerMessages  conversation_logs.full_history, parsed
+ *                                        — the exact array the client receives
+ *                                        from GET /orchestrator/conversations/:id
+ * @param {string|null} [args.title]      existing title; a user's rename must
+ *                                        survive, so a title is only DERIVED
+ *                                        when the row has none
+ * @returns {{messages: Array, substance: number, title: string, content: string}|null}
+ *          null when there is nothing worth storing — an empty projection must
+ *          never be written over a real transcript.
+ */
+export function projectTranscript({
+  conversationId,
+  providerMessages,
+  title = null,
+  agentId = null,
+  agentName = null,
+} = {}) {
+  const messages = serverMessagesToUi(providerMessages);
+  if (!messages.length) return null;
+
+  const finalTitle = title || deriveTitle(messages);
+  return {
+    messages,
+    substance: transcriptSubstance(messages),
+    title: finalTitle,
+    content: serializeTranscript({ conversationId, title: finalTitle, messages, agentId, agentName }),
+  };
+}
+
+export default { projectTranscript, serializeTranscript, toStoredMessage, deriveTitle, transcriptSubstance };

--- a/backend/src/utils/realtimeSync.js
+++ b/backend/src/utils/realtimeSync.js
@@ -106,6 +106,25 @@ export const RealtimeEvents = {
   CHAT_MESSAGE_END: 'chat:message_end',
   CHAT_USER_MESSAGE: 'chat:user_message',
 
+  // Chat RUN LIFECYCLE — not chat CONTENT.
+  //
+  // The chat:* events above mirror a turn's content as it streams, which only
+  // helps a client that was already watching when the turn began: they carry no
+  // replay, so a client that arrives mid-run has missed chat:message_start and
+  // every delta before it connected.
+  //
+  // This announces that a run EXISTS. A client hearing it reattaches over the
+  // SSE replay path (GET /orchestrator/runs/:id/stream), which hands back the
+  // whole turn from conversation_started onward. One tiny event per turn buys
+  // what the delta fire-hose structurally cannot: a client that opened late,
+  // or was looking at another conversation, still picks the run up in full and
+  // without a reload.
+  //
+  // Carries `originClientId` so the client that STARTED the run can recognise
+  // and ignore its own announcement — see the header of
+  // frontend/src/services/clientId.js for why timing cannot be relied on here.
+  RUN_STARTED: 'run:started',
+
   // Autonomous AI Messages (AI-initiated without user trigger)
   AUTONOMOUS_MESSAGE_START: 'chat:autonomous_message_start',
   AUTONOMOUS_CONTENT_DELTA: 'chat:autonomous_content_delta',

--- a/frontend/_harness/crossclient.html
+++ b/frontend/_harness/crossclient.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<!--
+  Verification-only entrypoint for tests/e2e/cross-client-runs.spec.js.
+
+  Lives here for the same reason shelf.html does: _harness/ is where an
+  entrypoint goes when it exists to be measured rather than shipped. It is not
+  referenced by index.html, has no route, and is never part of a production
+  build — vite.config.js builds src/main.js alone.
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>AGNT cross-client run harness</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./crossclient.js"></script>
+  </body>
+</html>

--- a/frontend/_harness/crossclient.js
+++ b/frontend/_harness/crossclient.js
@@ -1,0 +1,126 @@
+/**
+ * crossclient.js — the real client plumbing for the two-tab run-visibility
+ * tests, without the UI.
+ *
+ * Driven by tests/e2e/cross-client-runs.spec.js. See that file for what the
+ * tests assert; this file exists to make the assertions be about the REAL
+ * modules rather than about a description of them.
+ *
+ * WHAT IS REAL HERE — and this list is the whole point of the file:
+ *   - the real `clientId.js`, so each TAB mints its own per-page-load identity
+ *   - the real `useRealtimeSync()` composable, in a real mounted component, so
+ *     it opens a real Socket.IO connection and registers the real `run:started`
+ *     handler
+ *   - the real `chat` and `chatUnified` Vuex modules, so `adoptAnnouncedRun`
+ *     dispatches into the real `reattachConversation` / `reattachChannel`
+ *   - the real `chatService.reattachRun`, so a reattach is a real SSE request
+ *     against the real route, and replayed events are applied by the real
+ *     reducer
+ *   - the real `runResume.resumeInflightRuns`, invoked the way sessionBoot
+ *     invokes it, so boot-discovery is exercised as well as the announcement
+ *
+ * WHAT IS NOT REAL: the Vue components. These tests are about which client
+ * picks a run up and which one declines — plumbing, not pixels. Store modules
+ * unrelated to that are registered as inert stubs so dispatches resolve; they
+ * take no part in any assertion.
+ */
+import { createApp, h } from 'vue';
+import { createStore } from 'vuex';
+
+import chat from '@/store/features/chat.js';
+import chatUnified from '@/store/features/chatUnified.js';
+import { useRealtimeSync } from '@/composables/useRealtimeSync.js';
+import { getClientId } from '@/services/clientId.js';
+import { resumeInflightRuns } from '@/services/runResume.js';
+import { API_CONFIG } from '@/tt.config.js';
+
+/** Must match USER in tests/e2e/fixtures/crossClientBackend.mjs. */
+const USER = 'u-xclient-harness';
+
+/** An inert namespaced module — present so dispatches resolve, does nothing. */
+const stub = (state = {}) => ({
+  namespaced: true,
+  state,
+  mutations: new Proxy({}, { get: () => () => {}, has: () => true }),
+  actions: new Proxy({}, { get: () => () => Promise.resolve(), has: () => true }),
+});
+
+const store = createStore({
+  modules: {
+    chat,
+    chatUnified,
+    // useRealtimeSync derives the socket identity from here.
+    userAuth: { namespaced: true, state: { user: { id: USER }, token: null } },
+    contentOutputs: stub({ outputs: [] }),
+    aiProvider: stub({ selectedProvider: null, selectedModel: null }),
+    goals: stub({ goals: [] }),
+    agents: stub({ agents: [] }),
+    groups: stub({ groups: [] }),
+  },
+});
+
+// Everything the spec needs to observe, in one place on `window`.
+const harness = {
+  clientId: getClientId(),
+  baseUrl: API_CONFIG.BASE_URL,
+  user: USER,
+  socketAuthenticated: false,
+  bootResumeResult: null,
+  store,
+
+  /**
+   * Start a run. Mirrors what chatService.streamChat sends — specifically the
+   * X-AGNT-Client-Id header, which is what lets the server label the
+   * announcement and this tab therefore recognise its own.
+   */
+  async startRun(conversationId) {
+    const res = await fetch(`${API_CONFIG.BASE_URL}/harness/start-run`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-AGNT-Client-Id': getClientId(),
+        Authorization: `Bearer ${localStorage.getItem('token') || ''}`,
+      },
+      body: JSON.stringify({ conversationId, chatType: 'orchestrator' }),
+    });
+    return res.json();
+  },
+
+  /** What this tab believes about a conversation. */
+  snapshot(conversationId) {
+    const conv = store.state.chat.conversations[conversationId];
+    return {
+      known: !!conv,
+      isStreaming: conv?.isStreaming ?? null,
+      isReattaching: conv?.isReattaching ?? null,
+      messageCount: conv?.messages?.length ?? 0,
+      text: (conv?.messages || []).map((m) => `${m.role}:${m.content}`).join(' | '),
+      allConversationIds: Object.keys(store.state.chat.conversations),
+    };
+  },
+};
+window.__agntHarness = harness;
+
+const App = {
+  setup() {
+    const rt = useRealtimeSync();
+
+    // Surface socket state so the spec can wait on a FACT rather than a sleep.
+    // A test that races the socket is a test that fails at random, and a gate
+    // that fails at random is not a gate.
+    const tick = setInterval(() => {
+      harness.socketAuthenticated = !!rt.isAuthenticated?.value;
+    }, 50);
+    window.addEventListener('beforeunload', () => clearInterval(tick));
+
+    // Mirrors sessionBoot: resume is kicked off once a session is established.
+    // This is what lets a tab opened MID-RUN discover it with no announcement.
+    Promise.resolve(resumeInflightRuns(store))
+      .then((r) => { harness.bootResumeResult = r; })
+      .catch((e) => { harness.bootResumeResult = { error: String(e) }; });
+
+    return () => h('div', { id: 'harness-ready' }, 'cross-client harness tab');
+  },
+};
+
+createApp(App).use(store).mount('#app');

--- a/frontend/src/composables/useRealtimeSync.js
+++ b/frontend/src/composables/useRealtimeSync.js
@@ -448,6 +448,31 @@ export function useRealtimeSync() {
       store.dispatch('contentOutputs/refreshOutputs');
     });
 
+    // A turn has started on one of this user's OTHER clients.
+    //
+    // The chat:* handlers below mirror a turn's content, which only helps a
+    // client that was already watching when it began — they carry no replay, so
+    // arriving mid-run means having missed the start. This instead attaches to
+    // the run over SSE, which replays the whole turn from conversation_started.
+    // It is what lets a browser that was sitting open and idle pick up a task
+    // begun somewhere else without being reloaded.
+    //
+    // All of the routing, and the do-not-attach-to-your-own-run rule, live in
+    // runResume.js so the boot path and this one cannot drift apart.
+    socket.on('run:started', async (data) => {
+      try {
+        const { adoptAnnouncedRun } = await import('../services/runResume.js');
+        // Not logged from the return value: it resolves only when the run ENDS.
+        // adoptAnnouncedRun announces the decision synchronously instead.
+        await adoptAnnouncedRun(store, data || {});
+      } catch (e) {
+        // Resume is an enhancement on top of a working chat. A failure here
+        // must never break the socket handler and take the rest of realtime
+        // sync down with it.
+        console.warn('[Realtime] Could not attach to announced run:', e?.message || e);
+      }
+    });
+
     // Chat events (real-time message sync across tabs)
     // Only forward events from main chat types (orchestrator, agent) — not widget/workflow/tool/goal chats
     const isMainChatEvent = (data) => !data.chatType || data.chatType === 'orchestrator' || data.chatType === 'agent';

--- a/frontend/src/services/chatService.clientHeader.spec.js
+++ b/frontend/src/services/chatService.clientHeader.spec.js
@@ -1,0 +1,74 @@
+// The chat request must say who is sending it.
+//
+// The server stamps its `run:started` announcement with this header so the
+// sending client can recognise and ignore its own run. If the header silently
+// stops being sent, nothing breaks loudly: announcements simply arrive
+// unlabelled, every client treats them as someone else's, and the sender
+// attaches to its own turn — forking the conversation in its own UI.
+//
+// That failure is invisible in every other test in this repo, which is exactly
+// why it is pinned here, on both request encodings.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/tt.config.js', () => ({ API_CONFIG: { BASE_URL: 'http://localhost:3333' } }));
+
+import { streamChat } from './chatService.js';
+import { getClientId } from './clientId.js';
+
+const HEADER = 'X-AGNT-Client-Id';
+
+/** Fail the request straight after fetch, so only the request shape is tested. */
+const failFast = () => vi.fn(async () => ({
+  ok: false, status: 503, statusText: 'unavailable', text: async () => '',
+}));
+
+const send = async (extra = {}) => {
+  try {
+    await streamChat({
+      chatType: 'orchestrator',
+      messages: [{ role: 'user', content: 'hi' }],
+      onEvent: () => {},
+      ...extra,
+    });
+  } catch {
+    /* the 503 is deliberate */
+  }
+  return global.fetch.mock.calls[0][1];
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  localStorage.setItem('token', 'a-token');
+  global.fetch = failFast();
+});
+
+describe('identifying the sending client', () => {
+  it('sends this client\'s id on a JSON request', async () => {
+    expect((await send()).headers[HEADER]).toBe(getClientId());
+  });
+
+  it('sends it on a multipart request too', async () => {
+    // The multipart branch builds its own body and must NOT set Content-Type;
+    // it would be easy to drop the shared headers along with it.
+    const file = new File(['x'], 'a.txt', { type: 'text/plain' });
+    const init = await send({ files: [file] });
+
+    expect(init.headers[HEADER]).toBe(getClientId());
+    expect(init.headers['Content-Type']).toBeUndefined();
+  });
+
+  it('sends it even when signed out', async () => {
+    // Identity here is about echo suppression, not authorisation, so it must
+    // not be entangled with the token.
+    localStorage.clear();
+    expect((await send()).headers[HEADER]).toBe(getClientId());
+  });
+
+  it('sends the same id on every request from this client', async () => {
+    const first = await send();
+    global.fetch = failFast();
+    const second = await send();
+    expect(second.headers[HEADER]).toBe(first.headers[HEADER]);
+  });
+});

--- a/frontend/src/services/chatService.js
+++ b/frontend/src/services/chatService.js
@@ -6,6 +6,7 @@
 // AbortController wiring so containers can stay focused on UI concerns.
 
 import { API_CONFIG } from '@/tt.config.js';
+import { getClientId } from './clientId.js';
 
 const ENDPOINTS = {
   orchestrator: '/orchestrator/chat',
@@ -66,6 +67,10 @@ export async function streamChat({
   const token = localStorage.getItem('token');
   const headers = {};
   if (token) headers['Authorization'] = `Bearer ${token}`;
+  // Lets the server stamp the run:started announcement with who started it, so
+  // this client can ignore its own. See clientId.js for why the conversation id
+  // cannot serve that purpose.
+  headers['X-AGNT-Client-Id'] = getClientId();
 
   const bodyFields = {
     messages,
@@ -230,6 +235,34 @@ export async function fetchRunStatus(conversationId) {
     return await response.json();
   } catch {
     return { active: false, known: false };
+  }
+}
+
+/**
+ * Every run the server currently holds for this user.
+ *
+ * The counterpart to fetchRunStatus: that one confirms a conversation you can
+ * already name, this one tells you which conversations exist to ask about. It
+ * is the only way a client can learn about a turn it did not start itself —
+ * the localStorage marker that used to be the sole record is per-browser, so
+ * a run begun in one browser was invisible to every other client.
+ *
+ * Returns [] on any failure: resume is an enhancement layered on top of a
+ * working chat, and it must never be the reason boot fails.
+ *
+ * @returns {Promise<Array<{conversationId:string, chatType:string, active:boolean,
+ *   ended:boolean, status:string|null, startedAt:number, channelKey:string|null,
+ *   title:string|null, outputId:string|null}>>}
+ */
+export async function fetchActiveRuns() {
+  try {
+    const response = await fetch(`${API_CONFIG.BASE_URL}/orchestrator/runs`, { headers: authHeaders() });
+    if (!response.ok) return [];
+    const json = await response.json().catch(() => null);
+    return Array.isArray(json?.runs) ? json.runs : [];
+  } catch (e) {
+    console.warn('chatService.fetchActiveRuns failed:', e?.message || e);
+    return [];
   }
 }
 

--- a/frontend/src/services/clientId.js
+++ b/frontend/src/services/clientId.js
@@ -1,0 +1,66 @@
+/**
+ * clientId.js — who "this client" is, for the lifetime of this page load.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The server announces `run:started` to every one of a user's connected
+ * clients so an already-open browser can attach to a turn begun somewhere else
+ * (see RealtimeEvents.RUN_STARTED). The client that STARTED the run is in that
+ * audience too, and it must ignore its own announcement — it is already
+ * streaming the turn over its own SSE connection.
+ *
+ * Recognising your own run by conversation id does NOT work, and the failure is
+ * not theoretical. For a NEW conversation the sender has no server id yet: its
+ * local slot is keyed by a temporary one until `conversation_started` arrives
+ * over SSE. The announcement travels on the socket, a different transport, so
+ * the two are unordered. When the announcement wins that race the sender does
+ * not recognise the id, reattaches to itself, and `MIGRATE_CONVERSATION_ID`
+ * then overwrites the slot it just created — leaving two live streams writing
+ * into a conversation that is only partly attached to the UI.
+ *
+ * So identity is carried explicitly instead of inferred from delivery order.
+ *
+ * WHY PER PAGE LOAD, AND NOT PERSISTED
+ * ------------------------------------
+ * A module-level value is deliberate. sessionStorage would survive a reload,
+ * and a reloaded tab would then recognise the still-running turn as "mine" and
+ * skip attaching to it — which is precisely the case resume exists to handle.
+ * A fresh page load is a fresh client, and should behave like one.
+ */
+
+/**
+ * Stable for this page load, unique across tabs, windows and browsers.
+ * crypto.randomUUID is available in every browser this app supports; the
+ * fallback keeps non-secure-context and older test environments working rather
+ * than throwing during module init.
+ */
+const CLIENT_ID = (() => {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch {
+    /* fall through */
+  }
+  return `client-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+})();
+
+/** The id sent as X-AGNT-Client-Id, and compared against announcements. */
+export function getClientId() {
+  return CLIENT_ID;
+}
+
+/**
+ * Did THIS client start the run being announced?
+ *
+ * A missing origin means the request predates the header (or came from
+ * somewhere that does not send it). That is treated as "not mine": the cost of
+ * ignoring an announcement that was ours is a duplicate attach, while the cost
+ * of claiming one that was not is never picking the run up at all — and the
+ * latter is the bug this whole path exists to fix.
+ */
+export function isOwnAnnouncement(originClientId) {
+  return !!originClientId && originClientId === CLIENT_ID;
+}
+
+export default getClientId;

--- a/frontend/src/services/clientId.spec.js
+++ b/frontend/src/services/clientId.spec.js
@@ -1,0 +1,71 @@
+// Who "this client" is — and why it is answered with an id rather than a guess.
+//
+// The server announces every started run to ALL of a user's connected clients
+// so an already-open browser can attach to a turn begun elsewhere. The client
+// that started it is in that audience and must ignore its own announcement.
+//
+// The obvious discriminator — "do I already know this conversation id?" —
+// does not work. For a NEW conversation the sender has no server id yet: its
+// slot is keyed by a temp id until conversation_started arrives over SSE,
+// while the announcement travels on the socket. Two transports, no ordering
+// guarantee. When the announcement wins, the sender does not recognise the id,
+// attaches to itself, and MIGRATE_CONVERSATION_ID then overwrites the slot it
+// just created — two live streams, one half-attached conversation.
+import { describe, it, expect, vi } from 'vitest';
+import { getClientId, isOwnAnnouncement } from './clientId.js';
+
+describe('the id', () => {
+  it('is stable for the life of the page', () => {
+    expect(getClientId()).toBe(getClientId());
+  });
+
+  it('is a non-empty string', () => {
+    expect(typeof getClientId()).toBe('string');
+    expect(getClientId().length).toBeGreaterThan(8);
+  });
+
+  it('differs between page loads, so a reloaded tab is a NEW client', async () => {
+    // Deliberately not persisted. sessionStorage would survive a reload, and a
+    // reloaded tab would then treat a still-running turn as its own and skip
+    // attaching to it — exactly the case resume exists to serve.
+    const first = getClientId();
+    vi.resetModules();
+    const { getClientId: reloaded } = await import('./clientId.js');
+    expect(reloaded()).not.toBe(first);
+  });
+
+  it('still produces an id where crypto.randomUUID is unavailable', async () => {
+    // Non-secure contexts and older test environments. Throwing here would
+    // break module init for every importer, chat included.
+    //
+    // stubGlobal rather than assignment: globalThis.crypto is defined with only
+    // a getter, so `globalThis.crypto = ...` throws before the code under test
+    // is ever reached.
+    vi.resetModules();
+    vi.stubGlobal('crypto', {});
+    try {
+      const { getClientId: fallback } = await import('./clientId.js');
+      expect(fallback()).toMatch(/^client-/);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe('recognising your own announcement', () => {
+  it('claims an announcement carrying this id', () => {
+    expect(isOwnAnnouncement(getClientId())).toBe(true);
+  });
+
+  it('disclaims another client\'s', () => {
+    expect(isOwnAnnouncement('some-other-client')).toBe(false);
+  });
+
+  it('disclaims an unlabelled announcement', () => {
+    // Resolves towards attaching: attaching twice is recoverable, never
+    // attaching is the bug this path exists to fix.
+    expect(isOwnAnnouncement(null)).toBe(false);
+    expect(isOwnAnnouncement(undefined)).toBe(false);
+    expect(isOwnAnnouncement('')).toBe(false);
+  });
+});

--- a/frontend/src/services/runResume.js
+++ b/frontend/src/services/runResume.js
@@ -1,17 +1,150 @@
 /**
- * runResume.js — reattach to turns that were still generating when this tab
- * last went away.
+ * runResume.js — reattach to turns that were still generating when this client
+ * last went away, INCLUDING turns it never started.
  *
- * One call site, every chat surface. The marker written by inflightRuns.js
- * records which store owns each run (a `channelKey` means a sidebar channel in
- * `chatUnified`; its absence means the main orchestrator chat), so a new chat
- * surface gets resume for free as long as it writes a marker.
+ * One call site, every chat surface.
+ *
+ * TWO SOURCES, AND WHY IT TAKES BOTH:
+ *
+ *   1. The local marker (inflightRuns.js → localStorage). Written the instant
+ *      the server assigns a conversation id, so it covers the turn that has
+ *      not been saved anywhere else yet. It is also per-browser-profile, which
+ *      is precisely its limit: a run started in Chrome leaves no trace Safari
+ *      or the Mac app can read.
+ *
+ *   2. The server (GET /orchestrator/runs). Authoritative, and the only source
+ *      that can answer "what is running for me?" from a client with no prior
+ *      knowledge. This is what makes a long task started on one machine
+ *      resumable on another.
+ *
+ * Neither subsumes the other: the marker is faster and survives a server that
+ * has already retired the run, the server list is the only one that crosses
+ * devices. They are merged by conversationId, and the SERVER wins on conflict
+ * because it knows things a stale local marker cannot — chiefly whether the
+ * run is still alive and which surface owns it.
  *
  * This deliberately does NOT block app startup: each reattach holds an SSE
  * connection open until its run finishes, which can be minutes.
  */
 
 import { listInflightRuns } from './inflightRuns.js';
+import { fetchActiveRuns } from './chatService.js';
+import { isOwnAnnouncement } from './clientId.js';
+
+/**
+ * Merge local markers with the server's list into one entry per conversation.
+ *
+ * Exported for tests: the precedence rule is the whole substance of this file,
+ * and it deserves to be asserted directly rather than inferred from dispatch
+ * side effects.
+ */
+export function mergeRunSources(localRuns = [], serverRuns = []) {
+  const byId = new Map();
+
+  for (const run of localRuns) {
+    if (!run?.conversationId) continue;
+    byId.set(run.conversationId, { ...run, source: 'local' });
+  }
+
+  for (const run of serverRuns) {
+    if (!run?.conversationId) continue;
+    const local = byId.get(run.conversationId);
+
+    // channelKey decides WHICH STORE handles the reattach, so a wrong value
+    // sends a workspace turn into the main chat window. The server derives it
+    // from the saved transcript, but returns null for a conversation too young
+    // to have been saved yet — and in exactly that case the local marker, if
+    // there is one, is the better answer. Prefer the server's value only when
+    // it actually has one.
+    const channelKey = run.channelKey ?? local?.channelKey ?? null;
+
+    byId.set(run.conversationId, {
+      ...local,
+      ...run,
+      channelKey,
+      source: local ? 'both' : 'server',
+    });
+  }
+
+  return [...byId.values()];
+}
+
+/**
+ * Which chat surface owns a conversation, from what THIS client already knows.
+ *
+ * The channel store is keyed by channelKey with the conversation id inside, so
+ * ownership is a reverse lookup. Exported for tests, and because getting this
+ * wrong is the interesting failure: routing a workspace turn into the main
+ * chat window puts an answer somewhere the user was not looking, and leaves the
+ * surface they WERE looking at still spinning.
+ *
+ * @returns {string|null} the owning channelKey, or null for the main chat.
+ */
+export function findChannelForConversation(store, conversationId) {
+  const channels = store?.state?.chatUnified?.conversations;
+  if (!channels || !conversationId) return null;
+  for (const [channelKey, conv] of Object.entries(channels)) {
+    if (conv?.conversationId === conversationId) return channelKey;
+  }
+  return null;
+}
+
+/**
+ * Chat types the main chat store is willing to adopt sight-unseen.
+ *
+ * Same rule the socket delta mirror already applies (isMainChatEvent in
+ * useRealtimeSync.js). Anything else — workspace, artifact, widget, tool —
+ * belongs to an embedded surface, and adopting it into the main conversation
+ * list would invent a conversation the user never opened there.
+ */
+const MAIN_CHAT_TYPES = new Set(['orchestrator', 'agent']);
+
+/**
+ * A run has started somewhere else. Attach to it, here, now.
+ *
+ * The PUSH half of resume. resumeInflightRuns() covers a client that is
+ * starting up; this covers one that is already open and idle, which is the
+ * case that previously required a reload: nothing polls, and the chat:* delta
+ * mirror is no use to a client that missed the beginning of the turn.
+ *
+ * Reattaching (rather than consuming the announcement's own payload) is the
+ * whole point: the SSE replay hands back the turn from conversation_started
+ * onward, so a client that hears about a run ten seconds late still gets all
+ * ten seconds.
+ *
+ * @returns {Promise<boolean>} true when a live run was found and consumed.
+ */
+export async function adoptAnnouncedRun(store, { conversationId, chatType, originClientId } = {}) {
+  if (!store || !conversationId) return false;
+
+  // Never attach to your own run: this client is already streaming it over the
+  // SSE connection it opened, and a second attach would fork the conversation
+  // in the UI. See clientId.js — for a new conversation the id in this
+  // announcement is one this client has not learned yet, so identity is the
+  // only reliable discriminator.
+  if (isOwnAnnouncement(originClientId)) return false;
+
+  const channelKey = findChannelForConversation(store, conversationId);
+  if (channelKey) {
+    // Announced HERE, at the moment of the decision — deliberately not from the
+    // dispatch's resolved value. Both reattach actions resolve only when the
+    // RUN ENDS, because the SSE connection stays open for the whole turn. A log
+    // that waits for that says nothing for the entire duration of exactly the
+    // long task this feature exists to rescue, and a human watching the console
+    // reasonably reads silence as failure.
+    console.log(`[Realtime] Attaching to run announced elsewhere: ${conversationId} → ${channelKey}`);
+    return store.dispatch('chatUnified/reattachChannel', { channelKey, conversationId });
+  }
+
+  // No local channel owns it. Only adopt into the main chat if it is the kind
+  // of conversation that lives there; an embedded surface that is not open on
+  // this client has nowhere to put the turn, and will pick it up from its own
+  // hydration when the user opens it.
+  if (!MAIN_CHAT_TYPES.has(chatType || 'orchestrator')) return false;
+
+  console.log(`[Realtime] Attaching to run announced elsewhere: ${conversationId} → main chat`);
+  return store.dispatch('chat/reattachConversation', conversationId);
+}
 
 /**
  * Kick off a reattach for every run left in flight.
@@ -34,10 +167,22 @@ export async function resumeInflightRuns(store) {
   }
   if (!token) return { attempted: 0, resumed: 0 };
 
-  const runs = listInflightRuns();
+  const localRuns = listInflightRuns();
+
+  // Asked unconditionally, NOT only when a local marker exists — a client that
+  // has never seen this conversation has no marker to trigger on, and that is
+  // the entire cross-device case. fetchActiveRuns swallows its own failures,
+  // so an unreachable server degrades to "local markers only", which is the
+  // behaviour that shipped before this endpoint existed.
+  const serverRuns = await fetchActiveRuns();
+
+  const runs = mergeRunSources(localRuns, serverRuns);
   if (runs.length === 0) return { attempted: 0, resumed: 0 };
 
-  console.log(`[runResume] ${runs.length} run(s) were in flight — attempting reattach`);
+  console.log(
+    `[runResume] ${runs.length} run(s) to reattach ` +
+      `(${localRuns.length} local marker(s), ${serverRuns.length} from server)`,
+  );
 
   const results = await Promise.allSettled(
     runs.map((run) => {

--- a/frontend/src/services/runResume.spec.js
+++ b/frontend/src/services/runResume.spec.js
@@ -3,6 +3,11 @@
  *
  * One call site serves both chat stores. The marker says which store owns each
  * run, so a new chat surface inherits resume for free.
+ *
+ * It now draws on TWO sources, because the local marker cannot cross a browser
+ * boundary: localStorage is per-profile, so a run started in Chrome left no
+ * trace Safari or the Mac app could read. The server list is what makes a task
+ * started on one machine resumable on another.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
@@ -11,15 +16,27 @@ vi.mock('./inflightRuns.js', () => ({
   listInflightRuns: (...args) => listInflightRuns(...args),
 }));
 
-import { resumeInflightRuns } from './runResume.js';
+const fetchActiveRuns = vi.fn();
+vi.mock('./chatService.js', () => ({
+  fetchActiveRuns: (...args) => fetchActiveRuns(...args),
+}));
 
-const makeStore = () => ({ dispatch: vi.fn(() => Promise.resolve(true)) });
+import { resumeInflightRuns, mergeRunSources, adoptAnnouncedRun, findChannelForConversation } from './runResume.js';
+// The REAL client id, not a mock: echo suppression is the thing under test, and
+// a stubbed identity would prove nothing about it.
+import { getClientId } from './clientId.js';
+
+const makeStore = (chatUnifiedConversations = {}) => ({
+  dispatch: vi.fn(() => Promise.resolve(true)),
+  state: { chatUnified: { conversations: chatUnifiedConversations } },
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
   localStorage.clear();
   localStorage.setItem('token', 'a-token');
   listInflightRuns.mockReturnValue([]);
+  fetchActiveRuns.mockResolvedValue([]);
 });
 
 describe('routing a marker to the store that owns it', () => {
@@ -98,6 +115,286 @@ describe('does nothing when there is nothing to do', () => {
 
   it('tolerates being called without a store', async () => {
     expect(await resumeInflightRuns(null)).toEqual({ attempted: 0, resumed: 0 });
+  });
+});
+
+describe('picking up a run this client never started', () => {
+  it('reattaches a run known only to the server — the cross-device case', async () => {
+    // No local marker: this browser has never seen the conversation.
+    listInflightRuns.mockReturnValue([]);
+    fetchActiveRuns.mockResolvedValue([
+      { conversationId: 'c-remote', chatType: 'orchestrator', active: true, channelKey: null, startedAt: Date.now() },
+    ]);
+    const store = makeStore();
+
+    const result = await resumeInflightRuns(store);
+
+    expect(store.dispatch).toHaveBeenCalledWith('chat/reattachConversation', 'c-remote');
+    expect(result).toEqual({ attempted: 1, resumed: 1 });
+  });
+
+  it('asks the server even when there are no local markers', async () => {
+    // The old code returned early on an empty marker list, which is exactly
+    // the state every OTHER device is in. Asking unconditionally is the fix.
+    await resumeInflightRuns(makeStore());
+    expect(fetchActiveRuns).toHaveBeenCalled();
+  });
+
+  it('routes a server run to the surface that owns it', async () => {
+    fetchActiveRuns.mockResolvedValue([
+      { conversationId: 'c-ws', chatType: 'orchestrator', active: true, channelKey: 'workspace:ws-1', startedAt: Date.now() },
+    ]);
+    const store = makeStore();
+
+    await resumeInflightRuns(store);
+
+    expect(store.dispatch).toHaveBeenCalledWith('chatUnified/reattachChannel', {
+      channelKey: 'workspace:ws-1',
+      conversationId: 'c-ws',
+    });
+  });
+
+  it('reattaches each conversation once when both sources report it', async () => {
+    listInflightRuns.mockReturnValue([{ conversationId: 'c-dup', channelKey: null, startedAt: Date.now() }]);
+    fetchActiveRuns.mockResolvedValue([{ conversationId: 'c-dup', active: true, channelKey: null, startedAt: Date.now() }]);
+    const store = makeStore();
+
+    const result = await resumeInflightRuns(store);
+
+    // Two SSE reattaches to one conversation would replay the turn twice.
+    expect(store.dispatch).toHaveBeenCalledTimes(1);
+    expect(result.attempted).toBe(1);
+  });
+
+  it('falls back to local markers when the server cannot be reached', async () => {
+    fetchActiveRuns.mockResolvedValue([]); // the service swallows its own errors
+    listInflightRuns.mockReturnValue([{ conversationId: 'c-local', channelKey: null, startedAt: Date.now() }]);
+    const store = makeStore();
+
+    // Degrades to exactly the behaviour that shipped before the endpoint
+    // existed, rather than losing resume altogether.
+    expect(await resumeInflightRuns(store)).toEqual({ attempted: 1, resumed: 1 });
+  });
+
+  it('does not call the server when signed out', async () => {
+    localStorage.removeItem('token');
+    await resumeInflightRuns(makeStore());
+    expect(fetchActiveRuns).not.toHaveBeenCalled();
+  });
+});
+
+describe('merging the two sources', () => {
+  const local = { conversationId: 'c1', channelKey: 'workspace:ws-1', startedAt: 1 };
+
+  it('keeps one entry per conversation', () => {
+    expect(mergeRunSources([local], [{ conversationId: 'c1', active: true }])).toHaveLength(1);
+  });
+
+  it('lets the server override a stale local marker', () => {
+    // The marker records only that a turn STARTED; it cannot know the run has
+    // since ended, so the server's view has to win.
+    const [run] = mergeRunSources([{ ...local, active: true }], [{ conversationId: 'c1', active: false, ended: true }]);
+    expect(run).toMatchObject({ active: false, ended: true });
+  });
+
+  it('keeps the local channelKey when the server has none yet', () => {
+    // A conversation younger than its first autosave has no stored row, so the
+    // server returns channelKey null. Taking that literally would drop a
+    // workspace turn into the main chat window.
+    const [run] = mergeRunSources([local], [{ conversationId: 'c1', active: true, channelKey: null }]);
+    expect(run.channelKey).toBe('workspace:ws-1');
+  });
+
+  it('prefers the server channelKey when it has one', () => {
+    const [run] = mergeRunSources([local], [{ conversationId: 'c1', channelKey: 'artifact:a-9' }]);
+    expect(run.channelKey).toBe('artifact:a-9');
+  });
+
+  it('ignores entries with no conversation id from either side', () => {
+    expect(mergeRunSources([{ channelKey: 'x' }], [{ active: true }])).toEqual([]);
+  });
+
+  it('handles either side being absent', () => {
+    expect(mergeRunSources([], [])).toEqual([]);
+    expect(mergeRunSources(undefined, undefined)).toEqual([]);
+    expect(mergeRunSources([local], [])).toHaveLength(1);
+  });
+});
+
+describe('attaching to a run announced by another client', () => {
+  // The push half of resume: a client that is already open and idle polls
+  // nothing, so before this it needed a reload to notice a turn started
+  // elsewhere.
+
+  it('attaches to a run this client has never seen', async () => {
+    const store = makeStore();
+
+    const adopted = await adoptAnnouncedRun(store, {
+      conversationId: 'c-announced', chatType: 'orchestrator', originClientId: 'some-other-client',
+    });
+
+    expect(store.dispatch).toHaveBeenCalledWith('chat/reattachConversation', 'c-announced');
+    expect(adopted).toBe(true);
+  });
+
+  it('IGNORES its own announcement', async () => {
+    // The sender is already streaming this turn over its own SSE connection.
+    // Attaching again forks the conversation in the UI — and for a new
+    // conversation the sender cannot recognise the id yet, which is exactly
+    // why identity is carried explicitly.
+    const store = makeStore();
+
+    const adopted = await adoptAnnouncedRun(store, {
+      conversationId: 'c-mine', chatType: 'orchestrator', originClientId: getClientId(),
+    });
+
+    expect(store.dispatch).not.toHaveBeenCalled();
+    expect(adopted).toBe(false);
+  });
+
+  it('treats an unlabelled announcement as someone else\'s', async () => {
+    // Failing to attach is the bug being fixed; attaching twice is recoverable.
+    // So a missing origin resolves towards attaching.
+    const store = makeStore();
+
+    await adoptAnnouncedRun(store, { conversationId: 'c-unlabelled', chatType: 'orchestrator' });
+
+    expect(store.dispatch).toHaveBeenCalledWith('chat/reattachConversation', 'c-unlabelled');
+  });
+
+  it('routes to the channel that owns the conversation', async () => {
+    const store = makeStore({ 'workspace:ws-1': { conversationId: 'c-ws' } });
+
+    await adoptAnnouncedRun(store, {
+      conversationId: 'c-ws', chatType: 'workspace', originClientId: 'other',
+    });
+
+    expect(store.dispatch).toHaveBeenCalledWith('chatUnified/reattachChannel', {
+      channelKey: 'workspace:ws-1',
+      conversationId: 'c-ws',
+    });
+  });
+
+  it('prefers the owning channel over the main chat', async () => {
+    // chatType alone would send this to the main chat window — the wrong
+    // surface, leaving the one the user is looking at still spinning.
+    const store = makeStore({ 'artifact:a-9': { conversationId: 'c-both' } });
+
+    await adoptAnnouncedRun(store, {
+      conversationId: 'c-both', chatType: 'orchestrator', originClientId: 'other',
+    });
+
+    expect(store.dispatch).toHaveBeenCalledWith('chatUnified/reattachChannel', expect.objectContaining({
+      channelKey: 'artifact:a-9',
+    }));
+  });
+
+  it('does not invent a main-chat conversation for an embedded surface', async () => {
+    // No local channel owns it and it is not a main-chat type: this client has
+    // nowhere to put the turn, and adopting it would add a conversation the
+    // user never opened here. The surface hydrates it when opened.
+    const store = makeStore();
+
+    const adopted = await adoptAnnouncedRun(store, {
+      conversationId: 'c-widget', chatType: 'widget', originClientId: 'other',
+    });
+
+    expect(store.dispatch).not.toHaveBeenCalled();
+    expect(adopted).toBe(false);
+  });
+
+  it('adopts agent chats, matching the delta mirror\'s own rule', async () => {
+    const store = makeStore();
+    await adoptAnnouncedRun(store, {
+      conversationId: 'c-agent', chatType: 'agent', originClientId: 'other',
+    });
+    expect(store.dispatch).toHaveBeenCalledWith('chat/reattachConversation', 'c-agent');
+  });
+
+  it('announces the attach at DECISION time, not when the run finishes', async () => {
+    // Caught by a real two-tab run: the handler used to log from the dispatch's
+    // RESOLVED VALUE, and both reattach actions resolve only when the run ends
+    // (the SSE connection is held open for the whole turn). So attaching to a
+    // ten-minute task printed nothing for ten minutes — indistinguishable, to
+    // anyone watching a console, from not attaching at all.
+    //
+    // A dispatch that NEVER settles is the whole point of the test: it is what
+    // an in-flight run actually looks like.
+    const store = {
+      dispatch: vi.fn(() => new Promise(() => {})),
+      state: { chatUnified: { conversations: {} } },
+    };
+    const logs = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...a) => logs.push(a.join(' ')));
+
+    try {
+      adoptAnnouncedRun(store, {
+        conversationId: 'c-ten-minutes', chatType: 'orchestrator', originClientId: 'other',
+      });
+      expect(logs.join('\n')).toMatch(/Attaching to run announced elsewhere: c-ten-minutes/);
+      expect(store.dispatch).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('names the surface it is attaching to', async () => {
+    const store = makeStore({ 'workspace:ws-2': { conversationId: 'c-ws2' } });
+    const logs = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...a) => logs.push(a.join(' ')));
+    try {
+      await adoptAnnouncedRun(store, { conversationId: 'c-ws2', chatType: 'workspace', originClientId: 'other' });
+      // Which surface claimed the run is the first thing worth knowing when a
+      // turn lands somewhere the user was not looking.
+      expect(logs.join('\n')).toMatch(/c-ws2 → workspace:ws-2/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('says nothing when it declines', async () => {
+    const store = makeStore();
+    const logs = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...a) => logs.push(a.join(' ')));
+    try {
+      await adoptAnnouncedRun(store, { conversationId: 'c-own', chatType: 'orchestrator', originClientId: getClientId() });
+      await adoptAnnouncedRun(store, { conversationId: 'c-widget2', chatType: 'widget', originClientId: 'other' });
+      // A decline that announces itself as an attach is worse than silence.
+      expect(logs.join('\n')).not.toMatch(/Attaching to run announced elsewhere/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('ignores a malformed announcement', async () => {
+    const store = makeStore();
+    expect(await adoptAnnouncedRun(store, {})).toBe(false);
+    expect(await adoptAnnouncedRun(store, { chatType: 'orchestrator' })).toBe(false);
+    expect(await adoptAnnouncedRun(null, { conversationId: 'c' })).toBe(false);
+    expect(store.dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('finding the surface that owns a conversation', () => {
+  it('finds the channel holding the conversation id', () => {
+    const store = makeStore({ 'workspace:a': { conversationId: 'c1' }, 'widget:b': { conversationId: 'c2' } });
+    expect(findChannelForConversation(store, 'c2')).toBe('widget:b');
+  });
+
+  it('returns null when no channel holds it', () => {
+    expect(findChannelForConversation(makeStore({ 'workspace:a': { conversationId: 'c1' } }), 'c9')).toBeNull();
+  });
+
+  it('survives a store with no channel state at all', () => {
+    expect(findChannelForConversation({ state: {} }, 'c1')).toBeNull();
+    expect(findChannelForConversation(undefined, 'c1')).toBeNull();
+    expect(findChannelForConversation(makeStore(), null)).toBeNull();
+  });
+
+  it('ignores channels that have never held a conversation', () => {
+    const store = makeStore({ 'workspace:empty': { conversationId: null }, 'workspace:real': { conversationId: 'c1' } });
+    expect(findChannelForConversation(store, 'c1')).toBe('workspace:real');
+    expect(findChannelForConversation(store, null)).toBeNull();
   });
 });
 

--- a/frontend/src/services/transcriptProjection.parity.spec.js
+++ b/frontend/src/services/transcriptProjection.parity.spec.js
@@ -1,0 +1,184 @@
+// SERVER-SAVED == CLIENT-RECONCILED. The second half of the transcript contract.
+//
+// WHY THIS FILE EXISTS
+// --------------------
+// chatTranscriptParity.spec.js pins LIVE == RELOADED: a turn watched as it
+// streams renders the same as the same turn read back from storage. This file
+// pins the axis that opened up when the server started writing that storage
+// itself.
+//
+// At turn end the backend now projects the provider transcript into the saved
+// row, so a conversation whose client walked away still finishes on screen
+// (backend/src/services/orchestrator/persistTurnTranscript.js). The client does
+// the same projection when it reconciles a dead stream — chat.js →
+// recoverInterruptedStream → serverMessagesToUi. Same input, two runtimes.
+//
+// They cannot share a module: neither tree is shipped to the other (Docker
+// copies backend/ + frontend/dist; the frontend build stage sees only
+// frontend/). So the backend holds a byte-identical mirror, and byte-identity
+// is enforced by chatStreamReducer.mirror.test.js.
+//
+// That test proves the two COPIES agree. This one proves the two PIPELINES
+// agree — mirror, plus serialization, plus the client's own parser reading it
+// back — which is the thing the user actually experiences. A mirror can be
+// perfect while the serializer around it drops contentParts, and the symptom
+// would be tool cards silently reordered after the prose.
+//
+// The assertion is deliberately end-to-end and in the user's terms:
+//
+//   parseTranscript(what the SERVER stored)  ===  what the CLIENT would render
+//
+import { describe, it, expect } from 'vitest';
+import { serverMessagesToUi } from './chatStreamReducer.js';
+import { parseTranscript } from './conversationTranscript.js';
+import { projectTranscript } from '../../../backend/src/services/orchestrator/transcriptProjection.js';
+
+/** What a surface actually shows. Ids and timestamps are storage detail. */
+const renderSignature = (message) => ({
+  role: message.role,
+  text: (message.content || '').replace(/\s+/g, ''),
+  parts: (message.contentParts || []).map((p) =>
+    (p.type === 'text' ? `text:${(p.text || '').trim()}` : `tool:${p.toolCallId}`)),
+  tools: (message.toolCalls || []).map((tc) => ({
+    name: tc.name, status: tc.status, result: tc.result, error: tc.error,
+  })),
+});
+
+const render = (messages) => messages.map(renderSignature);
+
+/**
+ * The transcripts below are provider-shaped — the exact contents of
+ * conversation_logs.full_history, which is what both sides consume.
+ */
+const CORPUS = {
+  'a plain exchange': [
+    { role: 'user', content: 'hello' },
+    { role: 'assistant', content: 'Hi there.' },
+  ],
+
+  'anthropic block form with a tool round-trip': [
+    { role: 'user', content: 'check the disk' },
+    {
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'Let me look.' },
+        { type: 'tool_use', id: 'call_a', name: 'shell', input: { cmd: 'df -h' } },
+      ],
+    },
+    { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call_a', content: '80% used' }] },
+    { role: 'assistant', content: [{ type: 'text', text: 'The disk is 80% full.' }] },
+  ],
+
+  'openai form with tool_calls beside the content': [
+    { role: 'user', content: 'weather?' },
+    {
+      role: 'assistant',
+      content: '',
+      tool_calls: [{ id: 'call_b', type: 'function', function: { name: 'getWeather', arguments: '{"city":"Oslo"}' } }],
+    },
+    { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call_b', content: 'sunny' }] },
+    { role: 'assistant', content: 'It is sunny in Oslo.' },
+  ],
+
+  'several tools interleaved with prose': [
+    { role: 'user', content: 'do three things' },
+    {
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'First.' },
+        { type: 'tool_use', id: 'c1', name: 'one', input: {} },
+        { type: 'text', text: 'Second.' },
+        { type: 'tool_use', id: 'c2', name: 'two', input: {} },
+      ],
+    },
+    {
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: 'c1', content: 'ok1' },
+        { type: 'tool_result', tool_use_id: 'c2', content: 'ok2' },
+      ],
+    },
+    { role: 'assistant', content: [{ type: 'text', text: 'Both done.' }] },
+  ],
+
+  'a failed tool': [
+    { role: 'user', content: 'break it' },
+    { role: 'assistant', content: [{ type: 'tool_use', id: 'c_err', name: 'boom', input: {} }] },
+    { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'c_err', content: 'nope', is_error: true }] },
+    { role: 'assistant', content: [{ type: 'text', text: 'That tool failed.' }] },
+  ],
+
+  'reasoning blocks the user never sees as prose': [
+    { role: 'user', content: 'think' },
+    {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'internal deliberation' },
+        { type: 'text', text: 'Here is my answer.' },
+      ],
+    },
+  ],
+
+  'several turns, so merging cannot run away': [
+    { role: 'user', content: 'one' },
+    { role: 'assistant', content: 'first answer' },
+    { role: 'user', content: 'two' },
+    { role: 'assistant', content: [{ type: 'tool_use', id: 'c3', name: 'x', input: {} }] },
+    { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'c3', content: 'r' }] },
+    { role: 'assistant', content: 'second answer' },
+  ],
+};
+
+describe('what the server saves is what the client would have rendered', () => {
+  for (const [name, providerMessages] of Object.entries(CORPUS)) {
+    it(name, () => {
+      // The server's pipeline: project, serialize, store.
+      const stored = projectTranscript({ conversationId: 'c1', providerMessages });
+      // The client's pipeline: read that row back with its own parser.
+      const readBack = parseTranscript(stored.content).messages;
+      // What the client would have produced on its own from the same log.
+      const clientSide = serverMessagesToUi(providerMessages);
+
+      expect(render(readBack)).toEqual(render(clientSide));
+    });
+  }
+});
+
+describe('the properties a transcript is allowed to rely on', () => {
+  const providerMessages = CORPUS['anthropic block form with a tool round-trip'];
+
+  it('keeps text/tool ORDER, not just contents', () => {
+    const readBack = parseTranscript(projectTranscript({ conversationId: 'c1', providerMessages }).content).messages;
+    const assistant = readBack.find((m) => m.role === 'assistant');
+    // contentParts is what makes a multi-tool answer readable; losing the
+    // order re-renders every tool card after all the prose.
+    expect(assistant.contentParts.map((p) => p.type)).toEqual(['text', 'tool_call', 'text']);
+  });
+
+  it('never stores the coercion artefact that shipped twice before', () => {
+    for (const messages of Object.values(CORPUS)) {
+      const { content } = projectTranscript({ conversationId: 'c1', providerMessages: messages });
+      expect(content).not.toMatch(/\[object \w+\]/);
+    }
+  });
+
+  it('drops the synthetic tool-result turn instead of rendering an empty bubble', () => {
+    const readBack = parseTranscript(projectTranscript({ conversationId: 'c1', providerMessages }).content).messages;
+    expect(readBack.map((m) => m.role)).toEqual(['user', 'assistant']);
+  });
+
+  it('derives the same title the client would', () => {
+    const { title } = projectTranscript({ conversationId: 'c1', providerMessages });
+    expect(title).toBe('check the disk');
+  });
+
+  it('prefers an existing title over deriving one', () => {
+    const { title } = projectTranscript({ conversationId: 'c1', providerMessages, title: 'User chose this' });
+    expect(title).toBe('User chose this');
+  });
+
+  it('returns null for a transcript with nothing to show', () => {
+    expect(projectTranscript({ conversationId: 'c1', providerMessages: [] })).toBeNull();
+    expect(projectTranscript({ conversationId: 'c1', providerMessages: [{ role: 'system', content: 'x' }] })).toBeNull();
+  });
+});

--- a/frontend/src/store/features/chat.js
+++ b/frontend/src/store/features/chat.js
@@ -283,6 +283,19 @@ function createConversationState(conversationId) {
     messages: [],
     isStreaming: false,
     isRemoteStreaming: false,
+    // A reattach has been decided on but its replay has not arrived yet.
+    //
+    // isStreaming cannot serve here: it is deliberately raised only once the
+    // server sends something, so a page load where nothing is running does not
+    // flash a spinner. That leaves a gap of one HTTP round trip during which
+    // the socket delta mirror is still applying content — and the replay that
+    // follows starts from the beginning of the turn, so whatever landed in that
+    // gap is applied a second time (SCOPED_ADD_MESSAGE pushes without checking
+    // ids, SCOPED_APPEND_MESSAGE_CONTENT appends unconditionally: a duplicated
+    // bubble AND duplicated prose).
+    //
+    // This flag closes the gap from the instant the decision is made.
+    isReattaching: false,
     streamAbortController: null,
     streamReader: null,
     activeAsyncTools: new Map(),
@@ -823,7 +836,11 @@ export default {
         const keys = Object.keys(state.conversations);
         if (keys.length >= MAX_CONVERSATIONS) {
           const evictable = keys
-            .filter(id => id !== state.activeConversationId && !state.conversations[id].isStreaming)
+            // A conversation awaiting a replay is as live as a streaming one:
+            // evicting it aborts the reattach and drops the turn on the floor.
+            .filter(id => id !== state.activeConversationId
+              && !state.conversations[id].isStreaming
+              && !state.conversations[id].isReattaching)
             .sort((a, b) => {
               const aLast = state.conversations[a].messages.at(-1)?.timestamp || 0;
               const bLast = state.conversations[b].messages.at(-1)?.timestamp || 0;
@@ -861,6 +878,20 @@ export default {
         state.activeConversationId = newId;
         state.currentConversationId = newId;
       }
+    },
+
+    /**
+     * Claim a conversation for an in-flight reattach.
+     *
+     * Kept separate from SCOPED_SET_STREAMING because it means something
+     * different to the UI: the spinner tracks "the server is sending", while
+     * this tracks "we have committed to a replay, so nothing else may write
+     * here". Conflating them would either flash a spinner on every idle boot or
+     * reopen the double-apply window.
+     */
+    SCOPED_SET_REATTACHING(state, { conversationId, value }) {
+      const conv = state.conversations[conversationId];
+      if (conv) conv.isReattaching = value;
     },
 
     SCOPED_SET_STREAMING(state, { conversationId, value }) {
@@ -1901,9 +1932,16 @@ export default {
       if (!conversationId || String(conversationId).startsWith('temp-')) return false;
 
       const existing = state.conversations[conversationId];
-      if (existing && existing.isStreaming) return false;
+      // isReattaching as well as isStreaming: two announcements for the same
+      // run (or an announcement racing boot resume) would otherwise open two
+      // replays of one turn into one slot.
+      if (existing && (existing.isStreaming || existing.isReattaching)) return false;
 
       commit('ENSURE_CONVERSATION', conversationId);
+      // Claimed BEFORE the request goes out — the round trip is exactly the
+      // window in which the socket mirror would write content the replay is
+      // about to deliver again.
+      commit('SCOPED_SET_REATTACHING', { conversationId, value: true });
 
       const abortController = new AbortController();
       commit('SCOPED_SET_ABORT_CONTROLLER', { conversationId, controller: abortController });
@@ -1952,6 +1990,10 @@ export default {
         return false;
       } finally {
         if (live) commit('SCOPED_SET_STREAMING', { conversationId, value: false });
+        // Released on every path, including a 204 "nothing running" and an
+        // abort: a claim that outlived its request would make the conversation
+        // permanently deaf to the socket mirror.
+        commit('SCOPED_SET_REATTACHING', { conversationId, value: false });
         commit('SCOPED_SET_ABORT_CONTROLLER', { conversationId, controller: null });
         markRunEnded(conversationId);
       }
@@ -2726,8 +2768,11 @@ export default {
 
       // Check if the target conversation is actively streaming via SSE in this tab
       const targetConv = targetConvId ? state.conversations[targetConvId] : null;
-      if (targetConv && targetConv.isStreaming && !isAutonomousEvent && !isAsyncToolEvent) {
-        console.log('[Realtime Chat] Ignoring Socket.IO event - conversation is streaming via SSE');
+      // isReattaching counts as owned too. The replay about to arrive covers
+      // this turn from its first event, so anything applied here in the
+      // meantime is content the replay will deliver a second time.
+      if (targetConv && (targetConv.isStreaming || targetConv.isReattaching) && !isAutonomousEvent && !isAsyncToolEvent) {
+        console.log('[Realtime Chat] Ignoring Socket.IO event - conversation is owned by an SSE stream');
         return;
       }
 

--- a/frontend/src/store/features/chat.reattachClaim.spec.js
+++ b/frontend/src/store/features/chat.reattachClaim.spec.js
@@ -1,0 +1,209 @@
+// One turn, one writer — the round trip is not a free-for-all.
+//
+// WHY THIS FILE EXISTS
+// --------------------
+// Two independent mechanisms deliver the same turn to a client that did not
+// start it:
+//
+//   1. the socket DELTA MIRROR (chat:message_start / chat:content_delta),
+//      which is live but has no replay, so it is useless to a client that
+//      arrived mid-run;
+//   2. the SSE REPLAY (GET /orchestrator/runs/:id/stream), which hands back the
+//      turn from conversation_started onward.
+//
+// Reattaching on a `run:started` announcement makes (2) the one that matters.
+// But the decision to reattach and the arrival of the replay are separated by
+// an HTTP round trip, and during it the mirror is still writing. The replay
+// then starts from the beginning of the turn and applies the same content
+// again — and neither mutation is idempotent: SCOPED_ADD_MESSAGE pushes
+// without checking ids, SCOPED_APPEND_MESSAGE_CONTENT appends unconditionally.
+// The visible result is a duplicated bubble containing duplicated prose.
+//
+// isStreaming cannot close that window: it is raised only when the server
+// actually sends something, precisely so an idle page load does not flash a
+// spinner. So the claim is its own flag, taken before the request goes out.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/views/_components/base/ChatWindow', () => ({ Message: class {}, ChatWindow: class {} }));
+vi.mock('@/tt.config.js', () => ({ API_CONFIG: { BASE_URL: 'http://localhost:3333' } }));
+vi.mock('@/services/chatChannelConfig.js', () => ({
+  resolveChannelProviderModel: vi.fn(),
+  resolveChannelEnabledTools: vi.fn(),
+}));
+vi.mock('@/composables/useRealtimeSync.js', () => ({ emitSteer: vi.fn(), emitClearSteer: vi.fn() }));
+vi.mock('@/utils/safeTruncate.js', () => ({ safeTruncate: (s) => s }));
+vi.mock('@/services/chatService.js', () => ({
+  reattachRun: vi.fn(),
+  cancelRun: vi.fn(),
+  fetchConversation: vi.fn(),
+}));
+
+import { reattachRun } from '@/services/chatService.js';
+
+const CONV = 'conv-race';
+
+let chat;
+let state;
+let commit;
+let dispatch;
+
+const makeState = () => ({
+  activeConversationId: CONV,
+  currentConversationId: null,
+  unreadOutputIds: {},
+  pendingSteer: '',
+  messages: [],
+  conversations: {},
+  activeSkillByConv: {},
+  activeGoalByConv: {},
+  aiByConv: {},
+  streamEventCallbacks: [],
+  autosaveEnabled: true,
+});
+
+/** A socket delta mirror event, exactly as useRealtimeSync forwards it. */
+const socketEvent = (type, extra = {}) => chat.actions.handleRealtimeChatEvent(
+  { commit, state, dispatch },
+  { type, conversationId: CONV, assistantMessageId: 'a1', ...extra },
+);
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  localStorage.clear();
+  localStorage.setItem('token', 't');
+  global.fetch = vi.fn();
+  const mod = await import('./chat.js');
+  chat = mod.default;
+  state = makeState();
+  commit = vi.fn((type, payload) => {
+    const fn = chat.mutations[type];
+    if (fn) fn(state, payload);
+  });
+  dispatch = vi.fn(() => Promise.resolve());
+  chat.mutations.ENSURE_CONVERSATION(state, CONV);
+});
+
+describe('claiming a conversation for a reattach', () => {
+  it('is claimed before the request goes out, not when the reply arrives', async () => {
+    let release;
+    reattachRun.mockImplementation(() => new Promise((r) => { release = r; }));
+
+    const pending = chat.actions.reattachConversation({ commit, state, dispatch }, CONV);
+    await Promise.resolve();
+
+    // The request is still in flight and the server has sent nothing, so the
+    // spinner is correctly still down — but the slot is already spoken for.
+    expect(state.conversations[CONV].isReattaching).toBe(true);
+    expect(state.conversations[CONV].isStreaming).toBe(false);
+
+    release(true);
+    await pending;
+  });
+
+  it('DROPS delta-mirror events that arrive during the round trip', async () => {
+    let release;
+    reattachRun.mockImplementation(() => new Promise((r) => { release = r; }));
+
+    const pending = chat.actions.reattachConversation({ commit, state, dispatch }, CONV);
+    await Promise.resolve();
+
+    // Exactly the sequence that used to double-apply: the mirror announces the
+    // assistant turn and streams prose the replay is about to deliver again.
+    await socketEvent('message_start');
+    await socketEvent('content_delta', { delta: 'Half an answer' });
+
+    expect(state.conversations[CONV].messages).toHaveLength(0);
+
+    release(true);
+    await pending;
+  });
+
+  it('lets the replay be the single source of the turn', async () => {
+    // The replay writes through the SSE path while the claim is held, so the
+    // transcript contains the turn exactly once.
+    reattachRun.mockImplementation(async ({ onEvent }) => {
+      onEvent('assistant_message', { id: 'a1', role: 'assistant', content: '' });
+      onEvent('content_delta', { assistantMessageId: 'a1', delta: 'Half an answer' });
+      onEvent('content_delta', { assistantMessageId: 'a1', delta: ' and the rest.' });
+      return true;
+    });
+
+    await chat.actions.reattachConversation({ commit, state, dispatch }, CONV);
+
+    const messages = state.conversations[CONV].messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toBe('Half an answer and the rest.');
+  });
+
+  it('releases the claim when the run was already over', async () => {
+    // 204: nothing running. A claim that outlived its request would leave the
+    // conversation permanently deaf to the mirror.
+    reattachRun.mockResolvedValue(false);
+
+    await chat.actions.reattachConversation({ commit, state, dispatch }, CONV);
+
+    expect(state.conversations[CONV].isReattaching).toBe(false);
+  });
+
+  it('releases the claim when the request fails', async () => {
+    reattachRun.mockRejectedValue(new Error('network went away'));
+
+    await chat.actions.reattachConversation({ commit, state, dispatch }, CONV);
+
+    expect(state.conversations[CONV].isReattaching).toBe(false);
+  });
+
+  it('accepts mirror events again once the claim is released', async () => {
+    reattachRun.mockResolvedValue(false);
+    await chat.actions.reattachConversation({ commit, state, dispatch }, CONV);
+
+    await socketEvent('message_start');
+
+    // Suppression is scoped to the reattach, not permanent: a later turn
+    // started in another tab must still stream in here.
+    expect(state.conversations[CONV].messages).toHaveLength(1);
+  });
+});
+
+describe('one run, one reattach', () => {
+  it('refuses a second reattach while one is in flight', async () => {
+    let release;
+    reattachRun.mockImplementation(() => new Promise((r) => { release = r; }));
+
+    const first = chat.actions.reattachConversation({ commit, state, dispatch }, CONV);
+    await Promise.resolve();
+
+    // Two announcements for one run — or an announcement landing during boot
+    // resume — would otherwise open two replays of the same turn into one slot.
+    const second = await chat.actions.reattachConversation({ commit, state, dispatch }, CONV);
+
+    expect(second).toBe(false);
+    expect(reattachRun).toHaveBeenCalledTimes(1);
+
+    release(true);
+    await first;
+  });
+
+  it('still refuses while the conversation is streaming normally', async () => {
+    chat.mutations.SCOPED_SET_STREAMING(state, { conversationId: CONV, value: true });
+
+    expect(await chat.actions.reattachConversation({ commit, state, dispatch }, CONV)).toBe(false);
+    expect(reattachRun).not.toHaveBeenCalled();
+  });
+});
+
+describe('a claimed conversation is live for eviction purposes', () => {
+  it('is not evicted to make room while its replay is in flight', () => {
+    // ENSURE_CONVERSATION evicts the least recent idle conversation at
+    // capacity. Evicting one mid-reattach aborts its controller and drops the
+    // turn on the floor — the exact outcome this whole path exists to prevent.
+    state.activeConversationId = 'other';
+    chat.mutations.SCOPED_SET_REATTACHING(state, { conversationId: CONV, value: true });
+
+    for (let i = 0; i < 60; i++) chat.mutations.ENSURE_CONVERSATION(state, `filler-${i}`);
+
+    expect(state.conversations[CONV]).toBeDefined();
+    expect(state.conversations[CONV].isReattaching).toBe(true);
+  });
+});

--- a/frontend/src/views/Terminal/CenterPanel/screens/Dashboard/components/GlobalPulseRibbon.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Dashboard/components/GlobalPulseRibbon.vue
@@ -1,5 +1,12 @@
 <template>
-  <div class="global-pulse-ribbon">
+  <!--
+    data-tour-id implements the `dashboard.global-pulse-ribbon` entry that
+    tourTargets.js (and its backend mirror) has always declared. The registry
+    promises the assistant it can highlight this element; until now the
+    attribute did not exist anywhere in the app, so a tour step naming it
+    resolved to nothing and highlighted air. See tests/e2e/tour-targets.spec.js.
+  -->
+  <div class="global-pulse-ribbon" data-tour-id="dashboard.global-pulse-ribbon">
     <div class="pulse-section agnt-score-section">
       <span class="pulse-label"><span style="color: var(--color-primary)">AGNT</span> XP:</span>
       <span class="agnt-score-value">{{ agntScoreData?.formatted || '0' }}</span>

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,3 +1,24 @@
+// SAME ISOLATION THE VITEST RUNNER ALREADY HAS — the Playwright runner had none.
+//
+// tests/e2e/mobile-lite-pair.spec.js imports backend/src/routes/PairingRoutes.js
+// at module scope, and backend/src/models/database/index.js is a boot sequence
+// disguised as an import: opening it runs createTables, ~25 ALTER TABLE probes,
+// FTS setup and the stale-run sweep (UPDATE agent_executions SET
+// status='interrupted' WHERE status='running'). Playwright COLLECTS every spec
+// before it runs any, so `npx playwright test` — with any filter, even one that
+// excludes that file — booted the developer's REAL database. Observed on a live
+// machine: "📁 AGNT data: ~/.agnt/data (source: homedir)".
+//
+// tests/setup/isolate-data-dir.mjs is the guard written for exactly this, for
+// vitest, in July. It is imported rather than reimplemented: it already knows
+// that USER_DATA_PATH outranks AGNT_HOME in PathManager's cascade, that a
+// zero-byte agnt.db is needed to disarm the legacy-migration shim, and which
+// host env vars must be scrubbed so a developer's shell cannot change what a
+// test means. A second copy of that reasoning would drift from the first.
+//
+// Playwright loads this config in every worker process, so the redirect is in
+// place before any spec module is imported. Its own marker makes it idempotent.
+import './tests/setup/isolate-data-dir.mjs';
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({

--- a/tests/e2e/agents.spec.js
+++ b/tests/e2e/agents.spec.js
@@ -1,47 +1,26 @@
-import { test, expect, _electron as electron } from '@playwright/test';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { loginUser, mockAgents } from './fixtures/auth.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+/**
+ * The agents list renders what the API returned.
+ *
+ * Assertion unchanged from the Electron version. What changed is how the app
+ * is launched (see fixtures/appFixture.js) and how the sidebar is addressed:
+ * `.primary-nav-button` / `.secondary-nav-button` belong to a navigation
+ * component that CanvasScreen replaced, so those selectors had been matching
+ * nothing since long before anyone noticed.
+ */
+import { test, expect, gotoApp } from './fixtures/appFixture.js';
+import { mockAgents } from './fixtures/auth.js';
 
 test.describe('Agents Feature', () => {
-  let electronApp;
-  let window;
+  test('can navigate to agents and see the list @ci', async ({ appPage }) => {
+    // Registered BEFORE the app boots: the screen fetches on mount, and a mock
+    // installed after that races a request already in flight.
+    await mockAgents(appPage);
+    await gotoApp(appPage, '/');
 
-  test.beforeEach(async ({}, testInfo) => {
-    const port = 3333 + testInfo.workerIndex;
-    const mainScriptPath = path.join(__dirname, '../../main.js');
-    electronApp = await electron.launch({
-      args: [mainScriptPath],
-      env: { ...process.env, NODE_ENV: 'development', PORT: port.toString() },
-    });
-    window = await electronApp.firstWindow();
-    await window.waitForLoadState('domcontentloaded');
+    await appPage.locator('[data-tour-id="sidebar.agents"]').click();
+    await appPage.waitForURL('**/agents');
 
-    await mockAgents(window);
-    await loginUser(window);
-    await window.reload();
-    await window.waitForLoadState('domcontentloaded');
-  });
-
-  test.afterEach(async () => {
-    if (electronApp) {
-      await electronApp.close();
-    }
-  });
-
-  test('can navigate to agents and see the list', async () => {
-    // Navigate to Agents via secondary nav
-    // Primary: Assets -> Agents
-    await window.locator('.primary-nav-button').filter({ hasText: 'Assets' }).click();
-    await window.locator('.secondary-nav-button').filter({ hasText: 'Agents' }).click();
-    await window.waitForURL('**/agents');
-
-    // Verify Agent List
-    // We expect the mocked agents to be present
-    await expect(window.getByText('Test Agent 1')).toBeVisible();
-    await expect(window.getByText('Test Agent 2')).toBeVisible();
+    await expect(appPage.getByText('Test Agent 1')).toBeVisible();
+    await expect(appPage.getByText('Test Agent 2')).toBeVisible();
   });
 });

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -1,57 +1,30 @@
-import { test, expect, _electron as electron } from '@playwright/test';
-import path from 'path';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+/**
+ * The app boots and mounts.
+ *
+ * Thin, but not nothing: it is the canary for "the bundle is broken" or "the
+ * session gate rejected us", both of which fail every other spec in confusing
+ * ways. Keeping it first means those produce one obvious failure instead of six.
+ *
+ * NOTE ON #app: the original asserted it was VISIBLE. In the canvas layout the
+ * root div carries no box of its own, so Playwright correctly reports it
+ * hidden while the app is plainly on screen. Visibility of something the user
+ * can actually see is asserted by gotoApp (the sidebar); what belongs here is
+ * that Vue mounted into the root at all.
+ */
+import { test, expect, gotoApp } from './fixtures/appFixture.js';
 
 test.describe('Application Launch', () => {
-  let electronApp;
+  test('app loads and mounts the shell @ci', async ({ appPage }, testInfo) => {
+    await gotoApp(appPage, '/');
 
-  test.afterEach(async () => {
-    if (electronApp) {
-      await electronApp.close();
-    }
-  });
+    // The HTML title, which the Electron window title used to override.
+    expect(await appPage.title()).toBe('AGNT.gg');
 
-  test('app launches and displays main window', async ({}, testInfo) => {
-    // Path to the main.js file
-    // tests/e2e -> tests -> desktop -> main.js
-    const mainScriptPath = path.join(__dirname, '../../main.js');
+    // Mounted: Vue sets data-v-app on the root it takes over.
+    const root = appPage.locator('#app');
+    await expect(root).toBeAttached();
+    await expect(root).toHaveAttribute('data-v-app', '');
 
-    console.log('Launching app from:', mainScriptPath);
-
-    const port = 3333 + testInfo.workerIndex;
-    console.log(`Launching app on port: ${port}`);
-
-    // Launch the app
-    electronApp = await electron.launch({
-      args: [mainScriptPath],
-      env: {
-        ...process.env,
-        NODE_ENV: 'development',
-        PORT: port.toString(),
-      },
-    });
-
-    // Get the first window that opens
-    const window = await electronApp.firstWindow();
-
-    // Wait for the window to load
-    // The app loads localhost:3333, so we wait for that to be ready
-    await window.waitForLoadState('domcontentloaded');
-
-    // Check title
-    const title = await window.title();
-    console.log('Window title:', title);
-    // The HTML title is AGNT.gg, which overrides the Electron window title
-    expect(title).toBe('AGNT.gg');
-
-    // Capture a screenshot
-    await window.screenshot({ path: 'test-results/initial-launch.png' });
-
-    // Basic verification that the app mounted
-    const appElement = window.locator('#app');
-    await expect(appElement).toBeVisible();
+    await appPage.screenshot({ path: testInfo.outputPath('initial-launch.png') });
   });
 });

--- a/tests/e2e/chat.spec.js
+++ b/tests/e2e/chat.spec.js
@@ -1,65 +1,22 @@
-import { test, expect, _electron as electron } from '@playwright/test';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { loginUser } from './fixtures/auth.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+/**
+ * The chat input is reachable and interactive.
+ *
+ * Deliberately does not send: submitting would need the chat API mocked, and
+ * that is covered far more thoroughly by the unit suites. What this proves is
+ * the thing only a browser can — the screen renders far enough to type into.
+ */
+import { test, expect, gotoApp } from './fixtures/appFixture.js';
 
 test.describe('Chat Feature', () => {
-  let electronApp;
-  let window;
+  test('can type in the chat input @ci', async ({ appPage }) => {
+    await gotoApp(appPage, '/');
+    await appPage.locator('[data-tour-id="sidebar.chat"]').click();
+    await appPage.waitForURL('**/chat');
 
-  test.beforeEach(async ({}, testInfo) => {
-    const port = 3333 + testInfo.workerIndex;
-    const mainScriptPath = path.join(__dirname, '../../main.js');
-    electronApp = await electron.launch({
-      args: [mainScriptPath],
-      env: { ...process.env, NODE_ENV: 'development', PORT: port.toString() },
-    });
-    window = await electronApp.firstWindow();
-    await window.waitForLoadState('domcontentloaded');
+    const input = appPage.locator('.chat-input-textarea').first();
+    await expect(input).toBeVisible({ timeout: 30000 });
 
-    await loginUser(window);
-    await window.reload();
-    await window.waitForLoadState('domcontentloaded');
-  });
-
-  test.afterEach(async () => {
-    if (electronApp) {
-      await electronApp.close();
-    }
-  });
-
-  test('can type in the chat input', async ({}, testInfo) => {
-    const port = 3333 + testInfo.workerIndex;
-    // Navigate to Chat
-    await window.goto(`http://localhost:${port}/chat`);
-    await window.waitForURL('**/chat');
-
-    // Verify that we are connected (welcome message instead of setup)
-    // "Hi! I'm Annie..." implies connection
-    // "Connect an AI Provider" implies no connection
-
-    // If we see the setup message, the test will fail because input is hidden
-    const setupMessage = window.locator('text=Connect an AI Provider');
-    if (await setupMessage.isVisible()) {
-      console.log('Setup message visible - provider not connected properly in test');
-    }
-
-    // Find the input field
-    // Using the specific class from BaseScreen.vue
-    const input = window.locator('.chat-input-textarea').first();
-    await expect(input).toBeVisible({ timeout: 20000 });
-
-    // Type a message
-    const testMessage = 'Hello AGNT Test';
-    await input.fill(testMessage);
-
-    // Verify input value
-    await expect(input).toHaveValue(testMessage);
-
-    // We won't submit to avoid backend errors since we haven't mocked the chat API
-    // But verifying we can type confirms the UI is interactive
+    await input.fill('Hello AGNT Test');
+    await expect(input).toHaveValue('Hello AGNT Test');
   });
 });

--- a/tests/e2e/cross-client-runs.spec.js
+++ b/tests/e2e/cross-client-runs.spec.js
@@ -1,0 +1,240 @@
+/**
+ * TWO TABS, ONE RUN. The cross-client run-visibility contract, made executable.
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * A chat run outlives the socket that started it, and any of a user's clients
+ * may attach to it: at boot via GET /orchestrator/runs, or live via the
+ * `run:started` announcement. Every layer of that has unit tests — 3,600 of
+ * them — and they all passed while the feature had a defect that made it look
+ * broken to a human: the attach was logged from a promise that settles only
+ * when the RUN ENDS, so attaching to a ten-minute task printed nothing for ten
+ * minutes. The attach worked. It was silent. Nothing that mocks a store or
+ * asserts on source can see that, because nothing there has a clock and a
+ * console and a second tab.
+ *
+ * So this suite runs the real thing: two real tabs in one real browser, two
+ * real Socket.IO connections, a real fan-out, and a real SSE reattach off the
+ * real replay log.
+ *
+ * THE ONE SUBSTITUTION: the chat turn itself. See fixtures/crossClientBackend.mjs
+ * for exactly what is stood in for, and which committed test covers the part
+ * that is. Everything downstream of the wire is real here.
+ *
+ * WHY THE TABS MUST SHARE A CONTEXT
+ * ---------------------------------
+ * One browser context is one browser: the tabs share localStorage. That is what
+ * makes the central assertion meaningful — "same browser" does NOT mean "same
+ * client", because the client id is per PAGE LOAD, held in module memory. Had
+ * it been persisted to sessionStorage (which looked tempting while building
+ * this), the second tab would recognise the first tab's run as its own and sit
+ * blind. Nothing else in the suite would notice.
+ */
+import { test, expect } from '@playwright/test';
+import {
+  portsForWorker,
+  assertSafePorts,
+  startHarnessBackend,
+  startHarnessVite,
+  openTab,
+} from './fixtures/crossClientHarness.js';
+
+// SERIAL: every test shares the servers and the browser context built in
+// beforeAll, and the later ones assert on runs the earlier ones started. Serial
+// also means a broken harness reports one failure rather than four.
+//
+// RETRIES ON CI, AND WHAT A RETRY MUST NOT BE TAKEN TO MEAN. This suite
+// orchestrates two servers, three tabs and a websocket on a shared runner, so
+// some flake is genuinely infrastructural (a slow cold start, a bind that loses
+// a race). One retry absorbs that. It does NOT absorb product flake: Playwright
+// reports a test that passed on retry as `flaky`, distinctly from `passed`, and
+// a flaky result HERE deserves investigation rather than a shrug — the races
+// this file exists to catch would present in exactly that way. `trace:
+// 'on-first-retry'` in playwright.config.js means the evidence is already saved.
+test.describe.configure({ mode: 'serial', retries: process.env.CI ? 1 : 0 });
+
+// THE @ci TAG IS THE CI CONTRACT, AND IT IS DELIBERATELY NOT A FILENAME.
+//
+// The CI job selects work with `--grep @ci` rather than by listing this file,
+// so a future headless suite is gated by tagging itself — not by someone
+// remembering to edit a workflow. Selecting by path would silently leave the
+// next one ungated, which is the same failure the root vitest config warns
+// about: dropping a suite quietly is as bad as ignoring one.
+//
+// To earn the tag a suite must need NOTHING beyond what the CI job already
+// provides: `npm ci`, `npm rebuild sqlite3`, the frontend deps, a built
+// frontend/dist, and `npx playwright install chromium`. Concretely that rules
+// out an Electron binary, a branded Chrome channel, the network, and API keys.
+//
+// (`frontend/dist` joined that list when the UI specs — app, navigation,
+// agents, chat, workflows — were ported off Electron and tagged: they drive
+// the real app, which backend/server.js serves from dist.)
+const CI_TAG = { tag: '@ci' };
+
+// Cold-starting a backend that runs the full database bootstrap, plus Vite, is
+// well past the config's 60s default on a cold CI runner.
+const SETUP_TIMEOUT = 240000;
+const TEST_TIMEOUT = 120000;
+
+/** Text published by the harness backend BEFORE any client attaches. */
+const REPLAYED_TEXT = 'Starting the long job';
+
+let backend;
+let vite;
+let context;
+let tab1;
+let tab2;
+let firstConversationId;
+
+test.beforeAll(async ({ browser }, testInfo) => {
+  test.setTimeout(SETUP_TIMEOUT);
+
+  const ports = portsForWorker(testInfo.workerIndex);
+  assertSafePorts(ports);
+
+  backend = await startHarnessBackend(ports.backend);
+  vite = await startHarnessVite(ports.vite, ports.backend);
+
+  // ONE context = one browser = shared localStorage. Two pages in it are two
+  // TABS, which is the distinction this whole suite turns on.
+  context = await browser.newContext();
+  await context.addInitScript((t) => { localStorage.setItem('token', t); }, backend.token);
+
+  tab1 = await openTab(context, vite.url);
+  tab2 = await openTab(context, vite.url);
+});
+
+test.afterAll(async () => {
+  await context?.close().catch(() => {});
+  await vite?.stop().catch(() => {});
+  backend?.stop();
+});
+
+test('the harness talks to its own backend, never a real install', CI_TAG, async () => {
+  // The single most consequential fact about this suite. frontend/user.config.js
+  // sends a page served on :5173 to http://localhost:3333 — a developer's real
+  // AGNT, with their real database. This asserts the URL the page ACTUALLY
+  // resolved, not merely that the port constant is right.
+  expect(tab1.baseUrl).not.toContain('3333');
+  expect(tab1.baseUrl).toContain(String(new URL(vite.url).port));
+});
+
+test('two tabs in one browser are two different clients', CI_TAG, async () => {
+  test.setTimeout(TEST_TIMEOUT);
+
+  expect(tab1.clientId).toBeTruthy();
+  expect(tab2.clientId).toBeTruthy();
+  // The load-bearing assertion. Same browser, same localStorage, different
+  // identity — because the id lives in module memory, per page load.
+  expect(tab2.clientId).not.toBe(tab1.clientId);
+
+  // ...and the storage really is shared, so the distinction above is not an
+  // accident of isolation.
+  expect(await tab2.page.evaluate(() => localStorage.getItem('token'))).toBe(backend.token);
+});
+
+test('a second tab attaches to a run started in the first', CI_TAG, async () => {
+  test.setTimeout(TEST_TIMEOUT);
+
+  firstConversationId = `conv-xclient-${Date.now()}`;
+  const started = await tab1.startRun(firstConversationId);
+
+  // The server can only label the announcement if the request identified its
+  // sender — the header chatService.streamChat sends on every turn.
+  expect(started.originClientId).toBe(tab1.clientId);
+
+  // Tab 2 was already open and idle. Nothing polls; nothing reloaded. The only
+  // thing that can tell it is the announcement.
+  //
+  // Polled on the REPLAYED TEXT rather than on the conversation existing: the
+  // slot appears the instant reattachConversation commits ENSURE_CONVERSATION,
+  // which is one HTTP round trip before any replayed event lands. Waiting on
+  // `known` therefore reads a half-attached conversation as success and then
+  // fails on the next line — a self-inflicted flake, and one this suite caught
+  // on its first run.
+  await expect.poll(async () => (await tab2.snapshot(firstConversationId)).text, {
+    timeout: 30000,
+    message: `tab 2 never received the replay. Console:\n${tab2.logs.join('\n')}`,
+  }).toContain(REPLAYED_TEXT);
+
+  const snap = await tab2.snapshot(firstConversationId);
+
+  // THE assertion that separates a real reattach from the old delta mirror:
+  // this text was published BEFORE tab 2 attached, so holding it proves tab 2
+  // received the REPLAY, not merely the notification. A test that only checked
+  // "tab 2 logged something" would pass on a broken reattach.
+  expect(snap.text).toContain(REPLAYED_TEXT);
+  expect(snap.isStreaming).toBe(true);
+
+  // And it said so AT THE ATTACH — the defect that prompted this file. The
+  // suffix names the surface, which is the difference between "a run was
+  // adopted" and "a run was adopted BY THE RIGHT SURFACE".
+  expect(tab2.logs.join('\n')).toContain(`Attaching to run announced elsewhere: ${firstConversationId} → main chat`);
+});
+
+test('the originating tab ignores its own announcement', CI_TAG, async () => {
+  test.setTimeout(TEST_TIMEOUT);
+
+  // An assertion of an ABSENCE, which is only meaningful beside the previous
+  // test: if the handler were simply dead, this would pass and mean nothing.
+  const snap = await tab1.snapshot(firstConversationId);
+  expect(snap.known).toBe(false);
+  expect(snap.allConversationIds).not.toContain(firstConversationId);
+  expect(tab1.logs.join('\n')).not.toContain('Attaching to run announced elsewhere');
+});
+
+test('a tab opened mid-run discovers it with no announcement at all', CI_TAG, async () => {
+  test.setTimeout(TEST_TIMEOUT);
+
+  // Tab 3 boots into a run that is already in flight, so it missed the
+  // announcement entirely. GET /orchestrator/runs is the only thing that can
+  // find it — and before that endpoint existed, nothing could.
+  const tab3 = await openTab(context, vite.url);
+
+  await expect.poll(async () => (await tab3.snapshot(firstConversationId)).text, {
+    timeout: 30000,
+    message: `tab 3 never discovered the run at boot. Console:\n${tab3.logs.join('\n')}`,
+  }).toContain(REPLAYED_TEXT);
+
+  // The log names WHICH source found it. `0 local marker(s), 1 from server` is
+  // the shape that matters: tab 3 wrote no marker of its own, so the server
+  // list is demonstrably what did the work.
+  expect(tab3.logs.join('\n')).toMatch(/\[runResume\].*from server/);
+
+  await tab3.page.close();
+});
+
+test('the broadcast audience counts tabs, not browsers', CI_TAG, async () => {
+  test.setTimeout(TEST_TIMEOUT);
+
+  // Two tabs remain open (tab 3 closed above). The count is read from the real
+  // broadcastToUser log line, so this is the product's own bookkeeping — which
+  // makes it a genuine diagnostic: a wrong count here means a dead socket, and
+  // knowing that immediately is worth more than the assertion itself.
+  await expect.poll(() => backend.lines('Broadcasting run:started').length, { timeout: 15000 })
+    .toBeGreaterThan(0);
+
+  const twoTabRun = backend.lines('(2 clients)');
+  expect(twoTabRun.length, `broadcast lines:\n${backend.lines('Broadcasting run:started').join('\n')}`)
+    .toBeGreaterThan(0);
+
+  // Open a third tab and the audience must grow.
+  const extra = await openTab(context, vite.url);
+  await tab1.startRun(`conv-xclient-three-${Date.now()}`);
+  await expect.poll(() => backend.lines('(3 clients)').length, {
+    timeout: 20000,
+    message: `audience never reached 3:\n${backend.lines('Broadcasting run:started').join('\n')}`,
+  }).toBeGreaterThan(0);
+
+  // Close it and the audience must shrink — proving the count is live rather
+  // than a high-water mark, and therefore that it cannot mask a dead socket.
+  await extra.page.close();
+  const before = backend.lines('(2 clients)').length;
+  await expect.poll(async () => {
+    await tab1.startRun(`conv-xclient-shrink-${Date.now()}`);
+    return backend.lines('(2 clients)').length;
+  }, {
+    timeout: 20000,
+    message: `audience never shrank back:\n${backend.lines('Broadcasting run:started').join('\n')}`,
+  }).toBeGreaterThan(before);
+});

--- a/tests/e2e/fixtures/appFixture.js
+++ b/tests/e2e/fixtures/appFixture.js
@@ -1,0 +1,162 @@
+/**
+ * The AGNT app, in a browser, without Electron.
+ *
+ * WHY THIS EXISTS
+ * ───────────────
+ * The UI specs launched Electron. That is the shipping form of the app, but it
+ * is not what the specs actually test: none of them assert anything about a
+ * native window, a menu, IPC, or the updater. They click nav buttons and read
+ * the DOM.
+ *
+ * Electron was therefore costing the suite its portability for nothing —
+ * `_electron.launch` needs a built app, a binary, and a display, none of which
+ * a bare CI runner has, which is why these specs could never be gated. And the
+ * cost was real: ungated, all seven of them rotted into failing for months
+ * without anyone noticing.
+ *
+ * Measured before writing this: frontend/src contains ZERO references to
+ * `electronAPI`, and all 128 uses of `window.electron` are feature-detected
+ * (`window.electron?.x`, `typeof window.electron !== 'undefined'`). The
+ * backend already serves frontend/dist and has an SPA fallback for deep links.
+ * So `node backend/server.js` + Chromium renders the same app — verified by
+ * running it.
+ *
+ * WORKER-SCOPED, AND WHY THAT MATTERS
+ * ───────────────────────────────────
+ * Booting the backend runs the whole database pipeline (createTables, ~25
+ * ALTER TABLE probes, FTS setup), which is ~10s. Per FILE that would be a
+ * minute of CI for five files; per TEST it would be far worse. One backend per
+ * worker amortises it, and each test still gets a fresh browser context, so
+ * localStorage and route mocks never leak between tests.
+ *
+ * ISOLATION: AGNT_HOME points at a throwaway directory, so the specs cannot
+ * touch a developer's real database — the same guarantee
+ * tests/setup/isolate-data-dir.mjs gives the unit suites.
+ */
+import { test as base, expect } from '@playwright/test';
+import { spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { e2ePort, loginUser, signTestToken, TEST_JWT_SECRET } from './auth.js';
+
+// tests/e2e/fixtures/ -> tests/e2e/ -> tests/ -> repo root
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+/** Start backend/server.js against a throwaway data directory. */
+async function startBackend(port) {
+  const distIndex = path.join(REPO, 'frontend', 'dist', 'index.html');
+  if (!fs.existsSync(distIndex)) {
+    throw new Error(
+      'frontend/dist is missing, so the backend has no app to serve.\n'
+      + 'Run: npm --prefix frontend run build',
+    );
+  }
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agnt-e2e-'));
+  fs.mkdirSync(path.join(tmp, '.agnt', 'data'), { recursive: true });
+  // A zero-byte agnt.db disarms the legacy-migration shim, which would
+  // otherwise treat this as a fresh install and copy a real database in.
+  fs.writeFileSync(path.join(tmp, '.agnt', 'data', 'agnt.db'), '');
+
+  const log = [];
+  const proc = spawn('node', [path.join(REPO, 'backend', 'server.js')], {
+    cwd: REPO,
+    env: {
+      ...process.env,
+      AGNT_HOME: tmp,
+      USER_DATA_PATH: '',
+      PORT: String(port),
+      NODE_ENV: 'development',
+      JWT_SECRET: TEST_JWT_SECRET,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const collect = (b) => { for (const l of b.toString().split('\n')) if (l.trim()) log.push(l); };
+  proc.stdout.on('data', collect);
+  proc.stderr.on('data', collect);
+
+  const deadline = Date.now() + 180000;
+  for (;;) {
+    if (proc.exitCode !== null) throw new Error(`backend exited early:\n${log.slice(-30).join('\n')}`);
+    try {
+      const r = await fetch(`http://127.0.0.1:${port}/api/health`);
+      if (r.ok) break;
+    } catch { /* not up yet */ }
+    if (Date.now() > deadline) throw new Error(`backend never became healthy:\n${log.slice(-30).join('\n')}`);
+    await new Promise((r) => setTimeout(r, 250));
+  }
+
+  return {
+    port,
+    baseUrl: `http://127.0.0.1:${port}`,
+    log,
+    stop: () => {
+      try { proc.kill('SIGTERM'); } catch { /* already gone */ }
+      try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }
+    },
+  };
+}
+
+export const test = base.extend({
+  /** One backend per worker. */
+  agntBackend: [async ({}, use, workerInfo) => {
+    const backend = await startBackend(e2ePort(workerInfo.workerIndex));
+    try {
+      await use(backend);
+    } finally {
+      backend.stop();
+    }
+  }, { scope: 'worker', timeout: 240000 }],
+
+  /**
+   * A signed-in page, NOT yet navigated.
+   *
+   * Deliberately not navigated: a spec that needs extra route mocks (agents,
+   * workflows) must register them before the app boots, or the app fetches the
+   * real empty list first and the mock arrives too late to matter.
+   */
+  appPage: async ({ browser, agntBackend }, use) => {
+    const context = await browser.newContext({ baseURL: agntBackend.baseUrl });
+    const page = await context.newPage();
+    const consoleLogs = [];
+    page.on('console', (m) => consoleLogs.push(`[${m.type()}] ${m.text()}`));
+    page.on('pageerror', (e) => consoleLogs.push(`[pageerror] ${e.message}`));
+    page.__consoleLogs = consoleLogs;
+
+    await loginUser(page, { token: signTestToken() });
+    try {
+      await use(page);
+    } finally {
+      await context.close();
+    }
+  },
+});
+
+export { expect };
+
+/**
+ * Navigate and wait until the app shell is genuinely up.
+ *
+ * Waits on the sidebar rather than on a load event: `domcontentloaded` fires
+ * long before Vue has mounted and verifySession has answered, and every one of
+ * these specs immediately clicks something in that sidebar.
+ *
+ * `data-tour-id` is the selector of choice here, and not incidentally. The old
+ * specs addressed `.primary-nav-button` / `.secondary-nav-button`, which
+ * belonged to LeftPanel/header/Navigation.vue — a component CanvasScreen
+ * replaced. Those selectors had been matching nothing for months, and because
+ * nothing ran the specs, nothing said so. `data-tour-id` is a maintained
+ * contract instead of a styling artefact: the guided-tour system addresses
+ * these exact ids, so renaming one breaks a user-visible feature and gets
+ * noticed. A test hook that something else depends on is a test hook that
+ * stays true.
+ */
+export async function gotoApp(page, routePath = '/') {
+  await page.goto(routePath, { waitUntil: 'domcontentloaded' });
+  await expect(
+    page.locator('[data-tour-id^="sidebar."]').first(),
+    `app shell never rendered — the session is probably invalid. Console:\n${(page.__consoleLogs || []).slice(-25).join('\n')}`,
+  ).toBeVisible({ timeout: 60000 });
+}

--- a/tests/e2e/fixtures/auth.js
+++ b/tests/e2e/fixtures/auth.js
@@ -1,5 +1,71 @@
+/**
+ * Signed-in state for the e2e specs.
+ *
+ * WHY THIS WAS REWRITTEN (2026-08-10)
+ * ───────────────────────────────────
+ * Every spec that used this fixture had been failing for months, silently,
+ * because none of them were in CI. They all rendered "Sign in to AGNT /
+ * Session expired" instead of the app. Two independent causes, both of which
+ * post-date the fixture:
+ *
+ *  1. THE TOKEN WAS NOT A TOKEN. It was the string 'mock-test-token', and only
+ *     four endpoints were mocked. The app makes ~20 authenticated calls at
+ *     boot (/api/version, /api/layouts, /api/widget-definitions,
+ *     /api/users/connection-health, six provider auth probes...). Every
+ *     unmocked one 401'd, and frontend/src/utils/axiosInterceptor.js signs the
+ *     session out on the FIRST 401 from ANY endpoint — a guard added after
+ *     this fixture was written. So the app logged itself out mid-boot.
+ *     Fixed by signing a REAL JWT the backend will accept, so the unmocked
+ *     calls succeed instead of 401ing.
+ *
+ *  2. THE SECOND AUTH CHECK LEAVES THE MACHINE. userAuth.js has two callers of
+ *     /users/auth/status: one on API_CONFIG.BASE_URL (local) and one on
+ *     API_CONFIG.REMOTE_URL, which is https://api.agnt.gg. A locally-signed
+ *     token is meaningless there, so the cloud answers
+ *     {isAuthenticated:false} — a DEFINITIVE rejection, not an outage — and
+ *     the session goes INVALID even though the local backend is happy.
+ *     The '**\/users/auth/status' mock below covers BOTH, which is why it must
+ *     stay even though the token is now real.
+ *
+ * NETWORK IS BLOCKED, DELIBERATELY
+ * ────────────────────────────────
+ * Because of (2) these specs would otherwise depend on api.agnt.gg being up.
+ * A CI gate that fails when a third party has an outage is a gate people learn
+ * to ignore, and the @ci tag contract promises no network. So every request
+ * that is not local is ABORTED rather than allowed — which also means a future
+ * unmocked external call fails loudly here instead of silently working on a
+ * developer's machine and breaking on a runner.
+ */
+import jwt from 'jsonwebtoken';
+
+/**
+ * The secret the harness backend is started with (fixtures/appFixture.js sets
+ * JWT_SECRET to this). Overridable so a developer can point a spec at a
+ * differently-configured backend without editing code.
+ */
+export const TEST_JWT_SECRET = process.env.AGNT_E2E_JWT_SECRET || 'agnt-e2e-jwt-secret';
+
+export const TEST_USER_ID = 'e2e-test-user';
+
+/**
+ * Port for the harness backend.
+ *
+ * 34600, NEVER 3333. The specs used to hardcode `3333 + workerIndex`, which is
+ * where a real AGNT install listens — and main.js does not fail on a busy
+ * port, it ADOPTS whatever already answers its health check
+ * ("[connection] sharing the AGNT backend already on port ..."). So running
+ * the suite on a developer's machine pointed it at their live backend and
+ * their real data. Nothing warned about it.
+ */
+export const e2ePort = (workerIndex = 0) => Number(process.env.AGNT_E2E_PORT || 34600) + workerIndex;
+
+/** A token the local backend will actually verify. */
+export function signTestToken({ secret = TEST_JWT_SECRET, userId = TEST_USER_ID } = {}) {
+  return jwt.sign({ id: userId, userId, email: 'test@agnt.gg' }, secret);
+}
+
 export const mockUser = {
-  id: 'test-user-id',
+  id: TEST_USER_ID,
   email: 'test@agnt.gg',
   name: 'Test Agent',
   isAuthenticated: true,
@@ -8,123 +74,71 @@ export const mockUser = {
 export const mockSubscription = {
   planType: 'pro',
   status: 'active',
-  features: {
-    agents: true,
-    workflows: true,
-  },
+  features: { agents: true, workflows: true },
 };
 
 export const mockWorkflowsData = [
-  {
-    id: 'wf-1',
-    name: 'Test Workflow 1',
-    description: 'A test workflow',
-    status: 'active',
-    updatedAt: new Date().toISOString(),
-  },
-  {
-    id: 'wf-2',
-    name: 'Test Workflow 2',
-    description: 'Another test workflow',
-    status: 'draft',
-    updatedAt: new Date().toISOString(),
-  },
+  { id: 'wf-1', name: 'Test Workflow 1', description: 'A test workflow', status: 'active', updatedAt: new Date().toISOString() },
+  { id: 'wf-2', name: 'Test Workflow 2', description: 'Another test workflow', status: 'draft', updatedAt: new Date().toISOString() },
 ];
 
 export const mockAgentsData = [
-  {
-    id: 'agent-1',
-    name: 'Test Agent 1',
-    role: 'Test Role',
-    description: 'A test agent',
-    avatar: '🤖',
-  },
-  {
-    id: 'agent-2',
-    name: 'Test Agent 2',
-    role: 'Helper',
-    description: 'Another test agent',
-    avatar: '👾',
-  },
+  { id: 'agent-1', name: 'Test Agent 1', role: 'Test Role', description: 'A test agent', avatar: '🤖' },
+  { id: 'agent-2', name: 'Test Agent 2', role: 'Helper', description: 'Another test agent', avatar: '👾' },
 ];
 
+const json = (body) => ({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
 /**
- * Mocks the authentication flow for the given window/page
- * @param {import('@playwright/test').Page} page
+ * Refuse every request that would leave this machine.
+ *
+ * Registered FIRST on purpose: Playwright gives priority to the most recently
+ * registered matching handler, so the specific mocks added after this one win,
+ * and this catches only what nothing else claimed.
  */
-export async function loginUser(page) {
-  // 1. Mock the API responses
-  // Mock Auth Status
-  await page.route('**/users/auth/status', async (route) => {
-    // console.log('Intercepted /users/auth/status');
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ isAuthenticated: true, user: mockUser }),
-    });
+async function blockExternalRequests(page) {
+  await page.route('**/*', async (route) => {
+    const url = route.request().url();
+    const local = /^https?:\/\/(127\.0\.0\.1|localhost|\[::1\])(:|\/)/.test(url)
+      || url.startsWith('data:') || url.startsWith('blob:') || url.startsWith('about:');
+    if (local) return route.fallback();
+    // Loud on purpose. A silent allow here is how a suite starts depending on
+    // a third party without anyone deciding that it should.
+    console.warn(`[e2e] BLOCKED external request: ${url}`);
+    return route.abort('blockedbyclient');
   });
+}
 
-  // Mock Subscription Status
-  await page.route('**/users/subscription/status', async (route) => {
-    // console.log('Intercepted /users/subscription/status');
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(mockSubscription),
-    });
-  });
+/**
+ * Put the page in a signed-in state.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {{ token?: string }} [opts] token defaults to a freshly signed one.
+ */
+export async function loginUser(page, { token = signTestToken() } = {}) {
+  await blockExternalRequests(page);
 
-  // Mock Pseudonym/Referral
-  await page.route('**/referrals/user/**', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ pseudonym: 'TestUser' }),
-    });
-  });
+  // Covers BOTH the local and the api.agnt.gg caller — see the header.
+  await page.route('**/users/auth/status', (route) => route.fulfill(json({ isAuthenticated: true, user: mockUser })));
+  await page.route('**/users/subscription/status', (route) => route.fulfill(json(mockSubscription)));
+  await page.route('**/referrals/user/**', (route) => route.fulfill(json({ pseudonym: 'TestUser' })));
+  await page.route('**/auth/connected', (route) => route.fulfill(json(['OpenAI', 'Anthropic'])));
 
-  // Mock Connected Apps
-  await page.route('**/auth/connected', async (route) => {
-    // console.log('Intercepted /auth/connected');
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(['OpenAI', 'Anthropic']),
-    });
-  });
-
-  // 2. Set localStorage
-  await page.evaluate(() => {
-    localStorage.setItem('token', 'mock-test-token');
+  // addInitScript, not evaluate: the store reads localStorage during module
+  // init, so a token written after load is a token the app has already decided
+  // it does not have. The old fixture papered over this with a reload().
+  await page.addInitScript((t) => {
+    localStorage.setItem('token', t);
     localStorage.setItem('hasCompletedOnboarding', 'true');
-    // Set default AI provider
     localStorage.setItem('selectedProvider', 'OpenAI');
     localStorage.setItem('selectedModel', 'gpt-4o');
-  });
-
-  // console.log('Mocked login state set in localStorage');
+  }, token);
 }
 
 export async function mockWorkflows(page) {
-  // Matches .../api/workflows/ and .../api/workflows/?status=...
-  await page.route('**/workflows/**', async (route) => {
-    // console.log('Intercepted /workflows');
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ workflows: mockWorkflowsData }),
-    });
-  });
+  await page.route('**/workflows/**', (route) => route.fulfill(json({ workflows: mockWorkflowsData })));
 }
 
 export async function mockAgents(page) {
-  // Matches .../api/agents/
-  await page.route('**/agents/**', async (route) => {
-    // console.log('Intercepted /agents');
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ agents: mockAgentsData }),
-    });
-  });
+  await page.route('**/agents/**', (route) => route.fulfill(json({ agents: mockAgentsData })));
 }

--- a/tests/e2e/fixtures/crossClientBackend.mjs
+++ b/tests/e2e/fixtures/crossClientBackend.mjs
@@ -1,0 +1,172 @@
+/**
+ * Harness backend for tests/e2e/cross-client-runs.spec.js.
+ *
+ * Stands up the REAL pieces of the backend the two-tab tests depend on, and
+ * nothing else:
+ *
+ *   REAL  OrchestratorRoutes         -> GET /runs, GET /runs/:id/stream (SSE replay)
+ *   REAL  activeRuns registry        -> startRun / publish / the replay log
+ *   REAL  broadcastToUser            -> the "(N clients)" line the tests assert on
+ *   REAL  resolveSocketIdentity      -> token-derived room membership
+ *   REAL  authenticateToken          -> a genuinely signed JWT, not a mocked guard
+ *
+ * STAND-IN, stated plainly: POST /api/harness/start-run replaces
+ * universalChatHandler. A real chat turn needs a real LLM, which would make a
+ * CI gate slow, costly and nondeterministic for reasons that have nothing to do
+ * with run visibility. This trigger performs the SAME two steps, in the SAME
+ * order, with the SAME payload as the real call site in OrchestratorService.js:
+ *
+ *     activeRun = startRun({ conversationId, userId, chatType, ... });
+ *     broadcastToUser(userId, RealtimeEvents.RUN_STARTED, {
+ *       conversationId, chatType, startedAt, originClientId,
+ *     });
+ *
+ * That the real call site does exactly that — after startRun, before the first
+ * sendEvent, gated on userId, reading x-agnt-client-id — is pinned separately by
+ * backend/src/services/OrchestratorService.runAnnouncement.test.js, which is
+ * mutation-verified: deleting the broadcast fails four of its assertions.
+ *
+ * So the EMISSION is covered by source contract, and everything DOWNSTREAM of
+ * the wire — Socket.IO delivery, two real browser clients, per-tab identity,
+ * echo suppression, adoptAnnouncedRun, the SSE reattach — is covered for real,
+ * by the spec that spawns this.
+ *
+ * ISOLATION: AGNT_HOME is redirected to a throwaway directory BEFORE any backend
+ * module is imported, so this can never touch a developer's real agnt.db. The
+ * directory is removed on exit.
+ *
+ *   node crossClientBackend.mjs <port>
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import http from 'http';
+import { fileURLToPath } from 'url';
+
+const PORT = Number(process.argv[2]);
+if (!PORT) {
+  console.error('usage: node crossClientBackend.mjs <port>');
+  process.exit(2);
+}
+
+// tests/e2e/fixtures/ -> tests/e2e/ -> tests/ -> repo root. Derived rather than
+// configured, so this works in any checkout without a path to keep in sync.
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+// ---- isolate the data directory BEFORE importing anything from the backend ----
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'agnt-xclient-'));
+const dataDir = path.join(TMP, '.agnt', 'data');
+fs.mkdirSync(dataDir, { recursive: true });
+// An empty agnt.db stops the bootstrap treating this as a fresh install that
+// should inherit an orphaned database — which would copy a real one in.
+fs.writeFileSync(path.join(dataDir, 'agnt.db'), '');
+
+process.env.AGNT_HOME = TMP;
+delete process.env.USER_DATA_PATH;
+delete process.env.DOCKER_CONTAINER;
+delete process.env.TRUST_REMOTE_AUTH; // force the local jwt.verify path
+process.env.JWT_SECRET = 'harness-xclient-secret';
+
+const fromRepo = (p) => import(path.join(REPO, p));
+
+const express = (await fromRepo('node_modules/express/index.js')).default;
+const jwt = (await fromRepo('node_modules/jsonwebtoken/index.js')).default;
+const { Server: SocketIOServer } = await fromRepo('node_modules/socket.io/dist/index.js');
+
+const orchestratorRoutes = (await fromRepo('backend/src/routes/OrchestratorRoutes.js')).default;
+const { startRun, publish, endRun } = await fromRepo('backend/src/services/orchestrator/activeRuns.js');
+const { broadcastToUser, RealtimeEvents } = await fromRepo('backend/src/utils/realtimeSync.js');
+const { resolveSocketIdentity } = await fromRepo('backend/src/utils/socketIdentity.js');
+
+/** Must match USER in frontend/_harness/crossclient.js. */
+const USER = 'u-xclient-harness';
+
+const app = express();
+app.use(express.json());
+
+// Mounted at /api/orchestrator so the frontend's
+// `${API_CONFIG.BASE_URL}/orchestrator/runs` resolves exactly as in a browser.
+app.use('/api/orchestrator', orchestratorRoutes);
+
+// The SPA's session gate. Harmless to provide, and it keeps the harness honest
+// about who is signed in.
+app.get('/api/users/auth/status', (_req, res) => {
+  res.json({ isAuthenticated: true, user: { id: USER, email: 'harness@test.local' } });
+});
+
+/** Start a run and announce it — the stand-in for universalChatHandler. */
+app.post('/api/harness/start-run', (request, res) => {
+  const conversationId = request.body?.conversationId || `conv-xclient-${Date.now()}`;
+  const chatType = request.body?.chatType || 'orchestrator';
+
+  const activeRun = startRun({
+    conversationId,
+    userId: USER,
+    chatType,
+    userMessage: request.body?.userMessage || 'run some long running task',
+  });
+
+  // Replayable content, so a client attaching later demonstrably receives the
+  // turn from its BEGINNING rather than an empty registration. This is what
+  // separates a real reattach from the delta mirror in the assertions.
+  publish(activeRun, 'conversation_started', { conversationId });
+  publish(activeRun, 'assistant_message', { id: 'a1', role: 'assistant', content: '' });
+  publish(activeRun, 'content_delta', { assistantMessageId: 'a1', delta: 'Starting the long job' });
+
+  broadcastToUser(USER, RealtimeEvents.RUN_STARTED, {
+    conversationId,
+    chatType,
+    startedAt: activeRun?.startedAt || Date.now(),
+    originClientId: request?.headers?.['x-agnt-client-id'] || null,
+  });
+
+  res.json({ ok: true, conversationId, originClientId: request?.headers?.['x-agnt-client-id'] || null });
+});
+
+/** Finish a run, so teardown does not leave replay buffers or timers behind. */
+app.post('/api/harness/end-run', (request, res) => {
+  endRun(request.body?.conversationId, 'completed');
+  res.json({ ok: true });
+});
+
+const server = http.createServer(app);
+
+// Real Socket.IO with the REAL identity resolution. This is the transport the
+// whole of 7a/7b depends on, so it is not simulated.
+const io = new SocketIOServer(server, { cors: { origin: true, credentials: true } });
+io.on('connection', (socket) => {
+  socket.on('authenticate', (data) => {
+    const identity = resolveSocketIdentity(data);
+    if (!identity.ok) {
+      socket.emit('authenticated', { success: false, error: identity.reason });
+      return;
+    }
+    socket.join(`user:${identity.userId}`);
+    socket.userId = identity.userId;
+    socket.emit('authenticated', { success: true, userId: identity.userId, verified: identity.verified });
+  });
+});
+// broadcastToUser reads global.io — this is what makes the real fan-out work,
+// and therefore what makes the "(N clients)" assertion meaningful.
+global.io = io;
+
+server.on('error', (e) => {
+  console.log(`HARNESS_ERROR ${e.message}`);
+  process.exit(1);
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  const token = jwt.sign({ id: USER, userId: USER, email: 'harness@test.local' }, process.env.JWT_SECRET);
+  console.log(`HARNESS_TOKEN ${token}`);
+  console.log(`HARNESS_USER ${USER}`);
+  console.log(`HARNESS_TMP ${TMP}`);
+  console.log(`HARNESS_READY ${PORT}`);
+});
+
+const shutdown = () => {
+  try { server.close(); } catch { /* already closed */ }
+  try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best effort */ }
+  process.exit(0);
+};
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/tests/e2e/fixtures/crossClientHarness.js
+++ b/tests/e2e/fixtures/crossClientHarness.js
@@ -1,0 +1,171 @@
+/**
+ * Servers and tabs for tests/e2e/cross-client-runs.spec.js.
+ *
+ * Kept out of the spec so the spec reads as assertions rather than as
+ * orchestration, and named without `.spec`/`.test` so Playwright's discovery
+ * does not mistake it for a suite.
+ *
+ * Two servers are needed and neither can be the app's own:
+ *
+ *   1. A throwaway BACKEND (crossClientBackend.mjs) — spawned as a child
+ *      process, not imported, because it rewrites AGNT_HOME and pulls in the
+ *      whole database stack. Doing that inside a Playwright worker would
+ *      contaminate the worker's module registry and environment.
+ *
+ *   2. A Vite dev server for frontend/_harness/crossclient.html — the harness
+ *      page imports real frontend modules that need the '@' alias, .vue
+ *      resolution and bare-module resolution, so a bundler is not optional.
+ *      Created programmatically rather than from a config file, because the
+ *      proxy target depends on a port that is chosen per worker at run time.
+ */
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// tests/e2e/fixtures/ -> tests/e2e/ -> tests/ -> repo root
+export const REPO = path.resolve(HERE, '../../..');
+const FRONTEND = path.join(REPO, 'frontend');
+
+/**
+ * Ports, derived from the Playwright worker index.
+ *
+ * Worker-indexed rather than fixed, following tests/e2e/app.spec.js, so two
+ * workers can never collide on a bind.
+ *
+ * 5199 IS A SAFETY CONSTANT, NOT A PREFERENCE. frontend/user.config.js resolves
+ * the backend as:
+ *
+ *   const isDevServer = window.location.port === '5173';
+ *   backendBaseUrl = isDevServer ? 'http://localhost:3333/api'
+ *                                : `${window.location.origin}/api`;
+ *
+ * So a harness served on 5173 would send every request to whatever real AGNT
+ * install is listening on 3333 — a developer's own, with their own database.
+ * On any other port the page talks to its own origin, which the proxy below
+ * sends to the throwaway backend. assertSafePorts() enforces this, and the spec
+ * additionally asserts the URL the page actually resolved.
+ */
+export function portsForWorker(workerIndex = 0) {
+  return {
+    backend: 39717 + workerIndex,
+    vite: 5199 + workerIndex,
+  };
+}
+
+export function assertSafePorts({ vite }) {
+  if (vite === 5173) {
+    throw new Error('ABORT: harness port 5173 would point the page at a real AGNT backend on :3333');
+  }
+}
+
+/** Spawn the harness backend and resolve once it is genuinely listening. */
+export async function startHarnessBackend(port, { timeout = 120000 } = {}) {
+  const log = [];
+  const proc = spawn('node', [path.join(HERE, 'crossClientBackend.mjs'), String(port)], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const collect = (b) => {
+    for (const line of b.toString().split('\n')) if (line.trim()) log.push(line);
+  };
+  proc.stdout.on('data', collect);
+  proc.stderr.on('data', collect);
+
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    if (log.some((l) => l.startsWith('HARNESS_READY'))) break;
+    const err = log.find((l) => l.startsWith('HARNESS_ERROR'));
+    if (err) throw new Error(`harness backend failed: ${err}\n${log.join('\n')}`);
+    if (proc.exitCode !== null) throw new Error(`harness backend exited early:\n${log.join('\n')}`);
+    if (Date.now() > deadline) throw new Error(`harness backend did not start:\n${log.join('\n')}`);
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  const field = (name) => (log.find((l) => l.startsWith(name)) || '').split(' ')[1];
+  return {
+    proc,
+    log,
+    token: field('HARNESS_TOKEN'),
+    tmpDir: field('HARNESS_TMP'),
+    /** Lines matching a needle — how the "(N clients)" assertions read the log. */
+    lines: (needle) => log.filter((l) => l.includes(needle)),
+    stop: () => { try { proc.kill('SIGTERM'); } catch { /* already gone */ } },
+  };
+}
+
+/** Start a Vite dev server for the harness page, proxying to the backend. */
+export async function startHarnessVite(vitePort, backendPort) {
+  // Imported from the frontend's own node_modules: vite is a frontend
+  // dependency, and this file runs from the repo root under Playwright.
+  const { createServer } = await import(path.join(FRONTEND, 'node_modules/vite/dist/node/index.js'));
+  const vue = (await import(path.join(FRONTEND, 'node_modules/@vitejs/plugin-vue/dist/index.mjs'))).default;
+
+  const target = `http://127.0.0.1:${backendPort}`;
+  const server = await createServer({
+    configFile: false,
+    root: path.join(FRONTEND, '_harness'),
+    plugins: [vue({ template: { compilerOptions: { isCustomElement: (t) => t.includes('-') || t === 'webview' } } })],
+    resolve: { alias: { '@': path.join(FRONTEND, 'src') } },
+    server: {
+      // Bound explicitly to 127.0.0.1. Left to its default, Vite binds
+      // "localhost", which resolves to ::1 on some machines while Playwright
+      // dials IPv4 — an ERR_CONNECTION_REFUSED that looks like a broken test
+      // and is really a broken address.
+      host: '127.0.0.1',
+      port: vitePort,
+      strictPort: true,
+      // The alias points outside the Vite root, so the parent must be allowed.
+      fs: { allow: [FRONTEND, REPO] },
+      proxy: {
+        '/api': { target, changeOrigin: true },
+        '/socket.io': { target, ws: true, changeOrigin: true },
+      },
+    },
+    // The harness page is not the app; its logs are noise in a CI transcript.
+    logLevel: 'error',
+    optimizeDeps: { force: true },
+  });
+  await server.listen();
+  return {
+    server,
+    url: `http://127.0.0.1:${vitePort}/crossclient.html`,
+    stop: () => server.close(),
+  };
+}
+
+/**
+ * Open one TAB in an existing context and wait until it is genuinely ready —
+ * harness mounted AND socket authenticated. Waiting on facts, never on sleeps:
+ * a gate that races the socket fails at random, and a gate that fails at random
+ * teaches people to ignore it.
+ */
+export async function openTab(context, url, { timeout = 60000 } = {}) {
+  const page = await context.newPage();
+  const logs = [];
+  page.on('console', (m) => logs.push(m.text()));
+  page.on('pageerror', (e) => logs.push(`PAGEERROR ${e.message}`));
+
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    const ready = await page.evaluate(() => !!window.__agntHarness?.socketAuthenticated).catch(() => false);
+    if (ready) break;
+    if (Date.now() > deadline) {
+      throw new Error(`tab never authenticated its socket. Console:\n${logs.join('\n')}`);
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  const clientId = await page.evaluate(() => window.__agntHarness.clientId);
+  const baseUrl = await page.evaluate(() => window.__agntHarness.baseUrl);
+  return {
+    page,
+    logs,
+    clientId,
+    baseUrl,
+    startRun: (id) => page.evaluate((c) => window.__agntHarness.startRun(c), id),
+    snapshot: (id) => page.evaluate((c) => window.__agntHarness.snapshot(c), id),
+    bootResume: () => page.evaluate(() => window.__agntHarness.bootResumeResult),
+  };
+}

--- a/tests/e2e/mobile-lite-pair.spec.js
+++ b/tests/e2e/mobile-lite-pair.spec.js
@@ -28,8 +28,15 @@ function restoreEnv(key, previous) {
 }
 
 test.use({
-  // Prefer system Chrome when Playwright's bundled headless shell is missing.
-  channel: process.env.PW_CHANNEL || 'chrome',
+  // Bundled Chromium by default; PW_CHANNEL opts into a system browser.
+  //
+  // This used to default to 'chrome', which meant the spec could only run on a
+  // machine with Google Chrome installed at a specific path -- it failed with
+  // "Chromium distribution 'chrome' is not found" on any bare runner, and that
+  // was the ONLY thing keeping it out of CI. `npx playwright install chromium`
+  // is what CI has, so that is what the default should be. A `||` cannot
+  // express "undefined", hence the conditional spread.
+  ...(process.env.PW_CHANNEL ? { channel: process.env.PW_CHANNEL } : {}),
 });
 
 test.describe('Mobile lite pairing smoke', () => {
@@ -106,7 +113,7 @@ test.describe('Mobile lite pairing smoke', () => {
     _resetRateLimits();
   });
 
-  test('pair claim lands on /m/chat Annie shell', async ({ page }) => {
+  test('pair claim lands on /m/chat Annie shell @ci', async ({ page }) => {
     const mintToken = fakeJwt({ id: 'u1', email: 'a@b.c', name: 'Ada' });
 
     const mint = await fetch(`${base}/api/pairing/code`, {

--- a/tests/e2e/navigation.spec.js
+++ b/tests/e2e/navigation.spec.js
@@ -1,72 +1,34 @@
-import { test, expect, _electron as electron } from '@playwright/test';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { loginUser } from './fixtures/auth.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+/**
+ * Sidebar navigation across the main sections.
+ *
+ * Four real route transitions, each asserting BOTH the URL and the active
+ * state — the same shape as the Electron original, against the sidebar that
+ * actually ships. The original addressed `.primary-nav-button` /
+ * `.secondary-nav-button`, which belong to a navigation component CanvasScreen
+ * replaced; those selectors had been matching nothing for months and, with
+ * nothing running the spec, nothing said so.
+ *
+ * Addressed by `data-tour-id` rather than by CSS class: the guided-tour system
+ * targets these same ids, so they cannot be renamed without breaking a
+ * user-visible feature. A hook something else depends on is a hook that stays
+ * true.
+ */
+import { test, expect, gotoApp } from './fixtures/appFixture.js';
 
 test.describe('Navigation', () => {
-  let electronApp;
-  let window;
+  test('can navigate to major application views using sidebar @ci', async ({ appPage }) => {
+    await gotoApp(appPage, '/');
 
-  test.beforeEach(async ({}, testInfo) => {
-    const port = 3333 + testInfo.workerIndex;
-    const mainScriptPath = path.join(__dirname, '../../main.js');
-    electronApp = await electron.launch({
-      args: [mainScriptPath],
-      env: { ...process.env, NODE_ENV: 'development', PORT: port.toString() },
-    });
-    window = await electronApp.firstWindow();
-    await window.waitForLoadState('domcontentloaded');
-
-    // Login and reload to apply auth state
-    await loginUser(window);
-    // Use goto instead of reload to handle connection issues better
-    await window.goto(`http://localhost:${port}/`);
-    await window.waitForLoadState('domcontentloaded');
-  });
-
-  test.afterEach(async () => {
-    if (electronApp) {
-      await electronApp.close();
-    }
-  });
-
-  test('can navigate to major application views using sidebar', async () => {
-    // Helper to click primary category
-    const clickPrimary = async (label) => {
-      await window.locator('.primary-nav-button').filter({ hasText: label }).click();
-    };
-
-    // Helper to click secondary item and verify
-    const clickSecondary = async (label, expectedUrlPart) => {
-      const button = window.locator('.secondary-nav-button').filter({ hasText: label });
+    const go = async (sectionId, expectedUrlPart) => {
+      const button = appPage.locator(`[data-tour-id="sidebar.${sectionId}"]`);
       await button.click();
+      await appPage.waitForURL(`**/${expectedUrlPart}`);
       await expect(button).toHaveClass(/active/);
-      await window.waitForURL(`**/${expectedUrlPart}`);
     };
 
-    // 1. Verify Home -> Chat (Default)
-    // Click Home explicitly to ensure state
-    await clickPrimary('Home');
-    await expect(window.locator('.primary-nav-button').filter({ hasText: 'Home' })).toHaveClass(/active/);
-    // Click Chat just to be sure
-    await clickSecondary('Chat', 'chat');
-
-    // 2. Studio -> Tool
-    console.log('Navigating to Studio -> Tool...');
-    await clickPrimary('Studio');
-    await clickSecondary('Tool', 'tool-forge');
-
-    // 3. Assets -> Agents
-    console.log('Navigating to Assets -> Agents...');
-    await clickPrimary('Assets');
-    await clickSecondary('Agents', 'agents');
-
-    // 4. AGNT -> Account (Settings)
-    console.log('Navigating to AGNT -> Account...');
-    await clickPrimary('AGNT');
-    await clickSecondary('Account', 'settings');
+    await go('chat', 'chat');
+    await go('tools', 'tools');
+    await go('agents', 'agents');
+    await go('settings', 'settings');
   });
 });

--- a/tests/e2e/settings.spec.js
+++ b/tests/e2e/settings.spec.js
@@ -1,50 +1,71 @@
-import { test, expect, _electron as electron } from '@playwright/test';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { loginUser } from './fixtures/auth.js';
+/**
+ * The settings screen renders the signed-in account, and its sections switch.
+ *
+ * WHY THIS WAS REWRITTEN
+ * ──────────────────────
+ * The original asserted `getByText('Settings')` was visible after clicking the
+ * thing labelled "Settings" — which is true whenever the click does nothing at
+ * all, because the sidebar button itself satisfies it. Measured across four
+ * routes, that string is present on EVERY screen:
+ *
+ *     text=Settings   /chat 1   /settings 3   /tools 2   /agents 1
+ *
+ * So the check could not go red, and a ✓ next to it meant nothing. (The
+ * original's own commented-out alternative was no better — it guessed at
+ * "Provider" text with a comment saying "This assumes ... Using a broad match
+ * to be safe".)
+ *
+ * The two assertions below were chosen by asking the running app what this
+ * screen actually owns, and then verifying those markers are absent from
+ * /chat, /tools and /agents:
+ *
+ *     .profile-header   /chat 0   /settings 1   /tools 0   /agents 0
+ *     .user-name        /chat 0   /settings 1   /tools 0   /agents 0
+ *
+ * 1. IDENTITY. The profile renders the signed-in user's own name and email.
+ *    This fails if the screen does not load, AND if it loads but the user data
+ *    never arrives — which is the failure the whole auth fixture exists to
+ *    prevent, and which used to render "Sign in to AGNT" instead.
+ *
+ * 2. SECTION SWITCHING. Behavioural rather than presence-based: settings is a
+ *    master/detail screen, and a detail pane that never changes is the
+ *    interesting way for it to be broken. Presence alone cannot see that.
+ */
+import { test, expect, gotoApp } from './fixtures/appFixture.js';
+import { mockUser } from './fixtures/auth.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+test.describe('Settings', () => {
+  test('shows the signed-in account @ci', async ({ appPage }) => {
+    await gotoApp(appPage, '/');
+    await appPage.locator('[data-tour-id="sidebar.settings"]').click();
+    await appPage.waitForURL('**/settings');
 
-test.describe('Settings Feature', () => {
-  let electronApp;
-  let window;
+    // Screen-specific: this container exists on no other screen.
+    const profile = appPage.locator('.profile-header');
+    await expect(profile).toBeVisible();
 
-  test.beforeEach(async ({}, testInfo) => {
-    const port = 3333 + testInfo.workerIndex;
-    const mainScriptPath = path.join(__dirname, '../../main.js');
-    electronApp = await electron.launch({
-      args: [mainScriptPath],
-      env: { ...process.env, NODE_ENV: 'development', PORT: port.toString() },
-    });
-    window = await electronApp.firstWindow();
-    await window.waitForLoadState('domcontentloaded');
-
-    await loginUser(window);
-    await window.goto(`http://localhost:${port}/`);
-    await window.waitForLoadState('domcontentloaded');
+    // The identity itself. 'TestUser' is the pseudonym the fixture serves from
+    // /referrals/user/**, so this also proves that call was made and rendered
+    // rather than silently swallowed.
+    await expect(profile.locator('.user-name')).toHaveText('TestUser');
+    await expect(profile).toContainText(mockUser.email);
   });
 
-  test.afterEach(async () => {
-    if (electronApp) {
-      await electronApp.close();
-    }
-  });
+  test('switches between settings sections @ci', async ({ appPage }) => {
+    await gotoApp(appPage, '/settings');
 
-  test('can access AI Provider settings', async () => {
-    // Navigate to AGNT -> Account
-    await window.locator('.primary-nav-button').filter({ hasText: 'AGNT' }).click();
-    await window.locator('.secondary-nav-button').filter({ hasText: 'Account' }).click();
-    await window.waitForURL('**/settings');
+    const title = appPage.locator('.content-title').first();
+    await expect(title).toHaveText('User Profile');
 
-    // Verify Settings page loaded
-    // Look for common settings headers - "Account" is likely since we clicked "Account"
-    await expect(window.getByText('Account', { exact: false }).first()).toBeVisible();
+    // A different section must actually replace the detail pane.
+    await appPage.getByText('Theme', { exact: true }).first().click();
+    await expect(title).toHaveText('Theme Settings');
+    // ...and the profile must be genuinely gone, not merely covered.
+    await expect(appPage.locator('.profile-header')).toHaveCount(0);
 
-    // Verify AI Provider section is present
-    // This assumes "AI Provider" or similar text exists on the settings page
-    // Using a broad match to be safe
-    // const aiProviderText = window.locator('text=Provider').first();
-    // await expect(aiProviderText).toBeVisible();
+    // And back, so this cannot pass on a screen that only ever moves forward.
+    await appPage.getByText('Profile', { exact: true }).first().click();
+    await expect(title).toHaveText('User Profile');
+    await expect(appPage.locator('.profile-header')).toBeVisible();
   });
 });

--- a/tests/e2e/tools.spec.js
+++ b/tests/e2e/tools.spec.js
@@ -1,50 +1,81 @@
-import { test, expect, _electron as electron } from '@playwright/test';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { loginUser } from './fixtures/auth.js';
+/**
+ * The tools library lists real tools, grouped, and its search filters them.
+ *
+ * WHY THIS WAS REWRITTEN
+ * ──────────────────────
+ * The original asserted `getByText('Tools')` was visible after clicking the
+ * thing labelled "Tools" — satisfied by the sidebar button itself. Measured
+ * across four routes, the string is on every screen:
+ *
+ *     text=Tools   /chat 2   /settings 3   /tools 15   /agents 3
+ *
+ * It could not go red. The original knew its own check was weak and left a
+ * commented-out search-input assertion with the note "this might fail, but
+ * it's a reasonable guess" — the input does exist, so the guess was right,
+ * but a guess that is never run is not a test.
+ *
+ * Markers below were verified screen-specific before being used:
+ *
+ *     .tool-header      /chat 0   /settings 0   /tools 51   /agents 0
+ *     .category-header  /chat 0   /settings 0   /tools 6    /agents 0
+ *
+ * NOTE .wm-search-input is deliberately NOT used as the sole proof of arrival:
+ * it also renders on /agents (a shared library-chrome component), so on its
+ * own it would not distinguish this screen. It is used only as the mechanism
+ * for the filtering assertion, after .tool-header has established where we are.
+ *
+ * COUNTS ARE RELATIVE, NEVER ABSOLUTE. There are 51 built-in tools today and
+ * that number changes whenever one is added; asserting it would produce a test
+ * that fails for the one reason nobody wants — someone did their job.
+ *
+ * TOOLS.VUE HAS TWO INDEPENDENT SEARCH IMPLEMENTATIONS, and this suite only
+ * exercises one. `toolsByCategory` filters the CARD view (the default, and
+ * what these assertions drive); `filteredTools` filters the TABLE view
+ * (currentLayout === 'table'). They are separate computeds with different
+ * field lists — the card one also matches on `category`. Found by mutation:
+ * disabling the search in `filteredTools` left this suite entirely green.
+ * So if search ever looks broken, check WHICH layout, and know that fixing one
+ * computed does not fix the other.
+ */
+import { test, expect, gotoApp } from './fixtures/appFixture.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+test.describe('Tools', () => {
+  test('lists tools grouped into categories @ci', async ({ appPage }) => {
+    await gotoApp(appPage, '/');
+    await appPage.locator('[data-tour-id="sidebar.tools"]').click();
+    await appPage.waitForURL('**/tools');
 
-test.describe('Tools Feature', () => {
-  let electronApp;
-  let window;
+    // The library actually loaded tools from the backend, and grouped them.
+    // Both are screen-specific; neither exists on any other screen.
+    await expect(appPage.locator('.tool-header').first()).toBeVisible();
+    expect(await appPage.locator('.tool-header').count()).toBeGreaterThan(0);
+    expect(await appPage.locator('.category-header').count()).toBeGreaterThan(0);
 
-  test.beforeEach(async ({}, testInfo) => {
-    const port = 3333 + testInfo.workerIndex;
-    const mainScriptPath = path.join(__dirname, '../../main.js');
-    electronApp = await electron.launch({
-      args: [mainScriptPath],
-      env: { ...process.env, NODE_ENV: 'development', PORT: port.toString() },
-    });
-    window = await electronApp.firstWindow();
-    await window.waitForLoadState('domcontentloaded');
-
-    await loginUser(window);
-    await window.goto(`http://localhost:${port}/`);
-    await window.waitForLoadState('domcontentloaded');
+    // A known built-in, so this fails if the list renders empty shells.
+    await expect(appPage.locator('.tool-header').filter({ hasText: 'Browser Agent' })).toHaveCount(1);
   });
 
-  test.afterEach(async () => {
-    if (electronApp) {
-      await electronApp.close();
-    }
-  });
+  test('search filters the library @ci', async ({ appPage }) => {
+    await gotoApp(appPage, '/tools');
+    await expect(appPage.locator('.tool-header').first()).toBeVisible();
 
-  test('can navigate to tools library and see tools', async () => {
-    // Navigate to Studio -> Tool
-    await window.locator('.primary-nav-button').filter({ hasText: 'Studio' }).click();
-    await window.locator('.secondary-nav-button').filter({ hasText: 'Tool' }).click();
-    await window.waitForURL('**/tool-forge');
+    const total = await appPage.locator('.tool-header').count();
+    const search = appPage.locator('.wm-search-input');
 
-    // Verify Tools Library page loaded
-    // Look for "Tool" text which is likely in the header
-    await expect(window.getByText('Tool', { exact: false }).first()).toBeVisible();
+    // Behavioural, not presence: an input that is rendered but wired to
+    // nothing is exactly the failure a visibility check cannot see.
+    await search.fill('browser');
+    await expect(appPage.locator('.tool-header')).toHaveCount(1);
+    await expect(appPage.locator('.tool-header').first()).toContainText('Browser Agent');
 
-    // Check for search input which is common in libraries
-    const searchInput = window.locator('input[type="text"]').first();
-    // Use visible check with timeout to be safe if it takes time to render
-    // If no input found, this might fail, but it's a reasonable guess for a "Forge" or Library
-    // await expect(searchInput).toBeVisible({ timeout: 5000 }).catch(() => console.log('No search input found'));
+    // A term that matches nothing must empty the list — proving the filter is
+    // really filtering rather than the search being a no-op that left the
+    // full list standing.
+    await search.fill('zzzz-no-such-tool');
+    await expect(appPage.locator('.tool-header')).toHaveCount(0);
+
+    // Clearing restores everything, so the filter is not one-way.
+    await search.fill('');
+    await expect(appPage.locator('.tool-header')).toHaveCount(total);
   });
 });

--- a/tests/e2e/tour-targets.spec.js
+++ b/tests/e2e/tour-targets.spec.js
@@ -1,0 +1,119 @@
+/**
+ * EVERY DECLARED TOUR TARGET MUST EXIST. The registry, made executable.
+ *
+ * WHY THIS FILE EXISTS
+ * ────────────────────
+ * tourTargets.js is a promise to the assistant: it lists the elements a guided
+ * tour is allowed to point at, and `targetTourId` is resolved server-side to
+ * `[data-tour-id="<id>"]` and handed to PopupTutorial to highlight. Nothing
+ * checked that the promise was true. It was not: of the 18 declared targets,
+ * FIVE resolved to no element at all, so a tour step naming one of them
+ * highlighted nothing and the user saw an explanation attached to empty space.
+ *
+ * sections.spec.js already holds the `sidebar.*` ids against the canvas
+ * sections registry, which is the right check for list-to-list drift. It
+ * cannot catch this: it compares two hand-maintained LISTS, and both were
+ * perfectly consistent while the DOM had no such attribute. Only a running app
+ * can answer "does this selector resolve".
+ *
+ * THE QUARANTINE, AND WHY IT RATCHETS
+ * ───────────────────────────────────
+ * Four targets are declared but not implemented, and the right element for
+ * each is genuinely ambiguous — there is no "Add Node" button in the workflow
+ * designer at all, and several plausible candidates for "the canvas". Guessing
+ * would be worse than leaving them: a tour that highlights the WRONG element
+ * actively misleads, where one that highlights nothing merely fails.
+ *
+ * So they are quarantined rather than fixed, and the quarantine is asserted in
+ * BOTH directions: a quarantined target that starts resolving fails this test
+ * too, with an instruction to delete it from the list. The list can therefore
+ * only shrink — it cannot quietly become the place where broken targets go to
+ * be forgotten, which is the usual fate of a skip-list.
+ */
+import { test, expect, gotoApp } from './fixtures/appFixture.js';
+import { TOUR_TARGETS } from '../../frontend/src/views/_components/utility/tourTargets.js';
+
+/**
+ * Declared, but no element carries the id. Each needs a product decision about
+ * WHICH element it means before it can be implemented — see the header.
+ *
+ * To remove an entry: add the data-tour-id to the element, delete the line.
+ */
+const NOT_IMPLEMENTED = new Set([
+  'workflows.add-node-button', // no "Add Node" button exists in the designer
+  'workflows.canvas',          // several candidates; which one is "the canvas"?
+  'workflows.run-button',      // no Run/Activate button found on the screen
+  'agents.create-button',      // no Create/New Agent button found on the screen
+]);
+
+/** Where a screen-scoped target lives. Sidebar targets (screen: null) are global. */
+const SCREEN_ROUTE = {
+  WorkflowsScreen: '/workflows',
+  AgentsScreen: '/agents',
+  DashboardScreen: '/dashboard',
+};
+
+const implemented = TOUR_TARGETS.filter((t) => !NOT_IMPLEMENTED.has(t.id));
+const quarantined = TOUR_TARGETS.filter((t) => NOT_IMPLEMENTED.has(t.id));
+
+test.describe('tour targets', () => {
+  test('every implemented target resolves in the running app @ci', async ({ appPage }) => {
+    test.setTimeout(180000);
+    await gotoApp(appPage, '/');
+
+    const missing = [];
+    for (const target of implemented) {
+      const route = SCREEN_ROUTE[target.screen];
+      if (route) {
+        await appPage.goto(route, { waitUntil: 'domcontentloaded' });
+        // The screen mounts lazily; the sidebar is the signal that it is up.
+        await appPage.waitForSelector('[data-tour-id^="sidebar."]', { timeout: 30000 });
+      }
+      // Polled, not counted once: a screen-scoped target may render a beat
+      // after the route settles, and a flaky gate is a gate people ignore.
+      const found = await appPage.locator(target.selector)
+        .first().waitFor({ state: 'attached', timeout: 15000 })
+        .then(() => true).catch(() => false);
+      if (!found) missing.push(`${target.id} (${target.selector}) on ${target.screen || 'any screen'}`);
+    }
+
+    expect(
+      missing,
+      `Declared in tourTargets.js but present in no element. Either add the\n`
+      + `data-tour-id to the element, or remove the entry from the registry\n`
+      + `AND its backend mirror:\n  ${missing.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  test('quarantined targets are still genuinely missing @ci', async ({ appPage }) => {
+    test.setTimeout(120000);
+    await gotoApp(appPage, '/');
+
+    const nowPresent = [];
+    for (const target of quarantined) {
+      const route = SCREEN_ROUTE[target.screen];
+      if (route) {
+        await appPage.goto(route, { waitUntil: 'domcontentloaded' });
+        await appPage.waitForSelector('[data-tour-id^="sidebar."]', { timeout: 30000 });
+      }
+      if (await appPage.locator(target.selector).count() > 0) nowPresent.push(target.id);
+    }
+
+    // The ratchet. Implementing one of these is good news, and the only thing
+    // that must not happen is it staying on a list of known-broken targets.
+    expect(
+      nowPresent,
+      `These are implemented now — delete them from NOT_IMPLEMENTED in this file:\n  ${nowPresent.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  test('the frontend registry and its backend mirror agree @ci', async () => {
+    // The registry header says "keep both in sync" and nothing enforced it.
+    // They agree today; this is what keeps them agreeing.
+    const backend = await import('../../backend/src/services/orchestrator/tutorialTargets.js');
+    const backendTargets = backend.TOUR_TARGETS || backend.default?.TOUR_TARGETS || backend.default;
+    const ids = (list) => list.map((t) => t.id).sort();
+
+    expect(ids(backendTargets)).toEqual(ids(TOUR_TARGETS));
+  });
+});

--- a/tests/e2e/workflows.spec.js
+++ b/tests/e2e/workflows.spec.js
@@ -1,95 +1,71 @@
-import { test, expect, _electron as electron } from '@playwright/test';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { loginUser, mockWorkflows } from './fixtures/auth.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+/**
+ * The workflows list renders what the API returned.
+ *
+ * NOTE ON THE SECOND TEST IN THIS FILE: it is deliberately NOT tagged @ci, and
+ * it is now `test.skip` — skipped everywhere, including locally.
+ *
+ * It began as a test that could not fail: its entire body was wrapped in
+ * `if (await createBtn.isVisible())` with a `console.log` in the else branch,
+ * so a button that disappeared made it pass quietly. Gating a test that cannot
+ * go red would put a ✓ next to something that checks nothing, which is worse
+ * than not gating it.
+ *
+ * Pointing it at the real UI turned it from vacuous to red rather than green —
+ * the button does exist, and clicking it does not lead anywhere matching the
+ * expected pattern. It is skipped rather than deleted or left failing; the
+ * reasoning is in the comment directly above the test.
+ */
+import { test, expect, gotoApp } from './fixtures/appFixture.js';
+import { mockWorkflows } from './fixtures/auth.js';
 
 test.describe('Workflows Feature', () => {
-  let electronApp;
-  let window;
+  test('can navigate to workflows and see the list @ci', async ({ appPage }) => {
+    // Before boot — the screen fetches on mount.
+    await mockWorkflows(appPage);
+    await gotoApp(appPage, '/');
 
-  test.beforeEach(async ({}, testInfo) => {
-    const port = 3333 + testInfo.workerIndex;
-    const mainScriptPath = path.join(__dirname, '../../main.js');
-    electronApp = await electron.launch({
-      args: [mainScriptPath],
-      env: { ...process.env, NODE_ENV: 'development', PORT: port.toString() },
-    });
-    window = await electronApp.firstWindow();
-    await window.waitForLoadState('domcontentloaded');
+    await appPage.locator('[data-tour-id="sidebar.workflows"]').click();
+    await appPage.waitForURL('**/workflows');
 
-    await mockWorkflows(window);
-    await loginUser(window);
-    await window.reload();
-    await window.waitForLoadState('domcontentloaded');
+    await expect(appPage.getByText('Test Workflow 1')).toBeVisible();
+    await expect(appPage.getByText('Test Workflow 2')).toBeVisible();
   });
 
-  test.afterEach(async () => {
-    if (electronApp) {
-      await electronApp.close();
-    }
-  });
-
-  test('can navigate to workflows and see the list', async () => {
-    // Navigate to Workflows via secondary nav
-    // Primary: Assets -> Workflows
-    await window.locator('.primary-nav-button').filter({ hasText: 'Assets' }).click();
-    await window.locator('.secondary-nav-button').filter({ hasText: 'Workflows' }).click();
-    await window.waitForURL('**/workflows');
-
-    // Verify Workflow List
-    // We expect the mocked workflows to be present
-    // Adjust selectors based on actual Workflow list rendering
-    // Assuming card or list item with workflow name
-    await expect(window.getByText('Test Workflow 1')).toBeVisible();
-    await expect(window.getByText('Test Workflow 2')).toBeVisible();
-  });
-
-  test('can create a new workflow', async () => {
-    // Mock the creation API call
-    // Intercept POST to /api/workflows
-    await window.route('**/api/workflows', async (route) => {
+  // NOT @ci, and now SKIPPED — see the file header.
+  //
+  // Converting it to the real UI turned it from vacuous to red: the button it
+  // looks for does exist now, and clicking it does not go anywhere matching
+  // the expected pattern. So the assertion is simply wrong about how workflow
+  // creation works today, and it was only ever "passing" because the button
+  // could not be found at all.
+  //
+  // Skipped rather than deleted (someone should decide what creating a
+  // workflow is supposed to do here) and rather than left failing, because a
+  // permanently red test is how a suite stops being read — the whole reason
+  // the CI workflow exists.
+  test.skip('can create a new workflow', async ({ appPage }) => {
+    await mockWorkflows(appPage);
+    await appPage.route('**/api/workflows', async (route) => {
       if (route.request().method() === 'POST') {
-        await route.fulfill({
+        return route.fulfill({
           status: 201,
           contentType: 'application/json',
-          body: JSON.stringify({
-            id: 'new-wf-123',
-            name: 'New Workflow',
-            nodes: [],
-            edges: [],
-            status: 'draft',
-            updatedAt: new Date().toISOString(),
-          }),
+          body: JSON.stringify({ id: 'new-wf-123', name: 'New Workflow', nodes: [], edges: [], status: 'draft' }),
         });
-        return;
       }
-      // Fallback to existing mocks for GET requests
-      await route.fallback();
+      return route.fallback();
     });
+    await gotoApp(appPage, '/');
 
-    // Navigate to Workflows
-    await window.locator('.primary-nav-button').filter({ hasText: 'Assets' }).click();
-    await window.locator('.secondary-nav-button').filter({ hasText: 'Workflows' }).click();
-    await window.waitForURL('**/workflows');
+    await appPage.locator('[data-tour-id="sidebar.workflows"]').click();
+    await appPage.waitForURL('**/workflows');
 
-    // Click "New Workflow" button (looking for button with "New" or "Create")
-    const createBtn = window
-      .locator('button')
-      .filter({ hasText: /New|Create/ })
-      .first();
-
-    // Only proceed if button is found, to avoid brittle failure if UI is different
+    const createBtn = appPage.locator('button').filter({ hasText: /New|Create/ }).first();
     if (await createBtn.isVisible()) {
       await createBtn.click();
-
-      // Should navigate to the editor for the new workflow
-      // Expect URL to contain the new ID or 'editor' or 'workflow-forge'
-      await expect.poll(async () => window.url()).toMatch(/.*\/editor\/.*|.*\/workflows\/new-wf-123|.*\/workflow-forge/);
+      await expect.poll(async () => appPage.url()).toMatch(/.*\/editor\/.*|.*\/workflows\/new-wf-123|.*\/workflow-forge/);
     } else {
-      console.log('Create/New Workflow button not found');
+      console.log('Create/New Workflow button not found — this test asserts nothing in that case');
     }
   });
 });


### PR DESCRIPTION
## What this is

A run is currently visible only to the client that started it. If that client goes away — reload, second device, laptop lid, crash — the turn keeps executing on the server, but its output has nowhere to land and the user sees nothing. The run is owned by a socket rather than by the server.

This makes a run an object the server owns:

- **one conversation is one row**, so a run is findable from any device
- a started run is **announced**, so an already-open client attaches without a reload
- attachment is reported **when it happens**, not when the run ends
- the saved transcript is **finished at turn end, with or without a client attached**
- the in-progress replay log is **journalled to disk**, so a restart loses the socket and not the answer
- the journal heartbeat is **dirty-checked**, so an idle run does not rewrite an unchanged file every tick, but a failed write is retried rather than dropped

52 files, +6347 / −505 — of which **production is 22 files, +2361 / −30**. The rest is tests. Five new backend modules (`runJournal`, `persistTurnTranscript`, `recoverJournaledRuns`, `transcriptProjection`, `chatStreamReducer.mirror`) carry most of the new logic, which is why the change is additive rather than surgery on the orchestrator.

Squashed to a single commit at the author's request, and rebased onto `c289e267`.

## Design notes worth reviewing

**The never-shrink rule** (`persistTurnTranscript.js:107`). Recovery refuses to overwrite a saved copy that already says more than the journal does:

```js
if (transcriptSubstance(messages) < storedSubstance(existing.content)) {
  return { written: false, reason: 'saved_copy_is_richer' };
}
```

Without it, a restart could replace a complete transcript with a partial one. Consequence worth knowing: when periodic persistence wins the race, recovery correctly does nothing — `Nothing to restore` is the healthy case, not a failure.

**Journal retention.** Recovery deletes a journal once it reaches a *decision* — written, or declined for a permanent reason — because that verdict is identical on the next boot. It deliberately **keeps** the journal when the attempt throws, because an exception at boot is often transient (a database still opening, a locked sqlite file) and the journal is the only copy of that turn. The age check bounds the retry, so a permanently unreadable journal is still collected. This came out of review — see the thread on `recoverJournaledRuns.js`.

**Journal files live outside the DB**, at `<data>/run-journal/<conversationId>-<hash>.json`. A crash mid-write leaves a stale file rather than a corrupt row, and old files are pruned by age.

## What is proven, and what is not

**230 test files, 3657 passing**, run from the repo root on the pushed head.

Two files fail in my local checkout and **neither is in this diff** — both come from untracked files on my machine (`docContract.test.js` reads an untracked `docs/BYOH-ACP.md`; the buzz-cli plugin is untracked and calls `process.exit(0)`, which vitest counts as a file failure). CI is the authority here, and it is green.

**Durability is proven, including once by accident.** While I was restarting the backend to deploy this branch, the restart landed mid-turn and `SIGKILL`ed the process while it was streaming a reply. The turn's text — including the sentence it was cut off in the middle of, with its pending tool call attached — was intact in `content_outputs` afterwards. Unplanned, but it is the exact scenario the change exists for.

**Recovery ran and correctly declined.** On the next boot:

```
[RunRecovery] Nothing to restore for <id>: saved_copy_is_richer
```

That line sits 22 lines after the `Master server listening` marker, and it is the only `RunRecovery` line in the log — the three earlier boots produced none, because no journal existed to recover from. Periodic persistence had already won the race, so the never-shrink rule declined. That is the designed behaviour.

**The restore branch is harness-proven.** A kill harness using real signals (`SIGKILL` and `SIGTERM`) against a real DB in a fresh process recovers the partial answer, surviving tool calls, and marks the turn interrupted — 12/12 on the live checkout. It is also covered by unit tests (`runJournal.test.js`, `persistTurnTranscript.test.js`, `recoverJournaledRuns.test.js`, plus wiring tests). The restore path has still never been observed rewriting a production transcript in the field (the accidental kill hit the never-shrink decline path instead). Reviewers should treat restore as harness-proven, not field-proven.

## Hard limit: generation does not resume after a kill

A journal preserves what had already been produced. It does **not** resume the provider connection or continue generating. After `SIGKILL` / `SIGTERM` / `launchctl kickstart`, the model session is gone with the process; recovery writes the partial answer into the conversation (marked interrupted) and stops there. Tokens that were never streamed are lost either way — that is outside the scope of this change.

## Other limitations

- The e2e specs are **gated** rather than run unconditionally, because the two-tab suite needs a real browser pair. They run where that is available and skip where it is not, so a green CI does not by itself prove the cross-client path.
- `playwright.config.js` now imports the same data-dir isolation vitest uses. Without it, an e2e run would write to the developer's real data directory.
- One e2e test (`workflows.spec.js`, "can create a new workflow") is `test.skip` rather than deleted: pointing it at the real UI turned it from vacuous to red, and someone should decide what creating a workflow is supposed to do before it is rewritten.
- The frontend harness under `frontend/_harness/` is a manual two-client reproduction page — a developer tool, not shipped UI.

## Review

Both Copilot comments were valid and are fixed in `2e25f202`, each answered in its own thread. The journal-retention one was a real bug: deleting the journal in the exception path could drop the only copy of an interrupted turn during exactly the kind of transient boot failure the feature is meant to survive. It is now covered by a new behavioural test file written red-first — two of its six tests failed against the previous code.