### PR TITLE
fix(models): a save must not erase the columns it does not name

### DIFF
--- a/backend/src/models/AgentModel.js
+++ b/backend/src/models/AgentModel.js
@@ -38,18 +38,74 @@ class AgentModel {
       // Only 'open' and 'restricted' are valid; anything else falls back to
       // the safe default so a malformed payload can't widen tool access.
       const accessMode = toolAccessMode === 'open' ? 'open' : 'restricted';
+      /**
+       * UPSERT, not INSERT OR REPLACE.
+       *
+       * `INSERT OR REPLACE` resolves a conflict by DELETING the existing row and
+       * inserting a new one, so every column the statement does not name reverts
+       * to its schema DEFAULT. This statement names the columns a caller supplies;
+       * the five it does not are the row's provenance, which no payload carries:
+       * created_at, deleted_at, insight_version, source_plugin, is_user_modified.
+       * Editing an agent silently reset its creation date, orphaned it from the
+       * plugin that installed it, zeroed the evolution counter, and undeleted it.
+       *
+       * Two features were disabled outright by that, each defeated by the save
+       * that was supposed to precede them:
+       *   - AgentService's `UPDATE ... SET is_user_modified = 1 WHERE id = ? AND
+       *     source_plugin IS NOT NULL` matched nothing, because source_plugin had
+       *     just been nulled.
+       *   - AgentApplicator's `insight_version = COALESCE(insight_version,0) + 1`
+       *     always produced 1, because the save had just zeroed it.
+       *
+       * Naming the missing five would fix today and rot tomorrow: `agents` has
+       * gained columns by migration repeatedly, and each new one silently joins
+       * the forgotten set. ON CONFLICT DO UPDATE touches ONLY the columns listed
+       * below, so an unnamed column is preserved by construction.
+       *
+       * created_by is deliberately absent from the SET list: an edit must not
+       * transfer ownership. AgentService already forks to a new id when the editor
+       * is not the owner, and importAgent always mints a fresh UUID, so no caller
+       * needs it to change on update.
+       *
+       * Guarded by AgentModel.provenance.test.js, whose last test enumerates the
+       * live schema and fails when a new column is neither written nor preserved.
+       */
       db.run(
-        `INSERT OR REPLACE INTO agents (id, name, description, status, icon, category, tools, workflows, provider, model, created_by, last_active, success_rate, system_prompt, skills, tool_access_mode, fallback_providers, fallback_enabled, routing_mode, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+        `INSERT INTO agents (id, name, description, status, icon, category, tools, workflows, provider, model, created_by, last_active, success_rate, system_prompt, skills, tool_access_mode, fallback_providers, fallback_enabled, routing_mode, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+         ON CONFLICT(id) DO UPDATE SET
+             name = excluded.name,
+             description = excluded.description,
+             status = excluded.status,
+             icon = excluded.icon,
+             category = excluded.category,
+             tools = excluded.tools,
+             workflows = excluded.workflows,
+             provider = excluded.provider,
+             model = excluded.model,
+             last_active = excluded.last_active,
+             success_rate = excluded.success_rate,
+             system_prompt = excluded.system_prompt,
+             skills = excluded.skills,
+             tool_access_mode = excluded.tool_access_mode,
+             fallback_providers = excluded.fallback_providers,
+             fallback_enabled = excluded.fallback_enabled,
+             routing_mode = excluded.routing_mode,
+             updated_at = CURRENT_TIMESTAMP`,
         [id, name, description, status, icon, category, toolsJson, workflowsJson, provider, model, userId, lastActive, successRate, systemPrompt, skillsJson, accessMode, fallbackProvidersJson, fallbackEnabledInt, routingModeValue],
         function (err) {
           if (err) {
             reject(err);
           } else {
-            // Update agent_resources with proper defaults
+            // Same reasoning as above: reset_period and last_reset live on this
+            // row and are not part of the payload, so the write must not clear
+            // them just because it has nothing to say about them.
             db.run(
-              `INSERT OR REPLACE INTO agent_resources (agent_id, credit_limit, credits_used)
-                   VALUES (?, ?, ?)`,
+              `INSERT INTO agent_resources (agent_id, credit_limit, credits_used)
+                   VALUES (?, ?, ?)
+               ON CONFLICT(agent_id) DO UPDATE SET
+                   credit_limit = excluded.credit_limit,
+                   credits_used = excluded.credits_used`,
               [id, creditLimit, creditsUsed],
               (err) => {
                 if (err) reject(err);

--- a/backend/src/models/AgentModel.provenance.test.js
+++ b/backend/src/models/AgentModel.provenance.test.js
@@ -1,0 +1,342 @@
+/**
+ * Saving an agent must not forget what the row already knew.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * AgentModel.createOrUpdate wrote the row with `INSERT OR REPLACE`. In SQLite
+ * that is not an update — it DELETES the conflicting row and INSERTs a new one,
+ * so every column the statement does not name silently reverts to its schema
+ * DEFAULT. The statement named 20 of the 25 columns on `agents`. The five it
+ * missed were exactly the ones nothing in the payload carries, because they are
+ * not user input — they are the row's provenance:
+ *
+ *   created_at       -> reset to now. An agent made in 2026-07 reported today.
+ *   source_plugin    -> NULL. A plugin-installed agent forgot who installed it.
+ *   is_user_modified -> 0. The PRD-057 "user has touched this" flag.
+ *   insight_version  -> 0. The evolution counter AgentApplicator increments.
+ *   deleted_at       -> NULL. A soft-deleted agent came back from the dead.
+ *
+ * Two of those did more than lose data, they disabled a feature outright:
+ *
+ *   1. AgentService flips the PRD-057 flag right after saving, with
+ *      `UPDATE agents SET is_user_modified = 1 WHERE id = ? AND source_plugin
+ *      IS NOT NULL`. The save had just nulled source_plugin, so the WHERE could
+ *      never match and the flag could never be set. The statement meant to
+ *      record the edit was defeated by the edit.
+ *   2. AgentApplicator._applySkillRecommendation saves the agent and then does
+ *      `insight_version = COALESCE(insight_version, 0) + 1`. Zeroed first,
+ *      incremented second — so the counter was pinned at 1 forever. Observed on
+ *      a live install: every agent row read insight_version = 0.
+ *
+ * THE FIX is not "name the other five columns". That is the same trap with a
+ * longer fuse: `agents` has gained columns by migration five times, and each
+ * one silently joins the forgotten set. The statement is now an UPSERT
+ * (INSERT ... ON CONFLICT(id) DO UPDATE SET ...), which touches ONLY the
+ * columns it names. Unnamed columns are left alone by construction, so a future
+ * migration cannot re-open this hole.
+ *
+ * The last test in this file is a ratchet: it enumerates the live schema and
+ * fails when a new column is neither written nor consciously preserved.
+ *
+ * Runs against a throwaway AGNT_HOME — never touches the user's database.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fsp from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+let db;
+let AgentModel;
+let TMP;
+const savedEnv = {};
+
+const USER = 'user-prov-1';
+
+const getRow = (id) => new Promise((resolve, reject) => {
+  db.get('SELECT * FROM agents WHERE id = ?', [id], (err, row) => (err ? reject(err) : resolve(row)));
+});
+
+const getResources = (id) => new Promise((resolve, reject) => {
+  db.get('SELECT * FROM agent_resources WHERE agent_id = ?', [id], (err, row) => (err ? reject(err) : resolve(row)));
+});
+
+const run = (sql, params = []) => new Promise((resolve, reject) => {
+  db.run(sql, params, function (err) { return err ? reject(err) : resolve(this.changes); });
+});
+
+const columnsOf = (table) => new Promise((resolve, reject) => {
+  db.all(`PRAGMA table_info(${table})`, [], (err, rows) => (err ? reject(err) : resolve(rows.map((r) => r.name))));
+});
+
+const agentPayload = (over = {}) => ({
+  name: 'Annie',
+  description: 'personal assistant',
+  status: 'active',
+  icon: null,
+  category: 'Personal',
+  assignedTools: ['buzz_whoami'],
+  assignedWorkflows: [],
+  provider: 'Claude-Code',
+  model: 'claude-opus-5',
+  systemPrompt: 'Be helpful.',
+  assignedSkills: [],
+  toolAccessMode: 'restricted',
+  fallbackProviders: [],
+  fallbackEnabled: false,
+  routingMode: null,
+  creditLimit: 1000,
+  creditsUsed: 0,
+  ...over,
+});
+
+/** Create a row, then stamp the provenance a real install would carry. */
+const seedAgent = async (id, provenance = {}) => {
+  await AgentModel.createOrUpdate(id, agentPayload(), USER);
+  const {
+    created_at = '2026-07-26 14:18:07',
+    source_plugin = null,
+    is_user_modified = 0,
+    insight_version = 0,
+    deleted_at = null,
+  } = provenance;
+  await run(
+    `UPDATE agents SET created_at = ?, source_plugin = ?, is_user_modified = ?, insight_version = ?, deleted_at = ?
+     WHERE id = ?`,
+    [created_at, source_plugin, is_user_modified, insight_version, deleted_at, id]
+  );
+};
+
+beforeAll(async () => {
+  TMP = await fsp.mkdtemp(path.join(os.tmpdir(), 'agnt-prov-'));
+  for (const k of ['AGNT_HOME', 'USER_DATA_PATH', 'DOCKER_CONTAINER']) savedEnv[k] = process.env[k];
+  delete process.env.USER_DATA_PATH;
+  delete process.env.DOCKER_CONTAINER;
+  process.env.AGNT_HOME = TMP;
+
+  // Pre-create an empty agnt.db: the bootstrap treats "AGNT_HOME set but no
+  // agnt.db" as a fresh install that should inherit an orphaned database, and
+  // would try to copy the developer's real database into temp.
+  const dataDir = path.join(TMP, '.agnt', 'data');
+  await fsp.mkdir(dataDir, { recursive: true });
+  await fsp.writeFile(path.join(dataDir, 'agnt.db'), '');
+
+  const dbMod = await import('./database/index.js');
+  db = dbMod.default;
+  await dbMod.dbReady;
+
+  AgentModel = (await import('./AgentModel.js')).default;
+
+  await run('INSERT INTO users (id, email) VALUES (?, ?)', [USER, `${USER}@test.local`]);
+}, 120000);
+
+afterAll(async () => {
+  await new Promise((r) => db.close(r));
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  await fsp.rm(TMP, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('an edit preserves the row provenance', () => {
+  it('keeps created_at — editing an agent is not creating one', async () => {
+    const id = 'prov-created-at';
+    await seedAgent(id, { created_at: '2026-07-26 14:18:07' });
+
+    await AgentModel.createOrUpdate(id, agentPayload({ model: 'claude-sonnet-5' }), USER);
+
+    expect((await getRow(id)).created_at).toBe('2026-07-26 14:18:07');
+  });
+
+  it('keeps source_plugin — an edit does not orphan a plugin-installed agent', async () => {
+    const id = 'prov-source-plugin';
+    await seedAgent(id, { source_plugin: 'buzz-cli-plugin' });
+
+    await AgentModel.createOrUpdate(id, agentPayload({ name: 'renamed' }), USER);
+
+    expect((await getRow(id)).source_plugin).toBe('buzz-cli-plugin');
+  });
+
+  it('lets the PRD-057 flag actually be set after a save', async () => {
+    // The exact statement AgentService runs after createOrUpdate. It is guarded
+    // by source_plugin, which the old save had just erased — so this UPDATE
+    // matched zero rows and the flag stayed 0 forever.
+    const id = 'prov-prd057';
+    await seedAgent(id, { source_plugin: 'buzz-cli-plugin', is_user_modified: 0 });
+
+    await AgentModel.createOrUpdate(id, agentPayload({ name: 'user renamed me' }), USER);
+    const changes = await run(
+      'UPDATE agents SET is_user_modified = 1 WHERE id = ? AND source_plugin IS NOT NULL',
+      [id]
+    );
+
+    expect(changes).toBe(1);
+    expect((await getRow(id)).is_user_modified).toBe(1);
+  });
+
+  it('keeps is_user_modified once it is set', async () => {
+    const id = 'prov-user-modified';
+    await seedAgent(id, { source_plugin: 'buzz-cli-plugin', is_user_modified: 1 });
+
+    await AgentModel.createOrUpdate(id, agentPayload({ description: 'edited again' }), USER);
+
+    expect((await getRow(id)).is_user_modified).toBe(1);
+  });
+
+  it('keeps insight_version — the evolution counter is not reset by a save', async () => {
+    const id = 'prov-insight';
+    await seedAgent(id, { insight_version: 7 });
+
+    // What AgentApplicator._applySkillRecommendation does: save, then increment.
+    await AgentModel.createOrUpdate(id, agentPayload({ assignedSkills: ['s1'] }), USER);
+    await run('UPDATE agents SET insight_version = COALESCE(insight_version, 0) + 1 WHERE id = ?', [id]);
+
+    expect((await getRow(id)).insight_version).toBe(8);
+  });
+
+  it('does not resurrect a soft-deleted agent', async () => {
+    const id = 'prov-deleted';
+    await seedAgent(id, { deleted_at: '2026-08-01 09:00:00' });
+
+    await AgentModel.createOrUpdate(id, agentPayload(), USER);
+
+    expect((await getRow(id)).deleted_at).toBe('2026-08-01 09:00:00');
+  });
+});
+
+describe('an edit still edits', () => {
+  it('writes every field the caller supplied', async () => {
+    const id = 'prov-still-writes';
+    await seedAgent(id);
+
+    await AgentModel.createOrUpdate(id, agentPayload({
+      name: 'New Name',
+      description: 'new description',
+      status: 'inactive',
+      category: 'Work',
+      provider: 'GrokAI',
+      model: 'grok-4.5',
+      systemPrompt: 'new prompt',
+      assignedTools: ['x', 'y'],
+      assignedWorkflows: ['wf1'],
+      assignedSkills: ['sk1'],
+      toolAccessMode: 'open',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: 'Cursor', model: 'cursor-grok-4.5-high' }],
+    }), USER);
+
+    const row = await getRow(id);
+    expect(row.name).toBe('New Name');
+    expect(row.description).toBe('new description');
+    expect(row.status).toBe('inactive');
+    expect(row.category).toBe('Work');
+    expect(row.provider).toBe('GrokAI');
+    expect(row.model).toBe('grok-4.5');
+    expect(row.system_prompt).toBe('new prompt');
+    expect(JSON.parse(row.tools)).toEqual(['x', 'y']);
+    expect(JSON.parse(row.workflows)).toEqual(['wf1']);
+    expect(JSON.parse(row.skills)).toEqual(['sk1']);
+    expect(row.tool_access_mode).toBe('open');
+    expect(row.fallback_enabled).toBe(1);
+    expect(JSON.parse(row.fallback_providers)).toEqual([{ provider: 'Cursor', model: 'cursor-grok-4.5-high' }]);
+  });
+
+  it('moves updated_at', async () => {
+    const id = 'prov-updated-at';
+    await seedAgent(id);
+    await run("UPDATE agents SET updated_at = '2020-01-01 00:00:00' WHERE id = ?", [id]);
+
+    await AgentModel.createOrUpdate(id, agentPayload({ name: 'touched' }), USER);
+
+    expect((await getRow(id)).updated_at).not.toBe('2020-01-01 00:00:00');
+  });
+
+  it('still updates the resource row', async () => {
+    const id = 'prov-resources-update';
+    await seedAgent(id);
+
+    await AgentModel.createOrUpdate(id, agentPayload({ creditLimit: 4321, creditsUsed: 99 }), USER);
+
+    const res = await getResources(id);
+    expect(res.credit_limit).toBe(4321);
+    expect(res.credits_used).toBe(99);
+  });
+});
+
+describe('a brand new agent', () => {
+  it('gets a created_at of its own', async () => {
+    const id = 'prov-new';
+    await AgentModel.createOrUpdate(id, agentPayload(), USER);
+
+    const row = await getRow(id);
+    expect(row.created_at).toBeTruthy();
+    // Same statement sets both on insert.
+    expect(row.created_at).toBe(row.updated_at);
+  });
+
+  it('starts with clean provenance', async () => {
+    const id = 'prov-new-clean';
+    await AgentModel.createOrUpdate(id, agentPayload(), USER);
+
+    const row = await getRow(id);
+    expect(row.source_plugin).toBeNull();
+    expect(row.deleted_at).toBeNull();
+    expect(row.is_user_modified).toBe(0);
+    expect(row.insight_version).toBe(0);
+  });
+});
+
+describe('agent_resources has the same shape of bug', () => {
+  it('keeps the columns the save does not carry', async () => {
+    const id = 'prov-resources';
+    await seedAgent(id);
+    await run(
+      "UPDATE agent_resources SET reset_period = 'monthly', last_reset = '2026-08-01 00:00:00' WHERE agent_id = ?",
+      [id]
+    );
+
+    await AgentModel.createOrUpdate(id, agentPayload({ creditsUsed: 5 }), USER);
+
+    const res = await getResources(id);
+    expect(res.credits_used).toBe(5);
+    expect(res.reset_period).toBe('monthly');
+    expect(res.last_reset).toBe('2026-08-01 00:00:00');
+  });
+});
+
+/**
+ * RATCHET — the point of the whole file.
+ *
+ * This bug was not a typo, it was drift: `agents` gained columns by migration
+ * and the write statement was never revisited. Enumerating the live schema
+ * here means the next migration cannot quietly re-open the hole — a new column
+ * must be listed as written or preserved, which forces the author to decide
+ * which it is.
+ */
+describe('every column is accounted for', () => {
+  // Columns the save legitimately writes from the caller's payload.
+  const WRITTEN = new Set([
+    'id', 'name', 'description', 'status', 'icon', 'category', 'tools', 'workflows',
+    'provider', 'model', 'created_by', 'last_active', 'success_rate', 'system_prompt',
+    'skills', 'tool_access_mode', 'fallback_providers', 'fallback_enabled',
+    'routing_mode', 'updated_at',
+  ]);
+
+  // Columns that belong to the row, not the payload. A save must leave them be.
+  const PRESERVED = new Set([
+    'created_at', 'deleted_at', 'insight_version', 'source_plugin', 'is_user_modified',
+  ]);
+
+  it('agents: no column is neither written nor preserved', async () => {
+    const unknown = (await columnsOf('agents')).filter((c) => !WRITTEN.has(c) && !PRESERVED.has(c));
+    expect(unknown, `New column(s) on 'agents' that AgentModel.createOrUpdate neither writes nor preserves: ${unknown.join(', ')}. Add each to WRITTEN (and to the UPSERT's SET list) or to PRESERVED.`).toEqual([]);
+  });
+
+  it('agent_resources: no column is neither written nor preserved', async () => {
+    const WRITTEN_RES = new Set(['agent_id', 'credit_limit', 'credits_used']);
+    const PRESERVED_RES = new Set(['reset_period', 'last_reset']);
+    const unknown = (await columnsOf('agent_resources')).filter((c) => !WRITTEN_RES.has(c) && !PRESERVED_RES.has(c));
+    expect(unknown, `New column(s) on 'agent_resources' unaccounted for: ${unknown.join(', ')}.`).toEqual([]);
+  });
+});

--- a/backend/src/models/CustomToolModel.js
+++ b/backend/src/models/CustomToolModel.js
@@ -4,9 +4,39 @@ class CustomToolModel {
   static createOrUpdate(id, tool, userId) {
     return new Promise((resolve, reject) => {
       const { title, category, type, icon, description, parameters, outputs, isShareable, base, code, config } = tool;
+      /**
+       * UPSERT, not INSERT OR REPLACE. See AgentModel.createOrUpdate for the
+       * full reasoning; this is the mildest of the three instances.
+       *
+       * `INSERT OR REPLACE` DELETEs the conflicting row and inserts a new one,
+       * so every column this statement does not name reverted to its schema
+       * DEFAULT — here that is created_at, reset to now on every edit. `tools`
+       * carries no provenance flags, so nothing was disabled by it, only lost.
+       *
+       * created_by is deliberately absent from the SET list: an edit must not
+       * transfer ownership. ToolService already forks to a new id when the
+       * editor is not the creator, so that transfer was unreachable through the
+       * UI — but a model should not rely on one caller's guard for a property
+       * this basic, and every other caller now inherits the guarantee.
+       *
+       * Guarded by CustomToolModel.provenance.test.js.
+       */
       db.run(
-        `INSERT OR REPLACE INTO tools (id, base, title, category, type, icon, description, config, code, parameters, outputs, created_by, is_shareable, updated_at) 
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+        `INSERT INTO tools (id, base, title, category, type, icon, description, config, code, parameters, outputs, created_by, is_shareable, updated_at) 
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+         ON CONFLICT(id) DO UPDATE SET
+             base = excluded.base,
+             title = excluded.title,
+             category = excluded.category,
+             type = excluded.type,
+             icon = excluded.icon,
+             description = excluded.description,
+             config = excluded.config,
+             code = excluded.code,
+             parameters = excluded.parameters,
+             outputs = excluded.outputs,
+             is_shareable = excluded.is_shareable,
+             updated_at = CURRENT_TIMESTAMP`,
         [
           id,
           base || 'AI',

--- a/backend/src/models/CustomToolModel.provenance.test.js
+++ b/backend/src/models/CustomToolModel.provenance.test.js
@@ -1,0 +1,197 @@
+/**
+ * Saving a custom tool must not forget when it was created, or who owns it.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The third instance of the same defect. `CustomToolModel.createOrUpdate` wrote
+ * the row with `INSERT OR REPLACE`, which in SQLite DELETEs the conflicting row
+ * and INSERTs a new one, so every column the statement does not name reverts to
+ * its schema DEFAULT.
+ *
+ * `tools` carries no provenance flags — no source_plugin, no is_user_modified —
+ * so the blast radius is smaller than `agents` or `skills`: nothing here is
+ * DISABLED by the bug, it only loses data. Two columns were affected:
+ *
+ *   created_at  -> reset to now on every edit
+ *   created_by  -> rewritten from the caller's argument
+ *
+ * created_by mattered less than it looks, because ToolService already forks to a
+ * new id when the editor is not the creator — so the transfer was unreachable
+ * through that route. It is preserved anyway: a model should not depend on one
+ * caller's guard for a property this basic, and every OTHER caller of this
+ * method now inherits the guarantee for free.
+ *
+ * Runs against a throwaway AGNT_HOME — never touches the user's database.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fsp from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+let db;
+let CustomToolModel;
+let TMP;
+const savedEnv = {};
+
+const USER = 'user-tool-1';
+const OTHER_USER = 'user-tool-2';
+
+const getRow = (id) => new Promise((resolve, reject) => {
+  db.get('SELECT * FROM tools WHERE id = ?', [id], (err, row) => (err ? reject(err) : resolve(row)));
+});
+
+const run = (sql, params = []) => new Promise((resolve, reject) => {
+  db.run(sql, params, function (err) { return err ? reject(err) : resolve(this.changes); });
+});
+
+const columnsOf = (table) => new Promise((resolve, reject) => {
+  db.all(`PRAGMA table_info(${table})`, [], (err, rows) => (err ? reject(err) : resolve(rows.map((r) => r.name))));
+});
+
+const toolPayload = (over = {}) => ({
+  title: 'Summarize',
+  category: 'text',
+  type: 'ai',
+  icon: 'fas fa-align-left',
+  description: 'summarize some text',
+  parameters: [{ name: 'text', type: 'string' }],
+  outputs: [{ name: 'summary', type: 'string' }],
+  isShareable: false,
+  base: 'AI',
+  code: null,
+  config: null,
+  ...over,
+});
+
+const seedTool = async (id, { created_at = '2026-07-26 14:18:07' } = {}) => {
+  await CustomToolModel.createOrUpdate(id, toolPayload(), USER);
+  await run('UPDATE tools SET created_at = ? WHERE id = ?', [created_at, id]);
+};
+
+beforeAll(async () => {
+  TMP = await fsp.mkdtemp(path.join(os.tmpdir(), 'agnt-toolprov-'));
+  for (const k of ['AGNT_HOME', 'USER_DATA_PATH', 'DOCKER_CONTAINER']) savedEnv[k] = process.env[k];
+  delete process.env.USER_DATA_PATH;
+  delete process.env.DOCKER_CONTAINER;
+  process.env.AGNT_HOME = TMP;
+
+  // Pre-create an empty agnt.db: the bootstrap treats "AGNT_HOME set but no
+  // agnt.db" as a fresh install that should inherit an orphaned database, and
+  // would try to copy the developer's real database into temp.
+  const dataDir = path.join(TMP, '.agnt', 'data');
+  await fsp.mkdir(dataDir, { recursive: true });
+  await fsp.writeFile(path.join(dataDir, 'agnt.db'), '');
+
+  const dbMod = await import('./database/index.js');
+  db = dbMod.default;
+  await dbMod.dbReady;
+
+  CustomToolModel = (await import('./CustomToolModel.js')).default;
+
+  for (const uid of [USER, OTHER_USER]) {
+    await run('INSERT INTO users (id, email) VALUES (?, ?)', [uid, `${uid}@test.local`]);
+  }
+}, 120000);
+
+afterAll(async () => {
+  await new Promise((r) => db.close(r));
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  await fsp.rm(TMP, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('an edit preserves the row provenance', () => {
+  it('keeps created_at — editing a tool is not creating one', async () => {
+    const id = 'tool-created-at';
+    await seedTool(id, { created_at: '2026-07-26 14:18:07' });
+
+    await CustomToolModel.createOrUpdate(id, toolPayload({ description: 'edited' }), USER);
+
+    expect((await getRow(id)).created_at).toBe('2026-07-26 14:18:07');
+  });
+
+  it('does not transfer ownership when someone else saves the row', async () => {
+    const id = 'tool-ownership';
+    await seedTool(id);
+
+    await CustomToolModel.createOrUpdate(id, toolPayload({ title: 'Edited' }), OTHER_USER);
+
+    expect((await getRow(id)).created_by).toBe(USER);
+  });
+});
+
+describe('an edit still edits', () => {
+  it('writes every field the caller supplied', async () => {
+    const id = 'tool-still-writes';
+    await seedTool(id);
+
+    await CustomToolModel.createOrUpdate(id, toolPayload({
+      title: 'New Title',
+      category: 'data',
+      type: 'code',
+      icon: 'fas fa-code',
+      description: 'new description',
+      parameters: [{ name: 'a' }],
+      outputs: [{ name: 'b' }],
+      isShareable: true,
+      base: 'CODE',
+      code: 'return 1;',
+      config: { k: 'v' },
+    }), USER);
+
+    const row = await getRow(id);
+    expect(row.title).toBe('New Title');
+    expect(row.category).toBe('data');
+    expect(row.type).toBe('code');
+    expect(row.icon).toBe('fas fa-code');
+    expect(row.description).toBe('new description');
+    expect(JSON.parse(row.parameters)).toEqual([{ name: 'a' }]);
+    expect(JSON.parse(row.outputs)).toEqual([{ name: 'b' }]);
+    expect(row.is_shareable).toBe(1);
+    expect(row.base).toBe('CODE');
+    expect(row.code).toBe('return 1;');
+    expect(JSON.parse(row.config)).toEqual({ k: 'v' });
+  });
+
+  it('moves updated_at', async () => {
+    const id = 'tool-updated-at';
+    await seedTool(id);
+    await run("UPDATE tools SET updated_at = '2020-01-01 00:00:00' WHERE id = ?", [id]);
+
+    await CustomToolModel.createOrUpdate(id, toolPayload({ title: 'touched' }), USER);
+
+    expect((await getRow(id)).updated_at).not.toBe('2020-01-01 00:00:00');
+  });
+});
+
+describe('a brand new tool', () => {
+  it('gets a created_at and the caller as owner', async () => {
+    const id = 'tool-new';
+    await CustomToolModel.createOrUpdate(id, toolPayload(), USER);
+
+    const row = await getRow(id);
+    expect(row.created_at).toBeTruthy();
+    expect(row.created_by).toBe(USER);
+  });
+});
+
+/**
+ * RATCHET — see AgentModel.provenance.test.js for the reasoning.
+ */
+describe('every column is accounted for', () => {
+  const WRITTEN = new Set([
+    'id', 'base', 'title', 'category', 'type', 'icon', 'description', 'config',
+    'code', 'parameters', 'outputs', 'is_shareable', 'updated_at',
+  ]);
+  const INSERT_ONLY = new Set(['created_by']);
+  const PRESERVED = new Set(['created_at']);
+
+  it('tools: no column is neither written nor preserved', async () => {
+    const unknown = (await columnsOf('tools'))
+      .filter((c) => !WRITTEN.has(c) && !INSERT_ONLY.has(c) && !PRESERVED.has(c));
+    expect(unknown, `New column(s) on 'tools' that CustomToolModel.createOrUpdate neither writes nor preserves: ${unknown.join(', ')}. Add each to WRITTEN (and to the UPSERT's SET list), INSERT_ONLY, or PRESERVED.`).toEqual([]);
+  });
+});

--- a/backend/src/models/SkillModel.js
+++ b/backend/src/models/SkillModel.js
@@ -105,9 +105,47 @@ class SkillModel {
         skill.allowedTools ?? skill.allowed_tools, '[]', true
       );
 
+      /**
+       * UPSERT, not INSERT OR REPLACE. See AgentModel.createOrUpdate for the
+       * full reasoning; the same defect lived here.
+       *
+       * `INSERT OR REPLACE` DELETEs the conflicting row and inserts a new one,
+       * so every column this statement does not name reverted to its schema
+       * DEFAULT: created_at, source_plugin and is_user_modified.
+       *
+       * That was worse here than a lost timestamp, because of the order
+       * SkillService.updateSkill uses — it sets the PRD-057 flag BEFORE it
+       * saves, so the save erased the flag it had just been told to set. The
+       * flag is what PluginAssetLoader._decideUpdate reads to decide whether a
+       * plugin upgrade may overwrite the row, so a user's edits to a
+       * plugin-installed skill were silently discarded by the next upgrade.
+       *
+       * user_id is deliberately absent from the SET list: an edit must not
+       * transfer ownership. SkillService.updateSkill looks the row up with an
+       * unscoped findById and passes the REQUESTER's id, so rewriting user_id
+       * handed the row to whoever edited it. (The remaining authorization gap —
+       * that a non-owner can edit the contents at all — belongs to
+       * SkillService, not here.)
+       *
+       * Guarded by SkillModel.provenance.test.js, whose last test enumerates the
+       * live schema and fails when a new column is unaccounted for.
+       */
       db.run(
-        `INSERT OR REPLACE INTO skills (id, user_id, name, description, instructions, license, compatibility, metadata, allowed_tools, icon, category, is_builtin, slug, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+        `INSERT INTO skills (id, user_id, name, description, instructions, license, compatibility, metadata, allowed_tools, icon, category, is_builtin, slug, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ON CONFLICT(id) DO UPDATE SET
+             name = excluded.name,
+             description = excluded.description,
+             instructions = excluded.instructions,
+             license = excluded.license,
+             compatibility = excluded.compatibility,
+             metadata = excluded.metadata,
+             allowed_tools = excluded.allowed_tools,
+             icon = excluded.icon,
+             category = excluded.category,
+             is_builtin = excluded.is_builtin,
+             slug = excluded.slug,
+             updated_at = datetime('now')`,
         [id, userId, name, description, instructions, license, compatibility, metadata, allowedTools, icon, category, isBuiltin, slug],
         function (err) {
           if (err) reject(err);

--- a/backend/src/models/SkillModel.provenance.test.js
+++ b/backend/src/models/SkillModel.provenance.test.js
@@ -1,0 +1,279 @@
+/**
+ * Saving a skill must not forget what the row already knew.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Same defect as AgentModel, one table over. `SkillModel.createOrUpdate` wrote
+ * the row with `INSERT OR REPLACE`, which in SQLite DELETEs the conflicting row
+ * and INSERTs a new one, so every column the statement does not name reverts to
+ * its schema DEFAULT. The statement named 14 of the 17 columns on `skills`. The
+ * three it missed are the row's provenance, which no payload carries:
+ *
+ *   created_at       -> reset to now
+ *   source_plugin    -> NULL, orphaning a plugin-installed skill
+ *   is_user_modified -> 0, the PRD-057 "user has touched this" flag
+ *
+ * HERE IT IS WORSE THAN A LOST TIMESTAMP, because of the order SkillService
+ * uses. `updateSkill` sets the flag BEFORE it saves:
+ *
+ *     if (existing.source_plugin) UPDATE skills SET is_user_modified = 1 ...
+ *     ...
+ *     await SkillModel.createOrUpdate(id, merged, userId);   // wipes it back to 0
+ *
+ * So the flag was set and then immediately erased, every single time. That flag
+ * is not decoration: PluginAssetLoader._decideUpdate reads it to decide whether
+ * a plugin upgrade may overwrite the row. With the flag stuck at 0 — and
+ * source_plugin nulled a moment later — a user's edits to a plugin-installed
+ * skill were silently discarded by the next upgrade of that plugin. Losing the
+ * edit is the user-visible bug; losing the flag is why it happened.
+ *
+ * `user_id` was also being rewritten from the caller's argument on every update.
+ * `SkillService.updateSkill` looks the row up with an UNSCOPED findById and then
+ * passes the REQUESTER's id, so editing someone else's skill transferred it to
+ * you. Preserving user_id on update closes the transfer. Note it does NOT close
+ * the underlying authorization gap — a non-owner can still edit the row's
+ * contents — which needs a fix in SkillService and is deliberately out of scope
+ * here rather than half-addressed.
+ *
+ * THE FIX is the same UPSERT as AgentModel: ON CONFLICT DO UPDATE touches only
+ * the columns it names, so unnamed columns are preserved by construction and a
+ * future migration cannot re-open the hole. The last test is a ratchet over the
+ * live schema.
+ *
+ * Runs against a throwaway AGNT_HOME — never touches the user's database.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fsp from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+let db;
+let SkillModel;
+let TMP;
+const savedEnv = {};
+
+const USER = 'user-skill-1';
+const OTHER_USER = 'user-skill-2';
+
+const getRow = (id) => new Promise((resolve, reject) => {
+  db.get('SELECT * FROM skills WHERE id = ?', [id], (err, row) => (err ? reject(err) : resolve(row)));
+});
+
+const run = (sql, params = []) => new Promise((resolve, reject) => {
+  db.run(sql, params, function (err) { return err ? reject(err) : resolve(this.changes); });
+});
+
+const columnsOf = (table) => new Promise((resolve, reject) => {
+  db.all(`PRAGMA table_info(${table})`, [], (err, rows) => (err ? reject(err) : resolve(rows.map((r) => r.name))));
+});
+
+const skillPayload = (over = {}) => ({
+  name: 'pdf-tools',
+  description: 'work with pdfs',
+  instructions: 'Step one.',
+  license: 'MIT',
+  compatibility: '',
+  metadata: {},
+  allowedTools: ['read_file'],
+  icon: 'fas fa-file-pdf',
+  category: 'documents',
+  slug: 'pdf-tools',
+  ...over,
+});
+
+/** Create a row, then stamp the provenance a real install would carry. */
+const seedSkill = async (id, provenance = {}) => {
+  await SkillModel.createOrUpdate(id, skillPayload(), USER);
+  const {
+    created_at = '2026-07-26 14:18:07',
+    source_plugin = null,
+    is_user_modified = 0,
+  } = provenance;
+  await run(
+    'UPDATE skills SET created_at = ?, source_plugin = ?, is_user_modified = ? WHERE id = ?',
+    [created_at, source_plugin, is_user_modified, id]
+  );
+};
+
+beforeAll(async () => {
+  TMP = await fsp.mkdtemp(path.join(os.tmpdir(), 'agnt-skillprov-'));
+  for (const k of ['AGNT_HOME', 'USER_DATA_PATH', 'DOCKER_CONTAINER']) savedEnv[k] = process.env[k];
+  delete process.env.USER_DATA_PATH;
+  delete process.env.DOCKER_CONTAINER;
+  process.env.AGNT_HOME = TMP;
+
+  // Pre-create an empty agnt.db: the bootstrap treats "AGNT_HOME set but no
+  // agnt.db" as a fresh install that should inherit an orphaned database, and
+  // would try to copy the developer's real database into temp.
+  const dataDir = path.join(TMP, '.agnt', 'data');
+  await fsp.mkdir(dataDir, { recursive: true });
+  await fsp.writeFile(path.join(dataDir, 'agnt.db'), '');
+
+  const dbMod = await import('./database/index.js');
+  db = dbMod.default;
+  await dbMod.dbReady;
+
+  SkillModel = (await import('./SkillModel.js')).default;
+
+  for (const uid of [USER, OTHER_USER]) {
+    await run('INSERT INTO users (id, email) VALUES (?, ?)', [uid, `${uid}@test.local`]);
+  }
+}, 120000);
+
+afterAll(async () => {
+  await new Promise((r) => db.close(r));
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  await fsp.rm(TMP, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('an edit preserves the row provenance', () => {
+  it('keeps created_at — editing a skill is not creating one', async () => {
+    const id = 'skill-created-at';
+    await seedSkill(id, { created_at: '2026-07-26 14:18:07' });
+
+    await SkillModel.createOrUpdate(id, skillPayload({ description: 'edited' }), USER);
+
+    expect((await getRow(id)).created_at).toBe('2026-07-26 14:18:07');
+  });
+
+  it('keeps source_plugin — an edit does not orphan a plugin-installed skill', async () => {
+    const id = 'skill-source-plugin';
+    await seedSkill(id, { source_plugin: 'pdf-plugin' });
+
+    await SkillModel.createOrUpdate(id, skillPayload({ name: 'renamed' }), USER);
+
+    expect((await getRow(id)).source_plugin).toBe('pdf-plugin');
+  });
+
+  it('keeps the PRD-057 flag that SkillService sets just before saving', async () => {
+    // The exact order SkillService.updateSkill uses: flag first, save second.
+    // Under INSERT OR REPLACE the save erased the flag it had just been told
+    // to set, so a user edit never registered as a user edit.
+    const id = 'skill-prd057';
+    await seedSkill(id, { source_plugin: 'pdf-plugin', is_user_modified: 0 });
+
+    await run('UPDATE skills SET is_user_modified = 1 WHERE id = ?', [id]);
+    await SkillModel.createOrUpdate(id, skillPayload({ instructions: 'user edited this' }), USER);
+
+    expect((await getRow(id)).is_user_modified).toBe(1);
+  });
+
+  it('leaves an edited plugin skill protected from the next plugin upgrade', async () => {
+    // What PluginAssetLoader._decideUpdate reads to choose skip vs overwrite.
+    // Flag 0 means "untouched, safe to overwrite" — which is how a user's edits
+    // to a plugin-installed skill were silently discarded on upgrade.
+    const id = 'skill-upgrade-guard';
+    await seedSkill(id, { source_plugin: 'pdf-plugin', is_user_modified: 0 });
+
+    await run('UPDATE skills SET is_user_modified = 1 WHERE id = ?', [id]);
+    await SkillModel.createOrUpdate(id, skillPayload({ instructions: 'my careful edits' }), USER);
+
+    const row = await new Promise((resolve, reject) => {
+      db.get('SELECT is_user_modified, source_plugin FROM skills WHERE id = ?', [id], (e, r) => (e ? reject(e) : resolve(r)));
+    });
+    expect(row.source_plugin).toBe('pdf-plugin');
+    expect(row.is_user_modified).toBe(1);
+  });
+
+  it('does not transfer ownership when someone else saves the row', async () => {
+    const id = 'skill-ownership';
+    await seedSkill(id);
+
+    await SkillModel.createOrUpdate(id, skillPayload({ description: 'edited by another user' }), OTHER_USER);
+
+    expect((await getRow(id)).user_id).toBe(USER);
+  });
+});
+
+describe('an edit still edits', () => {
+  it('writes every field the caller supplied', async () => {
+    const id = 'skill-still-writes';
+    await seedSkill(id);
+
+    await SkillModel.createOrUpdate(id, skillPayload({
+      name: 'new-name',
+      description: 'new description',
+      instructions: 'new instructions',
+      license: 'Apache-2.0',
+      compatibility: 'agnt>=1',
+      metadata: { a: 1 },
+      allowedTools: ['x', 'y'],
+      icon: 'fas fa-star',
+      category: 'other',
+      slug: 'new-name',
+      isBuiltin: 1,
+    }), USER);
+
+    const row = await getRow(id);
+    expect(row.name).toBe('new-name');
+    expect(row.description).toBe('new description');
+    expect(row.instructions).toBe('new instructions');
+    expect(row.license).toBe('Apache-2.0');
+    expect(row.compatibility).toBe('agnt>=1');
+    expect(JSON.parse(row.metadata)).toEqual({ a: 1 });
+    expect(JSON.parse(row.allowed_tools)).toEqual(['x', 'y']);
+    expect(row.icon).toBe('fas fa-star');
+    expect(row.category).toBe('other');
+    expect(row.slug).toBe('new-name');
+    expect(row.is_builtin).toBe(1);
+  });
+
+  it('moves updated_at', async () => {
+    const id = 'skill-updated-at';
+    await seedSkill(id);
+    await run("UPDATE skills SET updated_at = '2020-01-01 00:00:00' WHERE id = ?", [id]);
+
+    await SkillModel.createOrUpdate(id, skillPayload({ description: 'touched' }), USER);
+
+    expect((await getRow(id)).updated_at).not.toBe('2020-01-01 00:00:00');
+  });
+});
+
+describe('a brand new skill', () => {
+  it('gets a created_at and the caller as owner', async () => {
+    const id = 'skill-new';
+    await SkillModel.createOrUpdate(id, skillPayload(), USER);
+
+    const row = await getRow(id);
+    expect(row.created_at).toBeTruthy();
+    expect(row.user_id).toBe(USER);
+  });
+
+  it('starts with clean provenance', async () => {
+    const id = 'skill-new-clean';
+    await SkillModel.createOrUpdate(id, skillPayload(), USER);
+
+    const row = await getRow(id);
+    expect(row.source_plugin).toBeNull();
+    expect(row.is_user_modified).toBe(0);
+  });
+});
+
+/**
+ * RATCHET — see AgentModel.provenance.test.js for the reasoning. A new column
+ * on `skills` must be declared as written, insert-only, or preserved, so the
+ * next migration cannot quietly re-open this hole.
+ */
+describe('every column is accounted for', () => {
+  // Written from the caller's payload on both insert and update.
+  const WRITTEN = new Set([
+    'id', 'name', 'description', 'instructions', 'license', 'compatibility',
+    'metadata', 'allowed_tools', 'icon', 'category', 'is_builtin', 'slug', 'updated_at',
+  ]);
+
+  // Set when the row is created and never rewritten by an edit.
+  const INSERT_ONLY = new Set(['user_id']);
+
+  // Belong to the row, not the payload. A save must leave them be.
+  const PRESERVED = new Set(['created_at', 'is_user_modified', 'source_plugin']);
+
+  it('skills: no column is neither written nor preserved', async () => {
+    const unknown = (await columnsOf('skills'))
+      .filter((c) => !WRITTEN.has(c) && !INSERT_ONLY.has(c) && !PRESERVED.has(c));
+    expect(unknown, `New column(s) on 'skills' that SkillModel.createOrUpdate neither writes nor preserves: ${unknown.join(', ')}. Add each to WRITTEN (and to the UPSERT's SET list), INSERT_ONLY, or PRESERVED.`).toEqual([]);
+  });
+});


### PR DESCRIPTION
**One-line summary:** three models saved rows with `INSERT OR REPLACE`, which in SQLite is delete-then-insert — so every column the statement didn't name silently reverted to its schema default.

---

## The bug

`INSERT OR REPLACE` looks like an update. It isn't. On a conflict SQLite **deletes the existing row** and inserts a new one, so any column missing from the statement comes back as its `DEFAULT`.

Each of these statements listed the columns a caller supplies. The columns they omitted were the ones no payload ever carries — not user input, but the row's **provenance**:

| model | table | silently reset on every edit |
|---|---|---|
| `AgentModel` | `agents` | `created_at`, `source_plugin`, `is_user_modified`, `insight_version`, `deleted_at` |
| `SkillModel` | `skills` | `created_at`, `source_plugin`, `is_user_modified` |
| `CustomToolModel` | `tools` | `created_at` |
| `AgentModel` | `agent_resources` | `reset_period`, `last_reset` |

Found by accident: changing one agent's model moved its creation date forward by three weeks.

---

## Why it's more than cosmetic

Losing `created_at` is annoying. The other columns are **read by features**, and wiping them broke three of those features — each one defeated by the save that was supposed to precede or follow it.

**① The PRD-057 flag on agents could never be set.**
`AgentService` marks a plugin-installed agent as user-modified immediately after saving:

```js
await AgentModel.createOrUpdate(agent.id, agent, userId);   // ← nulls source_plugin
UPDATE agents SET is_user_modified = 1 WHERE id = ? AND source_plugin IS NOT NULL
//                                                      ^^^^^^^^^^^^^^^^^^^^^^^^ now matches nothing
```

**② The evolution counter was pinned at 1.**
`AgentApplicator._applySkillRecommendation` saves, then increments:

```js
await AgentModel.createOrUpdate(agent.id, {...});            // ← insight_version = 0
UPDATE agents SET insight_version = COALESCE(insight_version, 0) + 1 WHERE id = ?   // → always 1
```

On a live install, **every** agent row reads `insight_version = 0`.

**③ A plugin upgrade silently destroyed a user's edits to a skill.** ← the serious one

This is data loss, not lost metadata. `SkillService.updateSkill` sets the flag *before* it saves, so the save erases the flag it was just told to set:

```js
if (existing.source_plugin) UPDATE skills SET is_user_modified = 1 ...
await SkillModel.createOrUpdate(id, merged, userId);   // ← wipes it back to 0
```

That flag is exactly what `PluginAssetLoader._decideUpdate` reads to decide skip-vs-overwrite (`skipped.push({ reason: 'is_user_modified' })`). Stuck at `0`, with `source_plugin` nulled a moment later, the next upgrade of that plugin overwrote the user's edited skill without a word.

---

## Ownership (a second, smaller bug)

All three statements also rewrote the **owner** column — `agents.created_by`, `skills.user_id`, `tools.created_by` — from the caller's argument, so a save could transfer the row to whoever saved it.

- **agents / tools:** unreachable in practice — both services fork to a new id when the editor isn't the owner.
- **skills:** *reachable*. `SkillService.updateSkill` looks the row up with an unscoped `findById` and passes the **requester's** id, so editing someone else's skill handed it to you.

All three owner columns are now insert-only.

> ⚠️ This closes the *transfer*, **not** the underlying authorization gap — a non-owner can still edit another user's skill contents. That fix belongs in `SkillService` and is deliberately left out of this PR rather than half-done. See *Not in scope*.

---

## The fix

Adding the missing column names would fix today and rot tomorrow. These tables have gained columns by migration repeatedly, and each new one silently joins the forgotten set — which is how this happened in the first place.

All four statements are now **UPSERTs**:

```sql
INSERT INTO agents (...) VALUES (...)
ON CONFLICT(id) DO UPDATE SET
    name = excluded.name,
    ...
```

`ON CONFLICT ... DO UPDATE` touches **only** the columns it lists. Unnamed columns are preserved *by construction*, so a future migration cannot re-open this hole.

---

## Testing

Three new files — `AgentModel.provenance.test.js`, `SkillModel.provenance.test.js`, `CustomToolModel.provenance.test.js` — **30 tests against real SQLite** in a throwaway `AGNT_HOME` (following the existing `ContentOutputModel.channelScope` pattern). Mocked `db.run` cannot catch this bug; the defect *is* the row-deletion semantics.

**14 of the 30 fail on the old statements**, including `insight_version` returning `1` where `8` was expected — bug ② reproduced exactly.

Coverage worth calling out:
- Two tests replay the services' **exact** PRD-057 statements, in the order the services run them, and assert the flag survives.
- One asserts an edited plugin skill stays protected from the next upgrade — the bug ③ data-loss path.
- Each file ends with a **ratchet**: it enumerates the live schema via `PRAGMA table_info` and fails when a column is neither written, insert-only, nor preserved — naming the column and what to do about it.

**Mutation testing — 8 attempted, 8 killed:**

| # | mutation | result |
|---|---|---|
| 1 | `AgentModel` → `INSERT OR REPLACE` | 6 fail |
| 2 | drop `updated_at` from agents `SET` | 1 fail — *moves updated_at* |
| 3 | migration adds a column to `agents` | ratchet names `last_audited_at` |
| 4 | drop `provider` from agents `SET` | 1 fail — *writes every field the caller supplied* |
| 5 | `SkillModel` → `INSERT OR REPLACE` | 5 fail |
| 6 | restore `user_id` to skills `SET` | 1 fail — *does not transfer ownership* |
| 7 | `CustomToolModel` → `INSERT OR REPLACE` | 2 fail |
| 8 | migrations add columns to `skills` + `tools` | both ratchets fire, naming `review_state` / `last_run_at` |

Full backend suite: **265 files / 4188 tests green**, 20.4s.

---

## Risk

Low, and easy to check:

- **No schema change, no migration, no data backfill** — statement text only.
- **No frontend change** — 6 files, all under `backend/src/models/`.
- **Not a behaviour change for callers.** Every field a caller supplies is still written; the only difference is that columns it *doesn't* supply are now left alone instead of being reset.
- Verified end-to-end on a live install: re-saving an agent now holds `created_at` at its original value, and a row stamped with all five provenance columns survives a save through the running server unchanged.

---

## Not in scope

- **`SkillService.updateSkill`'s missing ownership check** (above) — a real gap, but a service-layer fix, not a model one.
- `EvolutionSettingsModel`, `SkillForgeSettingsModel`, `AuthManager` (`api_keys`, `oauth_tokens`) also use `INSERT OR REPLACE`. Each currently writes *every* column of a narrow table, so none is losing data today — but they carry the same fragility the moment a column is added. Left alone to keep this PR reviewable.
- `WorkflowModel` and `WidgetDefinitionModel` were audited and are **safe**: plain `INSERT` plus targeted `UPDATE`s.
