### PR TITLE
docs: switch the star history chart to star-history.dera.page

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,8 +393,8 @@ PORT=3333 npm run dev
 ## ⭐ Star history
 
 <p align="center">
-  <a href="https://star-history.com/#agnt-gg/agnt&Date">
-    <img src="https://api.star-history.com/svg?repos=agnt-gg/agnt&type=Date" alt="Star History Chart" width="100%">
+  <a href="https://star-history.dera.page/#agnt-gg/agnt&Date">
+    <img src="https://star-history.dera.page/svg?repos=agnt-gg/agnt&type=Date" alt="Star History Chart" width="100%">
   </a>
 </p>
 


### PR DESCRIPTION
The current star history chart is broken because GitHub stargazer API restrictions broke the upstream provider. This switches the chart image and its wrapping link to star-history.dera.page, an alternative that requires no API token. The wrapping link becomes a hash-based URL and the image uses the /svg endpoint directly, with no api subdomain.