### PR TITLE
fix(workflow): a save accepted workflows the engine cannot run

### DIFF
--- a/backend/src/services/WorkflowService.js
+++ b/backend/src/services/WorkflowService.js
@@ -6,6 +6,7 @@ import db from '../models/database/index.js';
 import { broadcast, broadcastToUser, RealtimeEvents } from '../utils/realtimeSync.js';
 import PluginManager from '../plugins/PluginManager.js';
 import PluginInstaller from '../plugins/PluginInstaller.js';
+import { validateWorkflowShape } from '../workflow/validateWorkflowShape.js';
 
 /**
  * PRD-057: Flip is_user_modified flag for plugin-installed workflows.
@@ -37,6 +38,18 @@ class WorkflowService {
       if (!workflow || typeof workflow !== 'object' || Array.isArray(workflow)) {
         return res.status(400).json({
           error: 'Request body must be { workflow: { ... } } with a workflow object.',
+        });
+      }
+
+      // Refuse a workflow the engine could never run. Without this the row is
+      // stored happily and the mismatch only surfaces at activation, as a
+      // TypeError inside the workflow process that reaches the caller as an
+      // unqualified 'error' — naming neither the node nor the field.
+      const shape = validateWorkflowShape(workflow);
+      if (!shape.valid) {
+        return res.status(400).json({
+          error: 'Workflow does not match the shape the workflow engine executes.',
+          details: shape.errors,
         });
       }
 

--- a/backend/src/services/WorkflowService.saveWorkflow.test.js
+++ b/backend/src/services/WorkflowService.saveWorkflow.test.js
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * POST /workflows/save must refuse a workflow the engine cannot execute.
+ *
+ * Before this guard the endpoint validated only that the body was an object,
+ * then stringified whatever arrived into the row. The save answered 201, the
+ * workflow appeared in the list, and the mismatch surfaced only at activation —
+ * as a TypeError inside the workflow process that reached the caller as an
+ * unqualified 'error'.
+ *
+ * The assertion that matters in every rejection case is not the status code but
+ * `createOrUpdate` never being called: a refused save must leave no row behind.
+ */
+
+const createOrUpdate = vi.fn(async () => ({}));
+const findOne = vi.fn(async () => null);
+const fetchWorkflowState = vi.fn(async () => ({ status: 'stopped' }));
+const dbRun = vi.fn((sql, params, cb) => cb && cb());
+
+vi.mock('../models/WorkflowModel.js', () => ({
+  default: { findOne, createOrUpdate, update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('../models/WebhookModel.js', () => ({ default: {} }));
+vi.mock('../workflow/WorkflowProcessBridge.js', () => ({
+  default: { fetchWorkflowState, activateWorkflow: vi.fn(), deactivateWorkflow: vi.fn() },
+}));
+vi.mock('../models/database/index.js', () => ({
+  default: { run: dbRun },
+  dbRunWithRetry: vi.fn(async (fn) => fn()),
+}));
+vi.mock('../utils/realtimeSync.js', () => ({
+  broadcast: vi.fn(),
+  broadcastToUser: vi.fn(),
+  RealtimeEvents: { WORKFLOW_CREATED: 'created', WORKFLOW_UPDATED: 'updated' },
+}));
+vi.mock('../plugins/PluginManager.js', () => ({ default: {} }));
+vi.mock('../plugins/PluginInstaller.js', () => ({ default: {} }));
+
+const { default: WorkflowService } = await import('./WorkflowService.js');
+
+/** Minimal express double that records what the handler answered. */
+function makeRes() {
+  const res = {
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res;
+}
+
+const makeReq = (workflow) => ({ body: { workflow }, user: { userId: 'user-1' } });
+
+const validWorkflow = () => ({
+  id: 'wf-1',
+  name: 'valid',
+  nodes: [
+    { id: 'n1', text: 'Timer Trigger', type: 'trigger-timer', category: 'trigger', parameters: {} },
+    { id: 'n2', text: 'Run JS', type: 'execute-javascript', category: 'action', parameters: {} },
+  ],
+  edges: [{ id: 'e1', start: { id: 'n1', type: 'output' }, end: { id: 'n2', type: 'input' } }],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  findOne.mockResolvedValue(null);
+});
+
+describe('saveWorkflow — a workflow the engine can run', () => {
+  it('persists it and answers 201', async () => {
+    const res = makeRes();
+    await WorkflowService.saveWorkflow(makeReq(validWorkflow()), res);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.workflowId).toBe('wf-1');
+    expect(createOrUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('still accepts a blank draft', async () => {
+    const res = makeRes();
+    await WorkflowService.saveWorkflow(makeReq({ id: 'wf-2', name: 'draft', nodes: [], edges: [] }), res);
+
+    expect(res.statusCode).toBe(201);
+    expect(createOrUpdate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('saveWorkflow — a workflow the engine cannot run', () => {
+  it('rejects a node without text and stores nothing', async () => {
+    const wf = validWorkflow();
+    delete wf.nodes[0].text;
+
+    const res = makeRes();
+    await WorkflowService.saveWorkflow(makeReq(wf), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(createOrUpdate).not.toHaveBeenCalled();
+  });
+
+  it('answers with the specific field, not just "invalid"', async () => {
+    const wf = validWorkflow();
+    delete wf.nodes[1].text;
+
+    const res = makeRes();
+    await WorkflowService.saveWorkflow(makeReq(wf), res);
+
+    expect(res.body.error).toMatch(/shape the workflow engine executes/i);
+    expect(Array.isArray(res.body.details)).toBe(true);
+    expect(res.body.details.join(' ')).toContain('node "n2"');
+    expect(res.body.details.join(' ')).toContain('"text"');
+  });
+
+  it('rejects the react-flow shape that agent tooling produces', async () => {
+    const res = makeRes();
+    await WorkflowService.saveWorkflow(
+      makeReq({
+        id: 'wf-3',
+        name: 'react-flow',
+        nodes: [{ id: 'trigger-1', type: 'trigger-timer', data: { label: 'Timer', properties: {} } }],
+        edges: [{ id: 'e1', source: 'trigger-1', target: 'js-1' }],
+      }),
+      res
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(createOrUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an edge pointing at a node that does not exist', async () => {
+    const wf = validWorkflow();
+    wf.edges[0].end = { id: 'ghost', type: 'input' };
+
+    const res = makeRes();
+    await WorkflowService.saveWorkflow(makeReq(wf), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.details.join(' ')).toContain('ghost');
+    expect(createOrUpdate).not.toHaveBeenCalled();
+  });
+
+  it('does not mark an existing row user-modified when the save is refused', async () => {
+    // PRD-057 stamps is_user_modified on update. A refused save must leave the
+    // existing row completely untouched, including that flag.
+    findOne.mockResolvedValue({ id: 'wf-1', source_plugin: 'some-plugin' });
+
+    const wf = validWorkflow();
+    delete wf.nodes[0].text;
+
+    const res = makeRes();
+    await WorkflowService.saveWorkflow(makeReq(wf), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(createOrUpdate).not.toHaveBeenCalled();
+    expect(dbRun).not.toHaveBeenCalled();
+  });
+
+  it('rejects before generating an id, so a bad payload mints nothing', async () => {
+    const res = makeRes();
+    await WorkflowService.saveWorkflow(makeReq({ name: 'no id', nodes: [{ id: 'n1' }], edges: [] }), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(findOne).not.toHaveBeenCalled();
+    expect(createOrUpdate).not.toHaveBeenCalled();
+  });
+
+  it('still rejects a non-object body with the original message', async () => {
+    const res = makeRes();
+    await WorkflowService.saveWorkflow(makeReq(null), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toMatch(/must be \{ workflow/i);
+  });
+});

--- a/backend/src/workflow/WorkflowEngine.js
+++ b/backend/src/workflow/WorkflowEngine.js
@@ -24,8 +24,9 @@ class WorkflowEngine extends EventEmitter {
     // TypeError this used to raise several lines below.
     assertWorkflowShape(workflow, `Workflow ${workflowId}`);
 
-    // Both collections are iterated unconditionally (nodes at :516, edges at
-    // :527). A blank draft is savable, so normalise rather than demand them.
+    // Both collections are iterated unconditionally (nodes in
+    // _initializeNodeNameMapping, edges in _findStartNodes). A blank draft is
+    // savable, so normalise rather than demand them.
     this.workflow = {
       ...workflow,
       nodes: Array.isArray(workflow.nodes) ? workflow.nodes : [],

--- a/backend/src/workflow/WorkflowEngine.js
+++ b/backend/src/workflow/WorkflowEngine.js
@@ -10,13 +10,27 @@ import Counter from '../tools/library/utilities/counter.js';
 import ExecutionModel from '../models/ExecutionModel.js';
 import AuthManager from '../services/auth/AuthManager.js';
 import runWorkflowAction from '../tools/library/controls/run-workflow.js';
+import { assertWorkflowShape } from './validateWorkflowShape.js';
 
 dotenv.config();
 
 class WorkflowEngine extends EventEmitter {
   constructor(workflow, workflowId, userId, isSubWorkflow = false, parentInputData = {}) {
     super();
-    this.workflow = workflow;
+
+    // Rows predating save-time validation are already in every database, and
+    // /workflows/import and direct DB writes never passed through it. Fail here
+    // with a message that names the node and the field, instead of the
+    // TypeError this used to raise several lines below.
+    assertWorkflowShape(workflow, `Workflow ${workflowId}`);
+
+    // Both collections are iterated unconditionally (nodes at :516, edges at
+    // :527). A blank draft is savable, so normalise rather than demand them.
+    this.workflow = {
+      ...workflow,
+      nodes: Array.isArray(workflow.nodes) ? workflow.nodes : [],
+      edges: Array.isArray(workflow.edges) ? workflow.edges : [],
+    };
     this.workflowId = workflowId;
     this.userId = userId;
     this.receivers = {};

--- a/backend/src/workflow/WorkflowEngine.shapeGuard.test.js
+++ b/backend/src/workflow/WorkflowEngine.shapeGuard.test.js
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * The engine must refuse a workflow it cannot read, and say which node is wrong.
+ *
+ * Save-time validation only protects rows written from now on. Rows that
+ * predate it are already in every database, and `/workflows/import` plus direct
+ * DB writes never passed through it — on one developer machine 22 of 22 stored
+ * workflows were unexecutable. So the engine is the backstop, and it has to
+ * fail with a diagnosis rather than:
+ *
+ *     TypeError: Cannot read properties of undefined (reading 'toLowerCase')
+ *         at WorkflowEngine._initializeNodeNameMapping (WorkflowEngine.js:518)
+ *
+ * validateWorkflowShape.js is deliberately NOT mocked — the point is that the
+ * engine really calls it.
+ */
+
+vi.mock('../models/WorkflowModel.js', () => ({ default: { updateStatus: vi.fn() } }));
+vi.mock('../models/database/index.js', () => ({
+  default: { run: vi.fn() },
+  dbRunWithRetry: vi.fn(async (fn) => fn()),
+}));
+vi.mock('../models/ExecutionModel.js', () => ({ default: {} }));
+vi.mock('../tools/ToolConfig.js', () => ({ default: { triggers: {}, actions: {} } }));
+vi.mock('../services/auth/AuthManager.js', () => ({ default: {} }));
+vi.mock('../tools/library/utilities/counter.js', () => ({ default: {} }));
+vi.mock('../tools/library/controls/run-workflow.js', () => ({ default: vi.fn() }));
+vi.mock('./NodeExecutor.js', () => ({ default: class NodeExecutor {} }));
+vi.mock('./EdgeEvaluator.js', () => ({ default: class EdgeEvaluator {} }));
+vi.mock('./ParameterResolver.js', () => ({ default: class ParameterResolver {} }));
+
+const { default: WorkflowEngine } = await import('./WorkflowEngine.js');
+
+const validWorkflow = () => ({
+  id: 'wf-1',
+  nodes: [
+    { id: 'n1', text: 'Timer Trigger', type: 'trigger-timer', category: 'trigger', parameters: {} },
+    { id: 'n2', text: 'Run JS', type: 'execute-javascript', category: 'action', parameters: {} },
+  ],
+  edges: [{ id: 'e1', start: { id: 'n1', type: 'output' }, end: { id: 'n2', type: 'input' } }],
+});
+
+describe('WorkflowEngine constructor — shape guard', () => {
+  it('constructs normally for a workflow the designer produced', () => {
+    const engine = new WorkflowEngine(validWorkflow(), 'wf-1', 'user-1');
+
+    expect(engine.workflow.nodes).toHaveLength(2);
+    // The name→id map is what used to crash; prove it was built.
+    expect(engine.nodeNameToId.get('timertrigger')).toBe('n1');
+    expect(engine.nodeNameToId.get('runjs')).toBe('n2');
+  });
+
+  it('throws a diagnosis, not a TypeError, when a node has no text', () => {
+    const wf = validWorkflow();
+    delete wf.nodes[0].text;
+
+    let thrown;
+    try {
+      new WorkflowEngine(wf, 'wf-42', 'user-1');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    // The regression: a bare TypeError naming neither node nor field.
+    expect(thrown).not.toBeInstanceOf(TypeError);
+    expect(thrown.message).not.toMatch(/toLowerCase/);
+    expect(thrown.message).toContain('Workflow wf-42');
+    expect(thrown.message).toContain('node "n1"');
+    expect(thrown.message).toContain('"text"');
+  });
+
+  it('rejects the react-flow shape stored by earlier API callers', () => {
+    const stored = {
+      nodes: [{ id: 'trigger-1', type: 'trigger-timer', data: { label: 'Timer', properties: {} } }],
+      edges: [{ id: 'e1', source: 'trigger-1', target: 'status-1' }],
+    };
+
+    expect(() => new WorkflowEngine(stored, 'wf-legacy', 'user-1')).toThrow(/"text"/);
+  });
+
+  it('rejects an edge whose endpoint names a node that is not there', () => {
+    const wf = validWorkflow();
+    wf.edges[0].end = { id: 'ghost', type: 'input' };
+
+    expect(() => new WorkflowEngine(wf, 'wf-1', 'user-1')).toThrow(/unknown node id "ghost"/);
+  });
+
+  it('normalises a blank draft instead of crashing on missing collections', () => {
+    // `nodes` is iterated at :516 and `edges` at :527, both unconditionally.
+    const engine = new WorkflowEngine({ id: 'wf-blank', name: 'draft' }, 'wf-blank', 'user-1');
+
+    expect(engine.workflow.nodes).toEqual([]);
+    expect(engine.workflow.edges).toEqual([]);
+    expect(engine.nodeNameToId.size).toBe(0);
+  });
+
+  it('preserves every other workflow field when normalising', () => {
+    const engine = new WorkflowEngine(
+      { id: 'wf-1', name: 'keep me', description: 'and me', ...validWorkflow() },
+      'wf-1',
+      'user-1'
+    );
+
+    expect(engine.workflow.name).toBe('keep me');
+    expect(engine.workflow.description).toBe('and me');
+  });
+
+  it('does not mutate the caller\'s workflow object', () => {
+    const stored = { id: 'wf-blank' };
+    new WorkflowEngine(stored, 'wf-blank', 'user-1');
+
+    // The worker parses this straight out of the DB row; leave it alone.
+    expect(stored.nodes).toBeUndefined();
+    expect(stored.edges).toBeUndefined();
+  });
+});

--- a/backend/src/workflow/WorkflowEngine.shapeGuard.test.js
+++ b/backend/src/workflow/WorkflowEngine.shapeGuard.test.js
@@ -10,7 +10,7 @@ import { describe, expect, it, vi } from 'vitest';
  * fail with a diagnosis rather than:
  *
  *     TypeError: Cannot read properties of undefined (reading 'toLowerCase')
- *         at WorkflowEngine._initializeNodeNameMapping (WorkflowEngine.js:518)
+ *         at WorkflowEngine._initializeNodeNameMapping
  *
  * validateWorkflowShape.js is deliberately NOT mocked — the point is that the
  * engine really calls it.
@@ -88,7 +88,8 @@ describe('WorkflowEngine constructor — shape guard', () => {
   });
 
   it('normalises a blank draft instead of crashing on missing collections', () => {
-    // `nodes` is iterated at :516 and `edges` at :527, both unconditionally.
+    // `nodes` is iterated in _initializeNodeNameMapping and `edges` in
+    // _findStartNodes, both unconditionally.
     const engine = new WorkflowEngine({ id: 'wf-blank', name: 'draft' }, 'wf-blank', 'user-1');
 
     expect(engine.workflow.nodes).toEqual([]);

--- a/backend/src/workflow/validateWorkflowShape.js
+++ b/backend/src/workflow/validateWorkflowShape.js
@@ -27,20 +27,22 @@
  * ---------------------------------------------------------------------------
  * Every rule below corresponds to a property the engine DEREFERENCES. Nothing
  * here encodes taste. If the engine stops reading a field, the rule for it
- * should go too.
+ * should go too. Sites are named by method rather than line number, which
+ * drifts on the first edit above them:
  *
- *   node.text    WorkflowEngine.js:518  node.text.toLowerCase()   — display
- *                name, lowercased into the {{Node Name.output}} lookup table
- *   node.id      WorkflowEngine.js:197  new Map(nodes.map(n => [n.id, n]))
- *   node.type    WorkflowEngine.js:114  import(`../tools/library/triggers/
- *                                       ${node.type}.js`)
- *   edge.start.id WorkflowEngine.js:201,204  edgeMap keyed by start.id
- *   edge.end.id   WorkflowEngine.js:405,408,527  execution queue + start-node
- *                                       detection
+ *   node.text     WorkflowEngine#_initializeNodeNameMapping —
+ *                 node.text.toLowerCase(), the display name lowercased into
+ *                 the {{Node Name.output}} lookup table
+ *   node.id       WorkflowEngine#executeWorkflow — new Map(nodes.map(n => [n.id, n]))
+ *   node.type     WorkflowEngine#setupTriggers —
+ *                 import(`../tools/library/triggers/${node.type}.js`)
+ *   edge.start.id WorkflowEngine#executeWorkflow — edgeMap keyed by start.id
+ *   edge.end.id   WorkflowEngine#executeWorkflow (execution queue) and
+ *                 #_findStartNodes (nodes with no incoming edge)
  *
  * Absent `nodes` / `edges` are treated as empty rather than rejected: a blank
- * draft is a legitimate thing to save, and WorkflowImportService.js:39-40
- * already coerces both the same way. Contents, not presence, are what break.
+ * draft is a legitimate thing to save, and WorkflowImportService already
+ * coerces both the same way. Contents, not presence, are what break.
  *
  * @module validateWorkflowShape
  */
@@ -59,7 +61,8 @@ function describe(value) {
   if (value === null) return 'null';
   if (Array.isArray(value)) return 'an array';
   if (typeof value === 'string') return value.trim() === '' ? 'an empty string' : `"${value}"`;
-  return `a ${typeof value}`;
+  const type = typeof value;
+  return `${/^[aeiou]/.test(type) ? 'an' : 'a'} ${type}`;
 }
 
 /** Label a node in an error message: prefer its id, fall back to position. */
@@ -162,9 +165,11 @@ export function validateWorkflowShape(workflow) {
         continue;
       }
 
-      // Only meaningful once we know every declared id — an edge pointing at a
-      // node that was never declared silently drops that branch of execution.
-      if (nodeList.length && !declaredIds.has(endpoint.id)) {
+      // An edge pointing at a node that was never declared silently drops that
+      // branch of execution. Checked even when `nodes` is empty: edges without
+      // any nodes at all is not a blank draft, it is a broken workflow — a
+      // blank draft has no edges either.
+      if (!declaredIds.has(endpoint.id)) {
         errors.push(`${label} "${end}" references unknown node id "${endpoint.id}".`);
       }
     }

--- a/backend/src/workflow/validateWorkflowShape.js
+++ b/backend/src/workflow/validateWorkflowShape.js
@@ -1,0 +1,190 @@
+/**
+ * The workflow shape WorkflowEngine actually reads.
+ *
+ * ---------------------------------------------------------------------------
+ * THE BUG THIS GUARDS
+ * ---------------------------------------------------------------------------
+ * The engine reads exactly one node/edge shape. It is produced by the workflow
+ * designer (WorkflowDesigner.vue `createNode` / `createEdge`) and by nothing
+ * else. Every other producer — the marketplace installer, `/workflows/import`,
+ * agent tooling that POSTs to `/workflows/save` — invents its own.
+ *
+ * Nothing checked. `saveWorkflow` validated only that the body was an object,
+ * then `JSON.stringify`'d it into the row. The mismatch surfaced later, once,
+ * at activation:
+ *
+ *     TypeError: Cannot read properties of undefined (reading 'toLowerCase')
+ *         at WorkflowEngine._initializeNodeNameMapping (WorkflowEngine.js:518)
+ *
+ * and reached the caller as `{ status: 'error' }` — WorkflowProcessBridge
+ * returns that for ANY caught IPC exception, so the message naming the real
+ * cause never left the workflow process. A save reported success, the workflow
+ * sat in the list looking fine, and activation failed with a string that named
+ * neither the node nor the field.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THESE RULES AND NOT MORE
+ * ---------------------------------------------------------------------------
+ * Every rule below corresponds to a property the engine DEREFERENCES. Nothing
+ * here encodes taste. If the engine stops reading a field, the rule for it
+ * should go too.
+ *
+ *   node.text    WorkflowEngine.js:518  node.text.toLowerCase()   — display
+ *                name, lowercased into the {{Node Name.output}} lookup table
+ *   node.id      WorkflowEngine.js:197  new Map(nodes.map(n => [n.id, n]))
+ *   node.type    WorkflowEngine.js:114  import(`../tools/library/triggers/
+ *                                       ${node.type}.js`)
+ *   edge.start.id WorkflowEngine.js:201,204  edgeMap keyed by start.id
+ *   edge.end.id   WorkflowEngine.js:405,408,527  execution queue + start-node
+ *                                       detection
+ *
+ * Absent `nodes` / `edges` are treated as empty rather than rejected: a blank
+ * draft is a legitimate thing to save, and WorkflowImportService.js:39-40
+ * already coerces both the same way. Contents, not presence, are what break.
+ *
+ * @module validateWorkflowShape
+ */
+
+/** Field is usable as an identifier or a display name. */
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+/**
+ * Describe what a caller sent, without dumping their payload back at them.
+ * Keeps error messages useful when the value is an object or an array.
+ */
+function describe(value) {
+  if (value === undefined) return 'missing';
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'an array';
+  if (typeof value === 'string') return value.trim() === '' ? 'an empty string' : `"${value}"`;
+  return `a ${typeof value}`;
+}
+
+/** Label a node in an error message: prefer its id, fall back to position. */
+function nodeLabel(node, index) {
+  return isNonEmptyString(node?.id) ? `node "${node.id}"` : `node at index ${index}`;
+}
+
+/**
+ * Check a workflow against the shape WorkflowEngine can execute.
+ *
+ * Pure: reads `workflow`, mutates nothing, touches no I/O.
+ *
+ * @param {unknown} workflow - the object about to be persisted or executed
+ * @returns {{ valid: boolean, errors: string[] }} `errors` is empty iff valid.
+ *   Every entry names the offending node/edge and the field that is wrong, so
+ *   the message can be handed to the caller verbatim.
+ */
+export function validateWorkflowShape(workflow) {
+  const errors = [];
+
+  if (!workflow || typeof workflow !== 'object' || Array.isArray(workflow)) {
+    return { valid: false, errors: ['Workflow must be an object.'] };
+  }
+
+  const { nodes, edges } = workflow;
+
+  // Absent is a blank draft. Present-but-not-an-array is a caller bug: the
+  // engine calls .forEach/.map on both unconditionally.
+  if (nodes !== undefined && nodes !== null && !Array.isArray(nodes)) {
+    errors.push(`Workflow "nodes" must be an array, got ${describe(nodes)}.`);
+  }
+  if (edges !== undefined && edges !== null && !Array.isArray(edges)) {
+    errors.push(`Workflow "edges" must be an array, got ${describe(edges)}.`);
+  }
+  if (errors.length) return { valid: false, errors };
+
+  const nodeList = Array.isArray(nodes) ? nodes : [];
+  const edgeList = Array.isArray(edges) ? edges : [];
+
+  const declaredIds = new Set();
+  const duplicateIds = new Set();
+
+  nodeList.forEach((node, index) => {
+    if (!node || typeof node !== 'object' || Array.isArray(node)) {
+      errors.push(`Node at index ${index} must be an object, got ${describe(node)}.`);
+      return;
+    }
+
+    if (!isNonEmptyString(node.id)) {
+      errors.push(`Node at index ${index} is missing "id" (got ${describe(node.id)}).`);
+    } else if (declaredIds.has(node.id)) {
+      // Two nodes sharing an id silently shadow each other in the engine's
+      // id→node Map, so the second one can never execute.
+      duplicateIds.add(node.id);
+    } else {
+      declaredIds.add(node.id);
+    }
+
+    if (!isNonEmptyString(node.text)) {
+      errors.push(
+        `${nodeLabel(node, index)} is missing "text" (got ${describe(node.text)}). ` +
+          '"text" is the node\'s display name; the engine lowercases it to resolve ' +
+          '{{Node Name.output}} references.'
+      );
+    }
+
+    if (!isNonEmptyString(node.type)) {
+      errors.push(
+        `${nodeLabel(node, index)} is missing "type" (got ${describe(node.type)}). ` +
+          '"type" selects the tool or trigger implementation to run.'
+      );
+    }
+  });
+
+  for (const id of duplicateIds) {
+    errors.push(`Duplicate node id "${id}" — node ids must be unique.`);
+  }
+
+  edgeList.forEach((edge, index) => {
+    if (!edge || typeof edge !== 'object' || Array.isArray(edge)) {
+      errors.push(`Edge at index ${index} must be an object, got ${describe(edge)}.`);
+      return;
+    }
+
+    const label = isNonEmptyString(edge.id) ? `edge "${edge.id}"` : `edge at index ${index}`;
+
+    for (const end of ['start', 'end']) {
+      const endpoint = edge[end];
+
+      if (!endpoint || typeof endpoint !== 'object' || Array.isArray(endpoint)) {
+        errors.push(
+          `${label} is missing "${end}" (got ${describe(endpoint)}). ` +
+            `Edges connect nodes as { ${end}: { id, type } }.`
+        );
+        continue;
+      }
+
+      if (!isNonEmptyString(endpoint.id)) {
+        errors.push(`${label} has "${end}" without an "id" (got ${describe(endpoint.id)}).`);
+        continue;
+      }
+
+      // Only meaningful once we know every declared id — an edge pointing at a
+      // node that was never declared silently drops that branch of execution.
+      if (nodeList.length && !declaredIds.has(endpoint.id)) {
+        errors.push(`${label} "${end}" references unknown node id "${endpoint.id}".`);
+      }
+    }
+  });
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Same check, phrased for a caller that wants to fail hard.
+ *
+ * @param {unknown} workflow
+ * @param {string} [context] - prefix for the thrown message, e.g. a workflow id
+ * @throws {Error} listing every problem found, one per line
+ */
+export function assertWorkflowShape(workflow, context = 'Workflow') {
+  const { valid, errors } = validateWorkflowShape(workflow);
+  if (!valid) {
+    throw new Error(`${context} cannot be executed:\n  - ${errors.join('\n  - ')}`);
+  }
+}
+
+export default validateWorkflowShape;

--- a/backend/src/workflow/validateWorkflowShape.test.js
+++ b/backend/src/workflow/validateWorkflowShape.test.js
@@ -3,9 +3,10 @@ import { validateWorkflowShape, assertWorkflowShape } from './validateWorkflowSh
 
 /**
  * The engine reads one workflow shape. Everything else that writes a workflow
- * invents its own, and nothing checked — so the mismatch surfaced at
- * activation as `TypeError: Cannot read properties of undefined (reading
- * 'toLowerCase')` and reached the caller as an unqualified 'error'.
+ * invents its own, and nothing checked — so the mismatch surfaced in
+ * WorkflowEngine#_initializeNodeNameMapping as `TypeError: Cannot read
+ * properties of undefined (reading 'toLowerCase')` and reached the caller as
+ * an unqualified 'error'.
  *
  * The fixtures under "shapes found in a real database" are not invented. They
  * are the exact key sets of the 22 workflows on one developer machine, none of
@@ -155,6 +156,26 @@ describe('validateWorkflowShape — ids and edge endpoints', () => {
     expect(errors.some((e) => e.includes('unknown node id "ghost-node"'))).toBe(true);
   });
 
+  it('rejects edges when there are no nodes at all', () => {
+    // Edges with an empty node list is not a blank draft — a blank draft has no
+    // edges either. Letting it through left _findStartNodes with no start node
+    // and a fallback that indexes nodes[0] on an empty array.
+    const { valid, errors } = validateWorkflowShape({
+      nodes: [],
+      edges: [{ id: 'e1', start: { id: 'ghost-a' }, end: { id: 'ghost-b' } }],
+    });
+
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('unknown node id "ghost-a"'))).toBe(true);
+    expect(errors.some((e) => e.includes('unknown node id "ghost-b"'))).toBe(true);
+  });
+
+  it('rejects edges when nodes is omitted entirely', () => {
+    expect(validateWorkflowShape({ edges: [{ id: 'e1', start: { id: 'a' }, end: { id: 'b' } }] }).valid).toBe(
+      false
+    );
+  });
+
   it('names the edge by id when it has one', () => {
     const wf = twoNodeWorkflow();
     wf.edges[0].end = { id: 'ghost', type: 'input' };
@@ -187,6 +208,16 @@ describe('validateWorkflowShape — malformed containers', () => {
   it('rejects a null entry in the nodes array', () => {
     const { errors } = validateWorkflowShape({ nodes: [null], edges: [] });
     expect(errors[0]).toContain('must be an object');
+  });
+
+  it('describes an unexpected value with the right article', () => {
+    // These strings reach the caller in `details`; "got a object" reads badly.
+    expect(validateWorkflowShape({ nodes: [{ id: 'n1', text: 't', type: {} }], edges: [] }).errors[0]).toContain(
+      'an object'
+    );
+    expect(validateWorkflowShape({ nodes: [{ id: 'n1', text: 't', type: 7 }], edges: [] }).errors[0]).toContain(
+      'a number'
+    );
   });
 
   it('does not also report per-node errors when nodes is not an array', () => {

--- a/backend/src/workflow/validateWorkflowShape.test.js
+++ b/backend/src/workflow/validateWorkflowShape.test.js
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest';
+import { validateWorkflowShape, assertWorkflowShape } from './validateWorkflowShape.js';
+
+/**
+ * The engine reads one workflow shape. Everything else that writes a workflow
+ * invents its own, and nothing checked — so the mismatch surfaced at
+ * activation as `TypeError: Cannot read properties of undefined (reading
+ * 'toLowerCase')` and reached the caller as an unqualified 'error'.
+ *
+ * The fixtures under "shapes found in a real database" are not invented. They
+ * are the exact key sets of the 22 workflows on one developer machine, none of
+ * which the engine could execute. Each one must be rejected, and the rejection
+ * must name the field that is wrong.
+ */
+
+/** A node in the shape WorkflowDesigner.vue actually produces. */
+const validNode = (over = {}) => ({
+  id: 'node-1',
+  text: 'Timer Trigger',
+  type: 'trigger-timer',
+  category: 'trigger',
+  x: 100,
+  y: 100,
+  icon: 'clock',
+  description: 'Fires on start',
+  parameters: {},
+  error: null,
+  isEditing: false,
+  isSelected: false,
+  ...over,
+});
+
+/** An edge in the shape WorkflowDesigner.vue actually produces. */
+const validEdge = (over = {}) => ({
+  id: 'edge-1',
+  start: { id: 'node-1', type: 'output' },
+  end: { id: 'node-2', type: 'input' },
+  startX: 0,
+  startY: 0,
+  endX: 0,
+  endY: 0,
+  isActive: false,
+  ...over,
+});
+
+const twoNodeWorkflow = () => ({
+  name: 'ok',
+  nodes: [validNode(), validNode({ id: 'node-2', text: 'Grok Bot Status', type: 'grok-bot-status' })],
+  edges: [validEdge()],
+});
+
+describe('validateWorkflowShape — what the designer produces is accepted', () => {
+  it('accepts a well-formed two-node workflow', () => {
+    expect(validateWorkflowShape(twoNodeWorkflow())).toEqual({ valid: true, errors: [] });
+  });
+
+  it('accepts a blank draft with empty collections', () => {
+    expect(validateWorkflowShape({ name: 'draft', nodes: [], edges: [] }).valid).toBe(true);
+  });
+
+  it('accepts a draft that omits nodes and edges entirely', () => {
+    // WorkflowImportService already coerces both to [] the same way; a blank
+    // draft must stay savable.
+    expect(validateWorkflowShape({ name: 'draft' }).valid).toBe(true);
+  });
+
+  it('accepts nodes with no edges between them', () => {
+    expect(validateWorkflowShape({ nodes: [validNode()], edges: [] }).valid).toBe(true);
+  });
+
+  it('ignores fields the engine never dereferences', () => {
+    const wf = twoNodeWorkflow();
+    delete wf.nodes[0].icon;
+    delete wf.nodes[0].description;
+    delete wf.nodes[0].category;
+    delete wf.nodes[0].parameters;
+    delete wf.edges[0].startX;
+    // Only text/id/type and edge endpoints are read, so this still runs.
+    expect(validateWorkflowShape(wf).valid).toBe(true);
+  });
+});
+
+describe('validateWorkflowShape — the field that actually crashed', () => {
+  it('rejects a node without text, and says why', () => {
+    const wf = twoNodeWorkflow();
+    delete wf.nodes[0].text;
+
+    const { valid, errors } = validateWorkflowShape(wf);
+    expect(valid).toBe(false);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('node "node-1"');
+    expect(errors[0]).toContain('"text"');
+    expect(errors[0]).toContain('missing');
+  });
+
+  it('rejects an empty-string text — .toLowerCase() would succeed but the name is unusable', () => {
+    const wf = twoNodeWorkflow();
+    wf.nodes[0].text = '   ';
+    expect(validateWorkflowShape(wf).valid).toBe(false);
+  });
+
+  it('names the index when the node has no id to name it by', () => {
+    const { errors } = validateWorkflowShape({ nodes: [{ type: 'x' }], edges: [] });
+    expect(errors.some((e) => e.includes('index 0'))).toBe(true);
+  });
+
+  it('reports every problem at once rather than only the first', () => {
+    const { errors } = validateWorkflowShape({ nodes: [{}], edges: [] });
+    // missing id, missing text, missing type
+    expect(errors).toHaveLength(3);
+  });
+});
+
+describe('validateWorkflowShape — ids and edge endpoints', () => {
+  it('rejects a missing node id', () => {
+    const wf = twoNodeWorkflow();
+    delete wf.nodes[0].id;
+    expect(validateWorkflowShape(wf).errors.some((e) => e.includes('"id"'))).toBe(true);
+  });
+
+  it('rejects a missing node type', () => {
+    const wf = twoNodeWorkflow();
+    delete wf.nodes[1].type;
+    expect(validateWorkflowShape(wf).errors.some((e) => e.includes('"type"'))).toBe(true);
+  });
+
+  it('rejects duplicate node ids — the second silently shadows the first in the id map', () => {
+    const wf = twoNodeWorkflow();
+    wf.nodes[1].id = 'node-1';
+    wf.edges = [];
+
+    const { valid, errors } = validateWorkflowShape(wf);
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('Duplicate node id "node-1"'))).toBe(true);
+  });
+
+  it('rejects an edge with no start', () => {
+    const wf = twoNodeWorkflow();
+    delete wf.edges[0].start;
+    expect(validateWorkflowShape(wf).errors.some((e) => e.includes('"start"'))).toBe(true);
+  });
+
+  it('rejects an edge endpoint without an id', () => {
+    const wf = twoNodeWorkflow();
+    wf.edges[0].end = { type: 'input' };
+    expect(validateWorkflowShape(wf).errors.some((e) => e.includes('without an "id"'))).toBe(true);
+  });
+
+  it('rejects an edge pointing at a node that does not exist', () => {
+    const wf = twoNodeWorkflow();
+    wf.edges[0].end = { id: 'ghost-node', type: 'input' };
+
+    const { valid, errors } = validateWorkflowShape(wf);
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('unknown node id "ghost-node"'))).toBe(true);
+  });
+
+  it('names the edge by id when it has one', () => {
+    const wf = twoNodeWorkflow();
+    wf.edges[0].end = { id: 'ghost', type: 'input' };
+    expect(validateWorkflowShape(wf).errors[0]).toContain('edge "edge-1"');
+  });
+});
+
+describe('validateWorkflowShape — malformed containers', () => {
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['an array', []],
+    ['a string', 'workflow'],
+    ['a number', 7],
+  ])('rejects a workflow that is %s', (_label, value) => {
+    expect(validateWorkflowShape(value).valid).toBe(false);
+  });
+
+  it('rejects nodes that is an object rather than an array', () => {
+    const { valid, errors } = validateWorkflowShape({ nodes: { a: 1 }, edges: [] });
+    expect(valid).toBe(false);
+    expect(errors[0]).toContain('"nodes" must be an array');
+  });
+
+  it('rejects edges that is a string', () => {
+    const { errors } = validateWorkflowShape({ nodes: [], edges: 'none' });
+    expect(errors[0]).toContain('"edges" must be an array');
+  });
+
+  it('rejects a null entry in the nodes array', () => {
+    const { errors } = validateWorkflowShape({ nodes: [null], edges: [] });
+    expect(errors[0]).toContain('must be an object');
+  });
+
+  it('does not also report per-node errors when nodes is not an array', () => {
+    // Short-circuits: a container error makes element errors meaningless noise.
+    expect(validateWorkflowShape({ nodes: 'x', edges: 'y' }).errors).toHaveLength(2);
+  });
+});
+
+describe('shapes found in a real database — every one must be rejected', () => {
+  /**
+   * Key sets taken verbatim from the 22 workflows stored on one machine.
+   * Zero were executable. Each entry is [label, nodes, edges].
+   */
+  const realShapes = [
+    [
+      'marketplace / plugin style: fields,id,nodeType,position,type',
+      [
+        {
+          fields: { agentId: 'abc', botToken: '' },
+          id: 'agent-chat',
+          nodeType: 'agnt-agent',
+          position: { x: 250, y: 100 },
+          type: 'action',
+        },
+      ],
+      [{ source: 'telegram-trigger', sourceHandle: 'text', target: 'agent-chat', targetHandle: 'message' }],
+    ],
+    [
+      'script style: code,id,name,type',
+      [{ code: 'return 1;', id: 'js-1', name: 'Run JS', type: 'execute-javascript' }],
+      [],
+    ],
+    [
+      'config style: config,id,name,type',
+      [{ config: { url: 'https://example.com' }, id: 'http-1', name: 'Fetch', type: 'http-request' }],
+      [],
+    ],
+    [
+      'react-flow style: data,id,type',
+      [{ data: { label: 'Timer', properties: {} }, id: 'trigger-1', type: 'trigger-timer' }],
+      [{ id: 'e1', source: 'trigger-1', target: 'js-1', sourceHandle: 'output', targetHandle: 'input' }],
+    ],
+    [
+      'react-flow style: data,id,position,type',
+      [
+        {
+          data: { label: 'Timer', properties: { fireOnStart: 'Yes' } },
+          id: 'trigger-1',
+          position: { x: 100, y: 100 },
+          type: 'trigger-timer',
+        },
+      ],
+      [{ id: 'e1', source: 'trigger-1', target: 'status-1' }],
+    ],
+  ];
+
+  it.each(realShapes)('rejects %s', (_label, nodes, edges) => {
+    const { valid, errors } = validateWorkflowShape({ name: 'real', nodes, edges });
+    expect(valid).toBe(false);
+    // The whole point is a message that names the missing field, not just "invalid".
+    expect(errors.some((e) => e.includes('"text"'))).toBe(true);
+  });
+
+  it('tells a react-flow caller that edges need start/end, not source/target', () => {
+    const { errors } = validateWorkflowShape({
+      nodes: [validNode()],
+      edges: [{ id: 'e1', source: 'node-1', target: 'node-1' }],
+    });
+    expect(errors.some((e) => e.includes('{ start: { id, type } }'))).toBe(true);
+    expect(errors.some((e) => e.includes('{ end: { id, type } }'))).toBe(true);
+  });
+});
+
+describe('assertWorkflowShape', () => {
+  it('does not throw on a valid workflow', () => {
+    expect(() => assertWorkflowShape(twoNodeWorkflow())).not.toThrow();
+  });
+
+  it('throws an Error naming the context and every problem', () => {
+    let thrown;
+    try {
+      assertWorkflowShape({ nodes: [{ id: 'n1' }], edges: [] }, 'Workflow wf-123');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    // Not a TypeError from dereferencing undefined — the old failure mode.
+    expect(thrown.constructor.name).toBe('Error');
+    expect(thrown.message).toContain('Workflow wf-123');
+    expect(thrown.message).toContain('"text"');
+    expect(thrown.message).toContain('"type"');
+  });
+
+  it('defaults the context so the message is still readable', () => {
+    expect(() => assertWorkflowShape({ nodes: [{}], edges: [] })).toThrow(/^Workflow cannot be executed:/);
+  });
+});


### PR DESCRIPTION
## What

`POST /workflows/save` accepted workflows that `WorkflowEngine` cannot execute, stored them, and answered `201`. The mismatch surfaced later, once, at activation — as a `TypeError` inside the workflow process that reached the caller as an unqualified `error`.

This adds a shape check derived from what the engine actually dereferences, and wires it into both the save path and the engine constructor.

## Why

The engine reads exactly one node/edge shape. `WorkflowDesigner.vue` produces it. Every other writer invents its own, and nothing checked:

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at WorkflowEngine._initializeNodeNameMapping (WorkflowEngine.js:518)
```

`node.text` was undefined. Two things made this hard to see:

1. **The save reported success.** `saveWorkflow` validated only that the body was an object, then `JSON.stringify`'d it into the row. The workflow appeared in the list looking fine.
2. **The error never left the workflow process.** `WorkflowProcessBridge.fetchWorkflowState` returns `{ status: 'error' }` for *any* caught IPC exception, so `/workflows/:id/status` reported `error` with no indication of which node or which field.

On one developer machine **22 of 22 stored workflows were in a shape the engine could not execute**, across five distinct variants — none of them authored in the UI:

| shape | source |
|---|---|
| `fields, id, nodeType, position, type` | marketplace / plugin-style installs |
| `data, id, position, type` | react-flow style, agent tooling |
| `data, id, type` | react-flow style |
| `code, id, name, type` | script-style |
| `config, id, name, type` | config-style |

Edges in those rows use `source`/`target`; the engine reads `edge.start.id` / `edge.end.id`.

## How

**`backend/src/workflow/validateWorkflowShape.js`** — a pure, dependency-free check. Every rule corresponds to a property the engine dereferences, and the module comment cites the line:

| rule | engine site |
|---|---|
| `node.text` non-empty | `WorkflowEngine.js:518` — `node.text.toLowerCase()` |
| `node.id` non-empty, unique | `:197` — `new Map(nodes.map(n => [n.id, n]))` |
| `node.type` non-empty | `:114` — `import(.../triggers/${node.type}.js)` |
| `edge.start.id` resolves | `:201`, `:204` |
| `edge.end.id` resolves | `:405`, `:408`, `:527` |

Nothing here encodes taste. If the engine stops reading a field, the rule for it should go too.

Wired in **twice**, because save-time validation alone would only protect rows written from now on:

- **`saveWorkflow`** answers `400` with a per-problem list naming the node and the field, and stores nothing.
- **The `WorkflowEngine` constructor** asserts the same shape. Rows that predate this — plus anything arriving via `/workflows/import` or a direct DB write, neither of which passes through save — now fail with a diagnosis instead of a `TypeError`.

Two deliberate choices:

- **Absent `nodes`/`edges` are normalised to `[]`, not rejected.** A blank draft must stay savable, and both collections are iterated unconditionally (`:516`, `:527`). `WorkflowImportService.js:39-40` already coerces them the same way.
- **The engine normalises into a copy**, leaving the caller's object alone — the worker parses it straight out of the DB row. Covered by a test.

## Testing

**50 new tests across 3 files. 11 fail without this change**, including a direct reproduction of the original failure (`expected TypeError: Cannot read properties of unde… to not be an instance of TypeError`).

The fixtures under *"shapes found in a real database"* are the verbatim key sets of the five malformed variants above, not invented examples.

**Mutation tested — 8 mutants, 8 killed, 0 survived:**

| mutant | result |
|---|---|
| stop requiring `node.text` | killed (14) |
| stop reporting duplicate node ids | killed (1) |
| stop checking edges resolve | killed (4) |
| stop requiring `node.type` | killed (3) |
| reject a blank draft (over-strict) | killed (3) |
| normalise by mutating the caller's object | killed (1) |
| drop the engine-side assert | killed (3) |
| drop save-time validation | killed (6) |

Full backend suite: **292 passed / 293 files**. The one failure, `UpdateScheduler.status.test.js > replaces the previous pass rather than accumulating`, is **pre-existing and unrelated** — I verified it fails identically on untouched `origin/main` (`1 failed | 289 passed`), it imports nothing this PR touches, and it passes in isolation. Looks order-dependent.

## Notes for the reviewer

- This is a **behaviour change at the API boundary**: callers currently POSTing a malformed workflow get `201` today and will get `400` after this. That is the point — those workflows could never run — but it is worth a deliberate nod, particularly for anything installing workflows from a remote marketplace (`frontend/src/store/features/marketplace.js:442,532` passes `assetData` through untransformed).
- **Not addressed here:** `WorkflowProcessBridge.fetchWorkflowState` collapsing every IPC exception to `{ status: 'error' }` is why this took so long to diagnose. Worth surfacing the underlying message, but it is a separate change.
- **Also not addressed:** `/workflows/import` still does not validate. The engine-side assert catches it at activation, but a 400 at import time would be friendlier.
