### PR TITLE
fix(workflow): an unreachable workflow process is not a workflow state

### DIFF
--- a/backend/src/services/WorkflowService.fetchWorkflowState.test.js
+++ b/backend/src/services/WorkflowService.fetchWorkflowState.test.js
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * GET /workflows/:id/status must not report a workflow state it never read.
+ *
+ * The bridge answered an unreachable workflow process with
+ * `{ status: 'error' }`, and this handler passed that through as 200. Since
+ * 'error' is a genuine workflow status — ProcessWorker sets it on a workflow
+ * whose engine failed — a client had no way to tell "your workflow failed"
+ * from "I could not reach the workflow process".
+ *
+ * The handler's own `catch` was unreachable while that was true: it tested
+ * `error.message.includes('not ready')`, but nothing ever threw. It was added
+ * on 2026-03-10, two months after the swallow landed (2026-01-20) — someone
+ * wrote handling for an error that structurally could not arrive.
+ *
+ * The predicate and error class are deliberately NOT mocked; the wiring
+ * between them and this handler is part of what is under test.
+ */
+
+vi.mock('../services/auth/sessionTokenCache.js', () => ({
+  subscribe: vi.fn(() => () => {}),
+  getSessionToken: vi.fn(() => null),
+  getSessionUserId: vi.fn(() => null),
+}));
+vi.mock('child_process', () => ({ fork: vi.fn(), default: { fork: vi.fn() } }));
+
+const fetchWorkflowState = vi.fn();
+
+vi.mock('../workflow/WorkflowProcessBridge.js', async (importActual) => {
+  const actual = await importActual();
+  return {
+    ...actual,
+    default: {
+      fetchWorkflowState,
+      activateWorkflow: vi.fn(),
+      deactivateWorkflow: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../models/WorkflowModel.js', () => ({ default: { findOne: vi.fn(), createOrUpdate: vi.fn() } }));
+vi.mock('../models/WebhookModel.js', () => ({ default: {} }));
+vi.mock('../models/database/index.js', () => ({
+  default: { run: vi.fn() },
+  dbRunWithRetry: vi.fn(async (fn) => fn()),
+}));
+vi.mock('../utils/realtimeSync.js', () => ({
+  broadcast: vi.fn(),
+  broadcastToUser: vi.fn(),
+  RealtimeEvents: { WORKFLOW_CREATED: 'created', WORKFLOW_UPDATED: 'updated' },
+}));
+vi.mock('../plugins/PluginManager.js', () => ({ default: {} }));
+vi.mock('../plugins/PluginInstaller.js', () => ({ default: {} }));
+
+const { default: WorkflowService } = await import('./WorkflowService.js');
+const { WorkflowProcessUnavailableError } = await import('../workflow/WorkflowProcessBridge.js');
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+const req = { params: { id: 'wf-1' }, user: { userId: 'user-1' } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('GET /workflows/:id/status — the process answered', () => {
+  it('passes a real workflow state straight through', async () => {
+    fetchWorkflowState.mockResolvedValue({ status: 'listening', outputs: { n1: 1 }, errors: {} });
+
+    const res = makeRes();
+    await WorkflowService.fetchWorkflowState(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ status: 'listening', outputs: { n1: 1 }, errors: {} });
+  });
+
+  it('still reports a workflow whose engine genuinely errored as status "error"', async () => {
+    // The value this PR stops manufacturing must keep working when it is real.
+    fetchWorkflowState.mockResolvedValue({ status: 'error', errors: { n1: 'boom' } });
+
+    const res = makeRes();
+    await WorkflowService.fetchWorkflowState(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.status).toBe('error');
+    expect(res.body.errors).toEqual({ n1: 'boom' });
+  });
+});
+
+describe('GET /workflows/:id/status — the process could not be reached', () => {
+  it('answers 200 "initializing" while the process is still starting', async () => {
+    // Benign and self-resolving. This branch existed but was unreachable.
+    fetchWorkflowState.mockRejectedValue(
+      new WorkflowProcessUnavailableError('Workflow process is not ready', 'not-ready')
+    );
+
+    const res = makeRes();
+    await WorkflowService.fetchWorkflowState(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      status: 'initializing',
+      message: 'Workflow process is starting up',
+    });
+  });
+
+  it.each([
+    ['not-spawned', 'Workflow process is not available'],
+    ['init-failed', 'Workflow process failed to initialize'],
+    ['timeout', 'Message FETCH_WORKFLOW_STATE timed out after 30000ms'],
+  ])('answers 503 "unavailable" for reason %s', async (reason, message) => {
+    fetchWorkflowState.mockRejectedValue(new WorkflowProcessUnavailableError(message, reason));
+
+    const res = makeRes();
+    await WorkflowService.fetchWorkflowState(req, res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body.status).toBe('unavailable');
+    expect(res.body.reason).toBe(reason);
+    expect(res.body.details).toBe(message);
+  });
+
+  it('never reports an unreachable process as a workflow in the error state', async () => {
+    // The regression, stated directly: 'error' must not be manufactured.
+    fetchWorkflowState.mockRejectedValue(
+      new WorkflowProcessUnavailableError('Workflow process is not available', 'not-spawned')
+    );
+
+    const res = makeRes();
+    await WorkflowService.fetchWorkflowState(req, res);
+
+    expect(res.body.status).not.toBe('error');
+    expect(res.statusCode).not.toBe(200);
+  });
+});
+
+describe('GET /workflows/:id/status — the process reported a failure', () => {
+  it('answers 500 and forwards the diagnosis instead of a generic string', async () => {
+    const diagnosis =
+      'Workflow wf-1 cannot be executed:\n  - node "n1" is missing "text" (got missing).';
+    fetchWorkflowState.mockRejectedValue(new Error(diagnosis));
+
+    const res = makeRes();
+    await WorkflowService.fetchWorkflowState(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.error).toBe('Error retrieving workflow status');
+    // Previously discarded — which is exactly why such failures were invisible
+    // from the API and had to be dug out of the workflow process log.
+    expect(res.body.details).toBe(diagnosis);
+  });
+
+  it('does not classify a reported failure as unavailable', async () => {
+    fetchWorkflowState.mockRejectedValue(new Error('something the child knows about'));
+
+    const res = makeRes();
+    await WorkflowService.fetchWorkflowState(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.status).toBeUndefined();
+  });
+});

--- a/backend/src/services/WorkflowService.js
+++ b/backend/src/services/WorkflowService.js
@@ -1,6 +1,6 @@
 import WorkflowModel from '../models/WorkflowModel.js';
 import WebhookModel from '../models/WebhookModel.js';
-import WorkflowProcessBridge from '../workflow/WorkflowProcessBridge.js';
+import WorkflowProcessBridge, { isWorkflowProcessUnavailable } from '../workflow/WorkflowProcessBridge.js';
 import generateUUID from '../utils/generateUUID.js';
 import db from '../models/database/index.js';
 import { broadcast, broadcastToUser, RealtimeEvents } from '../utils/realtimeSync.js';
@@ -92,8 +92,11 @@ class WorkflowService {
           }
         }
       } catch (error) {
-        // If workflow process is not ready yet, skip the restart check
-        console.log('Workflow process not ready yet, skipping restart check');
+        // The restart check is best-effort: the save itself already succeeded.
+        // Report what actually went wrong rather than asserting a cause — this
+        // block is reached by an unreachable workflow process AND by a failure
+        // of the restart itself, and it used to blame the former for both.
+        console.warn(`Skipping post-save restart check for ${workflow.id}: ${error.message}`);
       }
 
       // Broadcast real-time update to user's connected clients (all tabs)
@@ -146,7 +149,9 @@ class WorkflowService {
           }
         }
       } catch (error) {
-        console.log('[updateWorkflow] Workflow process not ready yet, skipping restart check');
+        console.warn(
+          `[updateWorkflow] Skipping restart check for ${req.params.id}: ${error.message}`
+        );
       }
 
       // Broadcast real-time update to user's connected clients (all tabs)
@@ -318,18 +323,42 @@ class WorkflowService {
       res.status(500).json({ error: 'Failed to delete workflow', details: error.message });
     }
   }
+  /**
+   * GET /workflows/:id/status
+   *
+   * Never reports a workflow state that was not actually read. The bridge used
+   * to answer an unreachable workflow process with `{ status: 'error' }`, which
+   * this handler passed through as 200 — indistinguishable from a workflow
+   * whose engine really did fail, since 'error' is a genuine workflow status.
+   */
   async fetchWorkflowState(req, res) {
     try {
       const status = await WorkflowProcessBridge.fetchWorkflowState(req.params.id, req.user.userId);
       res.json(status);
     } catch (error) {
-      console.error('Error retrieving workflow status:', error);
-      // If workflow process is not ready, return a temporary status
-      if (error.message.includes('not ready')) {
-        res.json({ status: 'initializing', message: 'Workflow process is starting up' });
-      } else {
-        res.status(500).json({ error: 'Error retrieving workflow status' });
+      console.error(`Error retrieving status for workflow ${req.params.id}:`, error);
+
+      if (isWorkflowProcessUnavailable(error)) {
+        // Still starting up: benign and self-resolving, so keep the 200 the
+        // original handler intended. That branch was unreachable until now — it
+        // tested error.message for 'not ready', but the bridge never threw.
+        if (error.reason === 'not-ready') {
+          return res.json({ status: 'initializing', message: 'Workflow process is starting up' });
+        }
+
+        // Not spawned, failed to initialise, or did not answer. The workflow's
+        // real state is unknown, so say so rather than inventing one.
+        return res.status(503).json({
+          status: 'unavailable',
+          reason: error.reason,
+          error: 'Workflow process is unreachable',
+          details: error.message,
+        });
       }
+
+      // The process answered, reporting a failure. That message is the
+      // diagnosis — forward it instead of replacing it with a generic string.
+      res.status(500).json({ error: 'Error retrieving workflow status', details: error.message });
     }
   }
   async activateWorkflow(req, res) {

--- a/backend/src/workflow/WorkflowProcessBridge.js
+++ b/backend/src/workflow/WorkflowProcessBridge.js
@@ -10,6 +10,51 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+/**
+ * The workflow process could not be reached, so nothing is known about the
+ * workflow itself.
+ *
+ * This is deliberately distinct from an error the child process *answered*
+ * with. `sendMessage` can fail two ways, and conflating them is what made a
+ * workflow failure undiagnosable:
+ *
+ *   - TRANSPORT: the child was never spawned, is not ready, failed to
+ *     initialise, or did not answer in time. We learned nothing. → this class.
+ *   - REPLY: the child answered `{ success: false, error }`. That message is a
+ *     real diagnosis of a real problem — e.g. "Workflow wf-1 cannot be
+ *     executed: node "n1" is missing "text"". → a plain Error carrying it.
+ *
+ * Callers that need to tell these apart should check `error.code`, not the
+ * message text.
+ */
+export class WorkflowProcessUnavailableError extends Error {
+  /**
+   * @param {string} message
+   * @param {'not-spawned'|'not-ready'|'init-failed'|'timeout'} reason
+   */
+  constructor(message, reason) {
+    super(message);
+    this.name = 'WorkflowProcessUnavailableError';
+    this.code = 'WORKFLOW_PROCESS_UNAVAILABLE';
+    this.reason = reason;
+  }
+}
+
+/**
+ * True when the workflow process itself could not be reached.
+ *
+ * Kept as a predicate so callers never have to sniff message text — the route
+ * handler used to test `error.message.includes('not ready')`, which matched
+ * exactly one of the four transport failures and would silently stop matching
+ * if the wording changed.
+ *
+ * @param {unknown} error
+ * @returns {boolean}
+ */
+export function isWorkflowProcessUnavailable(error) {
+  return Boolean(error) && error.code === 'WORKFLOW_PROCESS_UNAVAILABLE';
+}
+
 class WorkflowProcessBridge {
   constructor() {
     this.workflowProcess = null;
@@ -214,17 +259,21 @@ class WorkflowProcessBridge {
       try {
         await this.readyPromise;
       } catch (error) {
-        return Promise.reject(new Error('Workflow process failed to initialize'));
+        return Promise.reject(
+          new WorkflowProcessUnavailableError('Workflow process failed to initialize', 'init-failed')
+        );
       }
     }
 
     return new Promise((resolve, reject) => {
       if (!this.workflowProcess) {
-        return reject(new Error('Workflow process is not available'));
+        return reject(
+          new WorkflowProcessUnavailableError('Workflow process is not available', 'not-spawned')
+        );
       }
 
       if (!this.isReady) {
-        return reject(new Error('Workflow process is not ready'));
+        return reject(new WorkflowProcessUnavailableError('Workflow process is not ready', 'not-ready'));
       }
 
       const id = ++this.messageId;
@@ -238,7 +287,9 @@ class WorkflowProcessBridge {
       // Set up timeout
       const timeoutId = setTimeout(() => {
         this.messageHandlers.delete(id);
-        reject(new Error(`Message ${type} timed out after ${timeout}ms`));
+        reject(
+          new WorkflowProcessUnavailableError(`Message ${type} timed out after ${timeout}ms`, 'timeout')
+        );
       }, timeout);
 
       // Store handler
@@ -285,6 +336,31 @@ class WorkflowProcessBridge {
     }
   }
 
+  /**
+   * Ask the workflow process for a workflow's live state.
+   *
+   * Throws rather than reporting a state it does not know.
+   *
+   * This used to `return { status: 'error', error: error.message }`, which was
+   * wrong twice over. `'error'` is a REAL workflow status — ProcessWorker sets
+   * it on a workflow whose engine failed, and ProcessManager reads it back out
+   * of the database — so "I could not reach the workflow process" and "this
+   * workflow failed" were reported with the identical value, and no caller
+   * could tell them apart. Callers testing
+   * `['running','listening','queued'].includes(status)` then quietly took the
+   * not-active branch on what was really an infrastructure failure.
+   *
+   * It also discarded the child's own diagnosis. When the child answers
+   * `{ success: false, error }` that message names the actual fault — e.g.
+   * `Workflow wf-1 cannot be executed: node "n1" is missing "text"` — and it
+   * was replaced by the single word `error` before any caller saw it.
+   *
+   * Log-and-rethrow matches restartActiveWorkflows below. All three callers
+   * already sit inside a try/catch.
+   *
+   * @throws {WorkflowProcessUnavailableError} the process could not be reached
+   * @throws {Error} the process answered, reporting this failure
+   */
   async fetchWorkflowState(workflowId, userId) {
     try {
       const result = await this.sendMessage('FETCH_WORKFLOW_STATE', {
@@ -294,7 +370,7 @@ class WorkflowProcessBridge {
       return result;
     } catch (error) {
       console.error('Error fetching workflow state via IPC:', error);
-      return { status: 'error', error: error.message };
+      throw error;
     }
   }
 

--- a/backend/src/workflow/WorkflowProcessBridge.js
+++ b/backend/src/workflow/WorkflowProcessBridge.js
@@ -31,9 +31,14 @@ export class WorkflowProcessUnavailableError extends Error {
   /**
    * @param {string} message
    * @param {'not-spawned'|'not-ready'|'init-failed'|'timeout'} reason
+   * @param {{ cause?: unknown }} [options] underlying error, where one exists
    */
-  constructor(message, reason) {
-    super(message);
+  constructor(message, reason, options = {}) {
+    // Keep the original failure attached. Three of the four reasons are
+    // synthesised from a state check and have no cause, but 'init-failed'
+    // wraps a real error — and dropping it would repeat the mistake this
+    // whole change exists to fix.
+    super(message, 'cause' in options ? { cause: options.cause } : undefined);
     this.name = 'WorkflowProcessUnavailableError';
     this.code = 'WORKFLOW_PROCESS_UNAVAILABLE';
     this.reason = reason;
@@ -260,7 +265,9 @@ class WorkflowProcessBridge {
         await this.readyPromise;
       } catch (error) {
         return Promise.reject(
-          new WorkflowProcessUnavailableError('Workflow process failed to initialize', 'init-failed')
+          new WorkflowProcessUnavailableError('Workflow process failed to initialize', 'init-failed', {
+            cause: error,
+          })
         );
       }
     }

--- a/backend/src/workflow/WorkflowProcessBridge.unavailable.test.js
+++ b/backend/src/workflow/WorkflowProcessBridge.unavailable.test.js
@@ -1,0 +1,248 @@
+import { EventEmitter } from 'events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * An unreachable workflow process must not be reported as a workflow state.
+ *
+ * `fetchWorkflowState` used to answer every IPC failure with
+ * `{ status: 'error', error: error.message }`. That is wrong twice:
+ *
+ *   1. `'error'` is a REAL workflow status — ProcessWorker sets it on a
+ *      workflow whose engine failed, and ProcessManager reads it back out of
+ *      the database. So "I could not reach the workflow process" and "this
+ *      workflow failed" arrived as the same value, and no caller could tell
+ *      them apart.
+ *   2. When the child answers `{ success: false, error }`, that message is a
+ *      real diagnosis — e.g. `Workflow wf-1 cannot be executed: node "n1" is
+ *      missing "text"`. It was replaced by the word `error` before any caller
+ *      saw it, which is precisely why such failures were undiagnosable from
+ *      the API.
+ *
+ * These tests pin the distinction: TRANSPORT failures throw
+ * WorkflowProcessUnavailableError; a failure the child REPORTED throws a plain
+ * Error still carrying the child's message.
+ */
+
+const { forkMock } = vi.hoisted(() => ({ forkMock: vi.fn() }));
+vi.mock('child_process', () => ({ fork: forkMock, default: { fork: forkMock } }));
+vi.mock('../services/auth/sessionTokenCache.js', () => ({
+  subscribe: vi.fn(() => () => {}),
+  getSessionToken: vi.fn(() => null),
+  getSessionUserId: vi.fn(() => null),
+}));
+
+let children = [];
+
+/** A child that acknowledges nothing unless a test tells it to. */
+function makeChild() {
+  const child = new EventEmitter();
+  child.pid = 1000 + children.length;
+  child.killed = false;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+  });
+  child.send = vi.fn();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  return child;
+}
+
+async function freshModule() {
+  vi.resetModules();
+  return import('./WorkflowProcessBridge.js');
+}
+
+/** Spawn a child and drive it to READY. */
+async function spawnReady(bridge) {
+  const p = bridge.spawn();
+  await p;
+  return children[children.length - 1];
+}
+
+beforeEach(() => {
+  children = [];
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  forkMock.mockImplementation(() => {
+    const child = makeChild();
+    children.push(child);
+    queueMicrotask(() => child.emit('message', { type: 'READY' }));
+    return child;
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  forkMock.mockReset();
+});
+
+describe('transport failures are typed and named', () => {
+  it('rejects with WorkflowProcessUnavailableError when nothing was ever spawned', async () => {
+    const { default: bridge, WorkflowProcessUnavailableError } = await freshModule();
+
+    // The branch under test is `if (!this.workflowProcess)`; this is that state.
+    bridge.workflowProcess = null;
+    bridge.readyPromise = null;
+    bridge.isReady = false;
+
+    const error = await bridge.sendMessage('FETCH_WORKFLOW_STATE', {}).catch((e) => e);
+
+    expect(error).toBeInstanceOf(WorkflowProcessUnavailableError);
+    expect(error.code).toBe('WORKFLOW_PROCESS_UNAVAILABLE');
+    expect(error.reason).toBe('not-spawned');
+  });
+
+  it('rejects with reason "not-ready" when the child exists but has not reported READY', async () => {
+    const { default: bridge, WorkflowProcessUnavailableError } = await freshModule();
+
+    // The state after a child dies: the process object is still installed but
+    // the exit handler has cleared isReady.
+    bridge.workflowProcess = makeChild();
+    bridge.readyPromise = null;
+    bridge.isReady = false;
+
+    const error = await bridge.sendMessage('FETCH_WORKFLOW_STATE', {}).catch((e) => e);
+
+    expect(error).toBeInstanceOf(WorkflowProcessUnavailableError);
+    expect(error.reason).toBe('not-ready');
+  });
+
+  it('rejects with reason "init-failed" when the ready promise rejected', async () => {
+    const { default: bridge, WorkflowProcessUnavailableError } = await freshModule();
+
+    bridge.isReady = false;
+    bridge.readyPromise = Promise.reject(new Error('spawn blew up'));
+    // Keep the rejection from tripping the unhandled-rejection detector before
+    // sendMessage awaits it.
+    bridge.readyPromise.catch(() => {});
+
+    const error = await bridge.sendMessage('FETCH_WORKFLOW_STATE', {}).catch((e) => e);
+
+    expect(error).toBeInstanceOf(WorkflowProcessUnavailableError);
+    expect(error.reason).toBe('init-failed');
+  });
+
+  it('rejects with reason "timeout" when the child never answers', async () => {
+    vi.useFakeTimers();
+    const { default: bridge, WorkflowProcessUnavailableError } = await freshModule();
+    await spawnReady(bridge);
+
+    // child.send is a no-op mock, so no reply ever arrives.
+    const pending = bridge.sendMessage('FETCH_WORKFLOW_STATE', {}, 5000).catch((e) => e);
+    await vi.advanceTimersByTimeAsync(5001);
+    const error = await pending;
+
+    expect(error).toBeInstanceOf(WorkflowProcessUnavailableError);
+    expect(error.reason).toBe('timeout');
+    expect(error.message).toContain('timed out');
+  });
+});
+
+describe('a failure the child REPORTED is not a transport failure', () => {
+  it('rejects with a plain Error that still carries the child\'s diagnosis', async () => {
+    const { default: bridge, WorkflowProcessUnavailableError, isWorkflowProcessUnavailable } =
+      await freshModule();
+    const child = await spawnReady(bridge);
+
+    const diagnosis = 'Workflow wf-1 cannot be executed:\n  - node "n1" is missing "text"';
+    child.send.mockImplementation((message) => {
+      queueMicrotask(() =>
+        child.emit('message', { id: message.id, success: false, error: diagnosis })
+      );
+    });
+
+    const error = await bridge.fetchWorkflowState('wf-1', 'user-1').catch((e) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    // The whole point: this must NOT be mistaken for an unreachable process.
+    expect(error).not.toBeInstanceOf(WorkflowProcessUnavailableError);
+    expect(isWorkflowProcessUnavailable(error)).toBe(false);
+    // And the message survives all the way out, instead of becoming 'error'.
+    expect(error.message).toBe(diagnosis);
+  });
+});
+
+describe('fetchWorkflowState', () => {
+  it('returns the state the child reported', async () => {
+    const { default: bridge } = await freshModule();
+    const child = await spawnReady(bridge);
+
+    child.send.mockImplementation((message) => {
+      queueMicrotask(() =>
+        child.emit('message', {
+          id: message.id,
+          success: true,
+          data: { status: 'listening', outputs: { n1: 1 }, errors: {} },
+        })
+      );
+    });
+
+    await expect(bridge.fetchWorkflowState('wf-1', 'user-1')).resolves.toEqual({
+      status: 'listening',
+      outputs: { n1: 1 },
+      errors: {},
+    });
+  });
+
+  it('throws instead of returning { status: "error" } when the process is unreachable', async () => {
+    const { default: bridge, WorkflowProcessUnavailableError } = await freshModule();
+
+    bridge.workflowProcess = null;
+    bridge.readyPromise = null;
+    bridge.isReady = false;
+
+    // The regression. This used to RESOLVE with { status: 'error' }, which is
+    // indistinguishable from a workflow whose engine genuinely failed.
+    const result = await bridge.fetchWorkflowState('wf-1', 'user-1').then(
+      (value) => ({ resolved: value }),
+      (error) => ({ rejected: error })
+    );
+
+    expect(result.resolved).toBeUndefined();
+    expect(result.rejected).toBeInstanceOf(WorkflowProcessUnavailableError);
+  });
+
+  it('still logs the failure before rethrowing', async () => {
+    const { default: bridge } = await freshModule();
+    bridge.workflowProcess = null;
+    bridge.readyPromise = null;
+    bridge.isReady = false;
+
+    await bridge.fetchWorkflowState('wf-1', 'user-1').catch(() => {});
+
+    expect(console.error).toHaveBeenCalledWith(
+      'Error fetching workflow state via IPC:',
+      expect.any(Error)
+    );
+  });
+});
+
+describe('isWorkflowProcessUnavailable', () => {
+  it('recognises the typed error', async () => {
+    const { WorkflowProcessUnavailableError, isWorkflowProcessUnavailable } = await freshModule();
+    expect(isWorkflowProcessUnavailable(new WorkflowProcessUnavailableError('x', 'timeout'))).toBe(
+      true
+    );
+  });
+
+  it.each([
+    ['a plain Error', new Error('boom')],
+    ['null', null],
+    ['undefined', undefined],
+  ])('does not misclassify %s', async (_label, value) => {
+    const { isWorkflowProcessUnavailable } = await freshModule();
+    expect(isWorkflowProcessUnavailable(value)).toBe(false);
+  });
+
+  it('matches on code rather than message text', async () => {
+    // The route handler previously tested error.message.includes('not ready'),
+    // which matched one of four transport failures and would break on a reword.
+    const { isWorkflowProcessUnavailable } = await freshModule();
+    const reworded = new Error('the workflow process is still warming up');
+    reworded.code = 'WORKFLOW_PROCESS_UNAVAILABLE';
+    expect(isWorkflowProcessUnavailable(reworded)).toBe(true);
+  });
+});

--- a/backend/src/workflow/WorkflowProcessBridge.unavailable.test.js
+++ b/backend/src/workflow/WorkflowProcessBridge.unavailable.test.js
@@ -123,6 +123,17 @@ describe('transport failures are typed and named', () => {
 
     expect(error).toBeInstanceOf(WorkflowProcessUnavailableError);
     expect(error.reason).toBe('init-failed');
+    // The reason this whole change exists: do not drop the underlying error.
+    expect(error.cause).toBeInstanceOf(Error);
+    expect(error.cause.message).toBe('spawn blew up');
+  });
+
+  it('leaves cause undefined for the reasons that have no underlying error', async () => {
+    const { WorkflowProcessUnavailableError } = await freshModule();
+    const synthesised = new WorkflowProcessUnavailableError('Workflow process is not ready', 'not-ready');
+
+    expect(synthesised.cause).toBeUndefined();
+    expect('cause' in synthesised).toBe(false);
   });
 
   it('rejects with reason "timeout" when the child never answers', async () => {


### PR DESCRIPTION
Follow-up to #70, which named this as the reason that bug took so long to diagnose. Independent of it — test-merged both ways, `Auto-merging backend/src/services/WorkflowService.js / Automatic merge went well`.

## What

`WorkflowProcessBridge.fetchWorkflowState` answered **every** IPC failure with `{ status: 'error', error: error.message }`. That is wrong twice over, and this replaces it with a distinction the callers can act on.

## Why

### 1. `'error'` is a real workflow status

`ProcessWorker` sets a workflow's status to `'error'` when its engine fails (`ProcessWorker.js:33,61,109`), and `ProcessManager.fetchWorkflowState` reads that value back out of the database for an inactive workflow. So the bridge was answering *"I could not reach the workflow process"* with the identical value that means *"this workflow failed"*. No caller could tell them apart.

Both restart checks in `WorkflowService` test `['running','listening','queued'].includes(currentState.status)`. On an infrastructure failure the status is `'error'`, which is not in that list, so the branch is quietly skipped: **a live workflow silently keeps running its old definition after a save**, and the log line blamed a cause it had not checked.

The API is worse — `GET /workflows/:id/status` returned **200** with `{status:'error'}`, so a client saw a failed *workflow* rather than an unreachable *service*.

### 2. It discarded the child's own diagnosis

`sendMessage` rejects for two structurally different reasons:

| | cause | what we know |
|---|---|---|
| **transport** | never spawned, not ready, failed to initialise, no answer in time | nothing about the workflow |
| **reply** | the child answered `{ success: false, error }` | a specific, actionable diagnosis |

The second case carries messages like `Workflow wf-1 cannot be executed: node "n1" is missing "text"`. That text was replaced by the single word `error` before any caller saw it. **This is precisely why the #70 bug could not be diagnosed from the API** and had to be dug out of the workflow-process log.

### 3. The handler's own catch was unreachable

`WorkflowService.fetchWorkflowState` already had a catch testing `error.message.includes('not ready')` and returning `{status:'initializing'}`. It could never fire, because the bridge caught everything. Git dates the two: the swallow landed in `c9923d20` (2026-01-20), the handler in `2887115c` (2026-03-10). Someone wrote handling for an error that structurally could not arrive, and nothing said so.

## How

- **`sendMessage`** rejects transport failures with a typed `WorkflowProcessUnavailableError` carrying `reason` of `not-spawned` / `not-ready` / `init-failed` / `timeout`. A failure the child *reported* stays a plain `Error` with its message intact.
- **`fetchWorkflowState`** logs and rethrows — matching `restartActiveWorkflows` in the same class, which already does exactly this. All three callers already sit inside a `try/catch`, so control flow is unchanged wherever it was already correct.
- **`GET /workflows/:id/status`** now distinguishes:
  - `not-ready` → **200** `{status:'initializing'}` — unchanged intent, just finally reachable
  - other transport failures → **503** `{status:'unavailable', reason, details}`
  - child-reported failure → **500** with the diagnosis in `details` (house style, matching `saveWorkflow`)
- **Both restart-check catches** report the real error instead of asserting "not ready" for every cause — including a failure of the restart itself, which this block also swallows.
- `isWorkflowProcessUnavailable(error)` is exported so nobody has to sniff message text again. The old check matched one of the four transport failures and would have silently stopped matching on a reword.

## Testing

**22 tests across 2 files.** Without the change, **11 of the 13 bridge tests fail** and the **9 route tests cannot load at all** (the typed error does not exist). The bridge tests drive the real bridge with a mocked child, following `WorkflowProcessBridge.lifecycle.test.js`. The route tests deliberately do **not** mock the predicate or the error class — the wiring between them and the handler is part of what is under test.

The baseline reproduces the bug verbatim:

```
AssertionError: expected { status: 'error', …(1) } to be an instance of Error
AssertionError: expected { status: 'error', …(1) } to be undefined
```

**Mutation tested — 8 mutants, 8 killed, 0 survived:**

| mutant | result |
|---|---|
| restore the original swallow | killed (2) |
| untype the not-spawned reject | killed (2) |
| untype the timeout reject | killed (1) |
| untype the not-ready reject | killed (1) |
| predicate matches message text instead of code | killed (5) |
| drop the 200 "initializing" branch | killed (1) |
| stop forwarding the child's diagnosis | killed (1) |
| classify a child-reported failure as unavailable | killed (2) |

Full backend suite: **291 passed / 292 files**, including the existing `WorkflowProcessBridge.lifecycle.test.js` which exercises `sendMessage` directly. The single failure, `UpdateScheduler.status.test.js > replaces the previous pass rather than accumulating`, is pre-existing and unrelated — verified failing identically on untouched `origin/main` while investigating #70, passes in isolation, imports nothing this PR touches, and does not fire on CI.

## Notes for the reviewer

- **`/workflows/:id/status` can now return non-2xx.** Both frontend pollers already handle it: each does `if (!response.ok) throw`, and the surviving poller reschedules from its catch — the same thing it previously did on `data.status === 'error'`, which is in its continue-polling list. So client behaviour is unchanged in the failure case either way; what changes is that the failure is now *legible*.
- **Deliberately not included:** `activateWorkflow` and `deactivateWorkflow` swallow the same way, returning `{ error: error.message }`. That shape at least does not impersonate a status, so it is a milder version of this bug and a bigger blast radius. Happy to do it as a third PR.
- The two restart-check `catch` blocks still skip the restart when the process is unreachable. Retrying there is a behaviour change I did not want to fold into an error-reporting fix.
