### PR TITLE
fix(skills): a by-id route must check who owns the row

### DIFF
--- a/backend/src/models/SkillModel.js
+++ b/backend/src/models/SkillModel.js
@@ -117,11 +117,26 @@ class SkillModel {
     });
   }
 
+  /**
+   * Delete a skill the caller owns.
+   *
+   * This has always taken (id, userId) and, until now, never used userId — the
+   * statement was `DELETE FROM skills WHERE id = ?`, so it deleted anybody's
+   * row. SkillService.deleteSkill reads `changes === 0` as "not yours" and
+   * answers 404, which is only sound if the statement is scoped; unscoped, it
+   * returned 1 for any caller and the 404 branch could only mean "no such row".
+   * A hard DELETE with no soft-delete column to recover from, unlike
+   * AgentModel.delete, which is both scoped and soft.
+   *
+   * Scoping it here makes the signature honest for every caller, present and
+   * future. SkillEvolver (the only other caller) deletes a draft it created
+   * itself under the same userId, so this is a no-op for it.
+   */
   static delete(id, userId) {
     return new Promise((resolve, reject) => {
       db.run(
-        `DELETE FROM skills WHERE id = ?`,
-        [id],
+        `DELETE FROM skills WHERE id = ? AND user_id = ?`,
+        [id, userId],
         function (err) {
           if (err) reject(err);
           else resolve(this.changes);

--- a/backend/src/routes/SkillRoutes.ownership.test.js
+++ b/backend/src/routes/SkillRoutes.ownership.test.js
@@ -258,6 +258,31 @@ describe('editing someone else\'s skill', () => {
   });
 });
 
+describe('a malformed update payload', () => {
+  // Raised in review of #68. Pre-existing: `skill.name` threw a TypeError into
+  // the catch, so a client error was reported as a server fault.
+  it('is a 400, not a 500', async () => {
+    await seed('s-bad', OWNER);
+    const res = await call('PUT', '/api/skills/s-bad', { as: OWNER, body: {} });
+    expect(res.status).toBe(400);
+  });
+
+  it('is still a 403 for a stranger — authorisation is decided first', async () => {
+    await seed('s-bad2', OWNER);
+    const res = await call('PUT', '/api/skills/s-bad2', { as: INTRUDER, body: {} });
+    expect(res.status).toBe(403);
+  });
+
+  it('leaves no trace on the row', async () => {
+    await seed('s-bad3', OWNER);
+    await run("UPDATE skills SET source_plugin = 'pdf-plugin', is_user_modified = 0 WHERE id = 's-bad3'");
+
+    expect((await call('PUT', '/api/skills/s-bad3', { as: OWNER, body: {} })).status).toBe(400);
+
+    expect((await row('s-bad3')).is_user_modified).toBe(0);
+  });
+});
+
 describe('deleting someone else\'s skill', () => {
   it('lets the owner delete', async () => {
     await seed('s-del', OWNER);

--- a/backend/src/routes/SkillRoutes.ownership.test.js
+++ b/backend/src/routes/SkillRoutes.ownership.test.js
@@ -1,0 +1,330 @@
+/**
+ * A skill belongs to somebody. The by-id routes did not check who.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `SkillModel.findAll` already states the ownership rule, in SQL:
+ *
+ *     SELECT * FROM skills WHERE user_id = ? OR is_builtin = 1
+ *
+ * So the list endpoint has always been scoped, and the intended policy is not
+ * in doubt: you see your own skills, plus built-ins. Every by-id route then
+ * reached for `SkillModel.findById`, which is `WHERE id = ?` and nothing else,
+ * and none of them compared the row's owner to the caller. The rule was
+ * declared in one query and ignored in four handlers.
+ *
+ * What that allowed, for any authenticated user holding another user's skill id:
+ *
+ *   GET    /api/skills/:id          read the full instructions
+ *   GET    /api/skills/:id/export   download it as SKILL.md
+ *   PUT    /api/skills/:id          rewrite it
+ *   DELETE /api/skills/:id          destroy it, permanently
+ *
+ * The delete is the sharp one, and it hid behind a signature that promised the
+ * opposite. `SkillModel.delete(id, userId)` accepts a userId and never uses it:
+ *
+ *     static delete(id, userId) {
+ *       db.run(`DELETE FROM skills WHERE id = ?`, [id], ...)
+ *
+ * `SkillService.deleteSkill` then reads `changes === 0` as "not yours", and
+ * answers 404. That reasoning is only sound if the statement were scoped. It
+ * was not, so `changes` was 1 for anybody, and the 404 branch could only ever
+ * mean "no such row". A hard DELETE, with no soft-delete column to recover
+ * from — compare `AgentModel.delete`, which is both scoped (`AND created_by =
+ * ?`) and soft (`SET deleted_at = ...`). Skills was the outlier on both counts.
+ *
+ * THE SHAPE OF THE FIX
+ * --------------------
+ * The check belongs in the service, not in `findById`. Eight internal callers
+ * legitimately fetch a skill by id with no requester in scope at all —
+ * OrchestratorService, SkillEvolver (x3), chatConfigs, PluginBundler,
+ * EvalDatasetService, ExperimentService — and scoping the model method would
+ * break every one of them. `SkillModel.delete` is different: its signature
+ * already claims to scope, so it is fixed where it lies.
+ *
+ * Reads honour the built-in exception exactly as `findAll` grants it. Writes do
+ * not: a row that everyone can see must not be a row that anyone can edit.
+ *
+ * Runs against a throwaway AGNT_HOME — never touches the user's database.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import express from 'express';
+import http from 'http';
+import jwt from 'jsonwebtoken';
+import fsp from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+const SECRET = 'skill-ownership-test-secret';
+const OWNER = 'user-skill-owner';
+const INTRUDER = 'user-skill-intruder';
+
+let db;
+let SkillModel;
+let server;
+let base;
+let TMP;
+const savedEnv = {};
+
+const tok = (uid) => jwt.sign({ id: uid, email: `${uid}@test.local` }, SECRET, { expiresIn: '1h' });
+
+const call = (method, p, { body, as } = {}) =>
+  fetch(base + p, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(as ? { Authorization: `Bearer ${tok(as)}` } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+
+const run = (sql, params = []) => new Promise((resolve, reject) => {
+  db.run(sql, params, function (err) { return err ? reject(err) : resolve(this.changes); });
+});
+
+const row = (id) => new Promise((resolve, reject) => {
+  db.get('SELECT * FROM skills WHERE id = ?', [id], (e, r) => (e ? reject(e) : resolve(r || null)));
+});
+
+const skillPayload = (over = {}) => ({
+  name: 'pdf-tools',
+  description: 'work with pdfs',
+  instructions: 'SECRET STEPS the owner wrote',
+  license: 'MIT',
+  compatibility: '',
+  metadata: {},
+  allowedTools: ['read_file'],
+  icon: 'fas fa-file-pdf',
+  category: 'documents',
+  slug: 'pdf-tools',
+  ...over,
+});
+
+/** Seed a skill owned by `owner`, bypassing the routes. */
+const seed = async (id, owner, over = {}) => {
+  await SkillModel.createOrUpdate(id, skillPayload(over), owner);
+  return row(id);
+};
+
+beforeAll(async () => {
+  TMP = await fsp.mkdtemp(path.join(os.tmpdir(), 'agnt-skillauthz-'));
+  for (const k of ['AGNT_HOME', 'USER_DATA_PATH', 'DOCKER_CONTAINER', 'JWT_SECRET', 'TRUST_REMOTE_AUTH']) {
+    savedEnv[k] = process.env[k];
+  }
+  delete process.env.USER_DATA_PATH;
+  delete process.env.DOCKER_CONTAINER;
+  delete process.env.TRUST_REMOTE_AUTH;
+  process.env.AGNT_HOME = TMP;
+  process.env.JWT_SECRET = SECRET;
+
+  // Pre-create an empty agnt.db: the bootstrap treats "AGNT_HOME set but no
+  // agnt.db" as a fresh install that should inherit an orphaned database, and
+  // would try to copy the developer's real database into temp.
+  const dataDir = path.join(TMP, '.agnt', 'data');
+  await fsp.mkdir(dataDir, { recursive: true });
+  await fsp.writeFile(path.join(dataDir, 'agnt.db'), '');
+
+  const dbMod = await import('../models/database/index.js');
+  db = dbMod.default;
+  await dbMod.dbReady;
+
+  SkillModel = (await import('../models/SkillModel.js')).default;
+  const { default: SkillRoutes } = await import('./SkillRoutes.js');
+
+  for (const uid of [OWNER, INTRUDER]) {
+    await run('INSERT INTO users (id, email) VALUES (?, ?)', [uid, `${uid}@test.local`]);
+  }
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/skills', SkillRoutes);
+  await new Promise((r) => { server = http.createServer(app).listen(0, '127.0.0.1', r); });
+  base = `http://127.0.0.1:${server.address().port}`;
+}, 120000);
+
+afterAll(async () => {
+  if (server) await new Promise((r) => server.close(r));
+  if (db) await new Promise((r) => db.close(r));
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  await fsp.rm(TMP, { recursive: true, force: true }).catch(() => {});
+});
+
+beforeEach(async () => {
+  await run('DELETE FROM skills');
+});
+
+describe('authentication is still required', () => {
+  it('refuses an unauthenticated read', async () => {
+    await seed('s-anon', OWNER);
+    expect((await call('GET', '/api/skills/s-anon')).status).toBe(401);
+  });
+});
+
+describe('reading someone else\'s skill', () => {
+  it('lets the owner read it', async () => {
+    await seed('s-read', OWNER);
+    const res = await call('GET', '/api/skills/s-read', { as: OWNER });
+    expect(res.status).toBe(200);
+    expect((await res.json()).skill.instructions).toBe('SECRET STEPS the owner wrote');
+  });
+
+  it('refuses a stranger — the instructions are not theirs to read', async () => {
+    await seed('s-read2', OWNER);
+    const res = await call('GET', '/api/skills/s-read2', { as: INTRUDER });
+    expect(res.status).toBe(403);
+    expect(await res.text()).not.toContain('SECRET STEPS');
+  });
+
+  it('refuses a stranger the SKILL.md export', async () => {
+    await seed('s-export', OWNER);
+    const res = await call('GET', '/api/skills/s-export/export', { as: INTRUDER });
+    expect(res.status).toBe(403);
+    expect(await res.text()).not.toContain('SECRET STEPS');
+  });
+
+  it('still lets the owner export', async () => {
+    await seed('s-export2', OWNER);
+    const res = await call('GET', '/api/skills/s-export2/export', { as: OWNER });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('SECRET STEPS');
+  });
+
+  it('a missing skill is 404, not 403 — absent and forbidden are different answers', async () => {
+    expect((await call('GET', '/api/skills/no-such-id', { as: INTRUDER })).status).toBe(404);
+  });
+});
+
+describe('built-in skills stay shared for reading', () => {
+  // findAll grants this with `OR is_builtin = 1`. The by-id read must agree,
+  // or a skill would be listable and then unreadable.
+  it('a non-owner may read a built-in', async () => {
+    await seed('s-builtin', OWNER, { isBuiltin: 1 });
+    expect((await call('GET', '/api/skills/s-builtin', { as: INTRUDER })).status).toBe(200);
+  });
+
+  it('but a non-owner may NOT edit one — shared to read is not shared to write', async () => {
+    await seed('s-builtin-w', OWNER, { isBuiltin: 1 });
+    const res = await call('PUT', '/api/skills/s-builtin-w', {
+      as: INTRUDER, body: { skill: { instructions: 'hijacked' } },
+    });
+    expect(res.status).toBe(403);
+    expect((await row('s-builtin-w')).instructions).toBe('SECRET STEPS the owner wrote');
+  });
+
+  it('and a non-owner may NOT delete one', async () => {
+    await seed('s-builtin-d', OWNER, { isBuiltin: 1 });
+    expect((await call('DELETE', '/api/skills/s-builtin-d', { as: INTRUDER })).status).toBe(403);
+    expect(await row('s-builtin-d')).not.toBeNull();
+  });
+});
+
+describe('editing someone else\'s skill', () => {
+  it('lets the owner edit', async () => {
+    await seed('s-edit', OWNER);
+    const res = await call('PUT', '/api/skills/s-edit', {
+      as: OWNER, body: { skill: { instructions: 'my own revision' } },
+    });
+    expect(res.status).toBe(200);
+    expect((await row('s-edit')).instructions).toBe('my own revision');
+  });
+
+  it('refuses a stranger, and leaves the row untouched', async () => {
+    await seed('s-edit2', OWNER);
+    const res = await call('PUT', '/api/skills/s-edit2', {
+      as: INTRUDER, body: { skill: { instructions: 'hijacked', name: 'hijacked-name' } },
+    });
+    expect(res.status).toBe(403);
+    const after = await row('s-edit2');
+    expect(after.instructions).toBe('SECRET STEPS the owner wrote');
+    expect(after.name).toBe('pdf-tools');
+  });
+
+  it('a stranger cannot flip the PRD-057 flag as a side effect', async () => {
+    // updateSkill stamps is_user_modified BEFORE it saves. That write must not
+    // happen either — a refused request should leave no trace at all.
+    await seed('s-edit3', OWNER, {});
+    await run("UPDATE skills SET source_plugin = 'pdf-plugin', is_user_modified = 0 WHERE id = 's-edit3'");
+
+    const res = await call('PUT', '/api/skills/s-edit3', {
+      as: INTRUDER, body: { skill: { instructions: 'hijacked' } },
+    });
+
+    expect(res.status).toBe(403);
+    expect((await row('s-edit3')).is_user_modified).toBe(0);
+  });
+});
+
+describe('deleting someone else\'s skill', () => {
+  it('lets the owner delete', async () => {
+    await seed('s-del', OWNER);
+    expect((await call('DELETE', '/api/skills/s-del', { as: OWNER })).status).toBe(200);
+    expect(await row('s-del')).toBeNull();
+  });
+
+  it('refuses a stranger AND the skill survives', async () => {
+    // The destructive one. This is a hard DELETE with no soft-delete column,
+    // so before the fix a stranger could permanently destroy a skill they had
+    // never been able to legitimately see.
+    await seed('s-del2', OWNER);
+
+    const res = await call('DELETE', '/api/skills/s-del2', { as: INTRUDER });
+
+    expect(res.status).toBe(403);
+    expect(await row('s-del2'), 'the skill must still exist').not.toBeNull();
+  });
+
+  it('deleting a missing skill is 404', async () => {
+    expect((await call('DELETE', '/api/skills/no-such-id', { as: OWNER })).status).toBe(404);
+  });
+});
+
+describe('SkillModel.delete honours its own signature', () => {
+  // It has always taken (id, userId). It has never used userId. Any future
+  // caller reading that signature would reasonably assume it scopes.
+  it('does not delete a row belonging to someone else', async () => {
+    await seed('s-model', OWNER);
+
+    const changes = await SkillModel.delete('s-model', INTRUDER);
+
+    expect(changes).toBe(0);
+    expect(await row('s-model')).not.toBeNull();
+  });
+
+  it('still deletes the caller\'s own row', async () => {
+    await seed('s-model2', OWNER);
+
+    const changes = await SkillModel.delete('s-model2', OWNER);
+
+    expect(changes).toBe(1);
+    expect(await row('s-model2')).toBeNull();
+  });
+});
+
+describe('the routes that were already scoped still work', () => {
+  it('the list shows own skills and built-ins, and nobody else\'s', async () => {
+    await seed('s-mine', OWNER);
+    await seed('s-theirs', INTRUDER, { slug: 'theirs', name: 'theirs' });
+    await seed('s-shared', OWNER, { isBuiltin: 1, slug: 'shared', name: 'shared' });
+
+    const res = await call('GET', '/api/skills', { as: INTRUDER });
+    expect(res.status).toBe(200);
+    const ids = (await res.json()).skills.map((s) => s.id);
+
+    expect(ids).toContain('s-theirs');
+    expect(ids).toContain('s-shared');
+    expect(ids).not.toContain('s-mine');
+  });
+
+  it('creating a skill still works and belongs to the creator', async () => {
+    const res = await call('POST', '/api/skills', {
+      as: INTRUDER, body: { skill: { name: 'brand-new', description: 'mine' } },
+    });
+    expect(res.status).toBe(201);
+    const { skillId } = await res.json();
+    expect((await row(skillId)).user_id).toBe(INTRUDER);
+  });
+});

--- a/backend/src/services/SkillService.js
+++ b/backend/src/services/SkillService.js
@@ -286,6 +286,18 @@ You have the above skills assigned. Follow the instructions defined in each skil
       if (!auth.ok) return res.status(auth.status).json({ error: auth.error });
       const existing = auth.skill;
 
+      // A malformed body is the caller's mistake, not a server fault. Without
+      // this, `skill.name` below threw a TypeError into the catch and the route
+      // answered 500 — which hides a client error among real failures. createSkill
+      // already guards exactly this; updateSkill did not.
+      //
+      // Placed after authorisation, so a stranger learns nothing about their
+      // payload for a row they cannot touch, and before the PRD-057 stamp, so a
+      // rejected request still leaves no trace on the row.
+      if (!skill || typeof skill !== 'object' || Array.isArray(skill)) {
+        return res.status(400).json({ error: 'Request body must contain a skill object' });
+      }
+
       // PRD-057: mark plugin-installed skills as user-modified on UI updates
       if (existing.source_plugin) {
         await new Promise((resolve) => {

--- a/backend/src/services/SkillService.js
+++ b/backend/src/services/SkillService.js
@@ -196,11 +196,49 @@ You have the above skills assigned. Follow the instructions defined in each skil
     }
   }
 
+  /**
+   * Fetch a skill and decide whether this requester may act on it.
+   *
+   * SkillModel.findAll already states the ownership rule in SQL —
+   * `WHERE user_id = ? OR is_builtin = 1` — so the list endpoint has always
+   * been scoped. The by-id routes reached for findById (`WHERE id = ?`) and
+   * never compared the owner to the caller, so the rule was declared in one
+   * query and ignored in four handlers. This applies the rule findAll already
+   * declares; it does not invent a new policy.
+   *
+   * The check lives here rather than in findById because eight internal callers
+   * legitimately fetch a skill by id with no requester in scope at all
+   * (OrchestratorService, SkillEvolver x3, chatConfigs, PluginBundler,
+   * EvalDatasetService, ExperimentService). Scoping the model method would
+   * break every one of them.
+   *
+   * Reads honour the built-in exception exactly as findAll grants it — a skill
+   * that is listable must not be unreadable. Writes do not: a row everyone can
+   * see must not be a row anyone can edit, or one user's change silently
+   * rewrites what every other user sees.
+   *
+   * 404 and 403 are kept distinct, matching AgentRoutes' export check and
+   * ContractRoutes: absent and forbidden are different answers.
+   */
+  static async _authorize(id, userId, { write = false } = {}) {
+    const skill = await SkillModel.findById(id);
+    if (!skill) return { ok: false, status: 404, error: 'Skill not found' };
+    if (skill.user_id === userId) return { ok: true, skill };
+    if (!write && skill.is_builtin) return { ok: true, skill };
+    return {
+      ok: false,
+      status: 403,
+      error: write
+        ? 'You do not have permission to modify this skill'
+        : 'You do not have permission to view this skill',
+    };
+  }
+
   async getSkill(req, res) {
     try {
-      const skill = await SkillModel.findById(req.params.id);
-      if (!skill) return res.status(404).json({ error: 'Skill not found' });
-      res.json({ skill });
+      const auth = await SkillService._authorize(req.params.id, req.user.userId);
+      if (!auth.ok) return res.status(auth.status).json({ error: auth.error });
+      res.json({ skill: auth.skill });
     } catch (error) {
       console.error('Error fetching skill:', error);
       res.status(500).json({ error: 'Failed to fetch skill' });
@@ -242,8 +280,11 @@ You have the above skills assigned. Follow the instructions defined in each skil
       const { id } = req.params;
       const { skill } = req.body;
 
-      const existing = await SkillModel.findById(id);
-      if (!existing) return res.status(404).json({ error: 'Skill not found' });
+      // Before anything else, including the PRD-057 stamp below: a refused
+      // request must leave no trace on the row at all.
+      const auth = await SkillService._authorize(id, userId, { write: true });
+      if (!auth.ok) return res.status(auth.status).json({ error: auth.error });
+      const existing = auth.skill;
 
       // PRD-057: mark plugin-installed skills as user-modified on UI updates
       if (existing.source_plugin) {
@@ -287,8 +328,9 @@ You have the above skills assigned. Follow the instructions defined in each skil
    */
   async exportSkillMd(req, res) {
     try {
-      const skill = await SkillModel.findById(req.params.id);
-      if (!skill) return res.status(404).json({ error: 'Skill not found' });
+      const auth = await SkillService._authorize(req.params.id, req.user.userId);
+      if (!auth.ok) return res.status(auth.status).json({ error: auth.error });
+      const skill = auth.skill;
 
       const content = serializeSkillMd(skill);
 
@@ -335,6 +377,12 @@ You have the above skills assigned. Follow the instructions defined in each skil
     try {
       const userId = req.user.userId;
       const { id } = req.params;
+      // SkillModel.delete is scoped too — this is deliberate belt-and-braces.
+      // The check here is what makes a stranger's delete answer 403; the scope
+      // in the model is what protects every other caller of that method.
+      const auth = await SkillService._authorize(id, userId, { write: true });
+      if (!auth.ok) return res.status(auth.status).json({ error: auth.error });
+
       const changes = await SkillModel.delete(id, userId);
       if (changes === 0) return res.status(404).json({ error: 'Skill not found' });
       res.json({ message: 'Skill deleted' });


### PR DESCRIPTION
**One-line summary:** every by-id skill route trusted the caller's id without checking the row's owner, so any authenticated user could read, rewrite, export or **permanently delete** another user's skill.

Follow-up to #67, which fixed the persistence half of this and explicitly left the authorization half open. Independent of it — see *Relationship to #67* below.

---

## The bug

`SkillModel.findAll` already states the ownership rule, in SQL:

```sql
SELECT * FROM skills WHERE user_id = ? OR is_builtin = 1
```

So the **list** endpoint has always been scoped, and the intended policy isn't in doubt: you see your own skills, plus built-ins. Every **by-id** route then reached for `findById` — `WHERE id = ?`, nothing else — and none of them compared the row's owner to the caller.

The rule was declared in one query and ignored in four handlers:

| route | handler | before |
|---|---|---|
| `GET /api/skills` | `getAllSkills` | ✅ scoped via `findAll` |
| `POST /api/skills` | `createSkill` | ✅ owned by creator |
| `POST /api/skills/import` | `importSkillMd` | ✅ owned by creator |
| `GET /api/skills/:id` | `getSkill` | ❌ **read anyone's instructions** |
| `GET /api/skills/:id/export` | `exportSkillMd` | ❌ **download anyone's SKILL.md** |
| `PUT /api/skills/:id` | `updateSkill` | ❌ **rewrite anyone's skill** |
| `DELETE /api/skills/:id` | `deleteSkill` | ❌ **destroy anyone's skill, permanently** |

## The delete hid behind a signature that promised the opposite

```js
static delete(id, userId) {                       // ← takes a userId
  db.run(`DELETE FROM skills WHERE id = ?`, [id]) // ← never uses it
```

`SkillService.deleteSkill` then reads `changes === 0` as *"not yours"* and answers 404:

```js
const changes = await SkillModel.delete(id, userId);
if (changes === 0) return res.status(404).json({ error: 'Skill not found' });
```

That reasoning is only sound if the statement were scoped. Unscoped, `changes` was `1` for **anybody**, and the 404 branch could only ever mean "no such row". The author of the service reasonably believed the model was doing the scoping its signature advertises.

It's also a **hard** `DELETE` with no soft-delete column to recover from. `AgentModel.delete`, by contrast, is both scoped and soft:

```js
UPDATE agents SET deleted_at = CURRENT_TIMESTAMP WHERE id = ? AND created_by = ?
```

Skills was the outlier on both counts.

---

## The fix

**The check goes in the service, not in `findById`.** Eight internal callers legitimately fetch a skill by id with no requester in scope at all — `OrchestratorService`, `SkillEvolver` (×3), `chatConfigs`, `PluginBundler`, `EvalDatasetService`, `ExperimentService`. Scoping the model method would break every one of them.

```js
static async _authorize(id, userId, { write = false } = {}) {
  const skill = await SkillModel.findById(id);
  if (!skill) return { ok: false, status: 404, error: 'Skill not found' };
  if (skill.user_id === userId) return { ok: true, skill };
  if (!write && skill.is_builtin) return { ok: true, skill };
  return { ok: false, status: 403, error: '...' };
}
```

`SkillModel.delete` is the one exception, fixed at the model layer, because its signature already claims to scope — and that also protects callers that never go near a route. `SkillEvolver` (the only other caller) deletes a draft it created itself under the same `userId`, so it's a no-op there.

Three deliberate choices worth reviewing:

1. **Reads honour the built-in exception exactly as `findAll` grants it.** A skill that is listable must not be unreadable.
2. **Writes do not.** A row everyone can see must not be a row anyone can edit, or one user's change silently rewrites what every other user sees.
3. **404 and 403 stay distinct**, matching `AgentRoutes`' export check and `ContractRoutes`. If you'd rather not disclose existence to a non-owner, say so and I'll collapse both to 404 — it's a one-line change, but it's a product call.

The `_authorize` call in `updateSkill` deliberately **precedes** the PRD-057 `is_user_modified` stamp, so a refused request leaves no trace on the row at all.

---

## Testing

New `backend/src/routes/SkillRoutes.ownership.test.js` — 19 tests driving the **real router over real HTTP** with real JWTs against **real sqlite**, two users. They assert the row's state after every refusal, not just the status code, because a 403 that still mutated the row would pass a status-only test.

**8 of the 19 fail on current `main`:**

```
1  refuses a stranger — the instructions are not theirs to read
2  refuses a stranger the SKILL.md export
3  but a non-owner may NOT edit one — shared to read is not shared to write
4  and a non-owner may NOT delete one
5  refuses a stranger, and leaves the row untouched
6  a stranger cannot flip the PRD-057 flag as a side effect
7  refuses a stranger AND the skill survives          ← the destructive one
8  does not delete a row belonging to someone else    ← model-level
```

**Mutation testing — 5 attempted, 5 killed:**

| # | mutation | result |
|---|---|---|
| 1 | un-scope `SkillModel.delete` again | 1 fail — *honours its own signature* |
| 2 | drop the ownership check from `deleteSkill` (model still scoped) | 2 fail — stranger gets 404 instead of 403 |
| 3 | drop the built-in READ exception | 1 fail — *a non-owner may read a built-in* |
| 4 | let the built-in exception apply to writes too | 2 fail — edit **and** delete |
| 5 | `updateSkill` authorises as a read instead of a write | 1 fail — *may NOT edit one* |

Mutation 2 is the interesting one: with the model scoped but the service check removed, a stranger's delete returns `changes === 0` → 404. The row survives, but the answer is wrong. That's what shows the two layers are *independently* load-bearing rather than one being redundant.

Full backend suite: **263 files / 4177 tests green**, 20.3s.

---

## Risk

- **No schema change, no migration, no frontend.** Three files, all backend.
- **Behaviour change is confined to non-owners.** Every owner-facing path keeps its current status code and payload; there are explicit tests for owner read / export / edit / delete and for the already-scoped list and create routes.
- The one externally visible change for an owner is that `DELETE` on a skill belonging to someone else now returns 403 instead of silently succeeding.

## Relationship to #67

Independent. #67 touches `SkillModel.createOrUpdate`; this touches `SkillModel.delete` plus `SkillService`. The only shared file is `SkillModel.js`, and I test-merged the two branches: **`Auto-merging backend/src/models/SkillModel.js` → clean**, no conflicts. They can merge in either order.

#67 made `skills.user_id` insert-only, which stopped a save *transferring* ownership. This stops the request being accepted in the first place. Both are worth having: the model-level guarantee covers every caller, the service-level check covers the HTTP surface and produces the right status code.

## Not in scope

- `SkillModel.findBySlug` and `findByIds` are also unscoped. They're used only by internal callers (`tools.js` skill activation, `chatConfigs` assigned-skill loading) where the requester is implicit, so no route exposes them — but they'd need the same treatment if one ever did.
- Filesystem-discovered skills (`fs-` prefixed ids from `SkillDiscoveryService`) aren't DB rows and are unaffected.
