### PR TITLE
fix(plugins): a node:-prefixed builtin must disclose what the bare one does

### DIFF
--- a/backend/plugins/lib/validate-core.js
+++ b/backend/plugins/lib/validate-core.js
@@ -298,10 +298,19 @@ const SCAN_MAX_FILE_BYTES = 1024 * 1024; // skip pathological single files > 1 M
  * migration window absorbs them (trust system).
  */
 const CAPABILITY_DETECTORS = {
+  // `node:child_process` must be detected exactly like `child_process`. The
+  // prefixed specifier is the modern spelling of the SAME builtin, and the
+  // filesystem detectors below already accept both forms — so a plugin writing
+  // `import { execFile } from 'node:child_process'` disclosed nothing while the
+  // identical unprefixed import disclosed spawn-process.
+  //
+  // The two call-shape patterns did not cover it either: execFile/spawn/exec
+  // only match when the first argument is a quoted literal, which it is not
+  // when the binary comes from a variable or env var.
   'spawn-process': [
-    /\brequire\s*\(\s*['"]child_process['"]\s*\)/,
-    /\bfrom\s+['"]child_process['"]/,
-    /\bimport\s*\(\s*['"]child_process['"]\s*\)/,
+    /\brequire\s*\(\s*['"](?:child_process|node:child_process)['"]\s*\)/,
+    /\bfrom\s+['"](?:child_process|node:child_process)['"]/,
+    /\bimport\s*\(\s*['"](?:child_process|node:child_process)['"]\s*\)/,
     /\b(?:execSync|spawnSync|execFileSync)\s*\(/,
     /\b(?:spawn|exec|execFile|fork)\s*\(\s*['"`]/,
   ],

--- a/backend/skills/agnt-plugin-builder/SKILL.md
+++ b/backend/skills/agnt-plugin-builder/SKILL.md
@@ -50,6 +50,10 @@ After `npm install` a `node_modules/` folder joins them and gets bundled into th
   "description": "What it does",
   "author": "AGNT User",
   "icon": "sparkles",
+  "permissions": {
+    "capabilities": ["network"],
+    "domains": ["api.example.com"]
+  },
   "tools": [
     {
       "type": "my-tool",
@@ -73,8 +77,58 @@ Rules that matter:
 - `category` is one of `action | trigger | utility | widget | control | custom`. 90% of plugins are `action`.
 - The top-level `type` in the tool object and the `type` inside `schema` must match.
 - `entryPoint` is relative to the manifest (use `./file.js`).
+- **`permissions` is required.** `cli/build-plugin.js` refuses to build without
+  `permissions.capabilities` and `permissions.domains` as arrays. Both must be
+  present even when empty — see below.
 
 For the full schema (parameter input types, conditional visibility, auth modes, output shapes), read `references/manifest-schema.md`.
+
+### `permissions` — what the plugin is allowed to do
+
+The build refuses to package a manifest without a structured `permissions`
+block, so this is not optional:
+
+```
+❌ Official plugin disclosure gate: manifest.json must contain structured
+   permissions.capabilities and permissions.domains arrays
+```
+
+```json
+"permissions": {
+  "capabilities": ["network", "filesystem", "env-access"],
+  "domains": ["api.example.com", "cdn.example.com"]
+}
+```
+
+`capabilities` is drawn from a fixed vocabulary — anything else is ignored:
+
+| Capability | Declare it when the plugin… |
+|---|---|
+| `network` | makes outbound HTTP/WebSocket calls (`fetch`, `axios`, `ws`, `https.request`) |
+| `filesystem` | reads or writes files (`fs`, `node:fs`, `fs/promises`, `fs-extra`) |
+| `spawn-process` | shells out (`child_process`, `node:child_process`, `execFile`, `spawn`) |
+| `env-access` | reads `process.env` |
+| `dynamic-eval` | uses `eval` or `new Function` |
+| `dynamic-import` | imports a module path built at runtime |
+
+`domains` lists the hostnames the plugin contacts. Leave it `[]` when the
+plugin makes no outbound calls of its own — a plugin that shells out to a CLI
+which then talks to the network declares `spawn-process`, not `network`, because
+the plugin's own code opens no socket.
+
+The build runs a source scan and prints what it found next to what you declared:
+
+```
+🔍 Scanning capabilities (first-party source only)...
+   Detected: filesystem, env-access
+   Declared: env-access, filesystem, spawn-process
+```
+
+The two lists do **not** have to match. Effective permissions are the union, so
+an undeclared capability is still granted — and disclosed to the user at install
+time as an undeclared one, which costs the plugin trust tier. Declaring more
+than the scan detects is harmless and is the right call whenever you know the
+plugin does something the regex-based scan cannot see.
 
 ### `package.json` essentials
 
@@ -175,6 +229,18 @@ execSync('node cli/build-plugin.js <plugin-name>', {
 ```
 
 Success produces `plugin-builds/<plugin-name>.agnt`. The build script validates the manifest, auto-fixes missing `"type": "module"`, runs `npm install` if needed, and gzipped-tars the folder.
+
+It also scans the source for capabilities and **refuses to build** a manifest
+without a structured `permissions` block. If the run stops on `manifest.json
+must contain structured permissions.capabilities and permissions.domains
+arrays`, add the block described above rather than working around it. To draft
+one from the source automatically — the script takes no arguments, it scans
+**every** plugin in `dev/` and writes one ready-to-paste block per plugin to
+`permissions-drafts/<plugin-name>.json`:
+
+```bash
+node cli/draft-permissions.js
+```
 
 ### Step 4 — Install via the API
 
@@ -317,6 +383,7 @@ To remove a plugin: `DELETE /api/plugins/:name`, then `POST /api/plugins/reload`
 | Bloated `.agnt` | Use `npm install --production` |
 | Tool `type` mismatch (manifest vs. `this.name`) | Keep them identical, kebab-case |
 | Invalid JSON in manifest | Always write via `JSON.stringify(obj, null, 2)` |
+| Build stops on `must contain structured permissions` | Add `permissions: { capabilities: [], domains: [] }` — both keys, both arrays, even when empty |
 | UI doesn't show new tool | Hit `POST /api/plugins/reload` — forgetting this is the #1 "it didn't work" cause |
 | Windows backslashes in `file://` URLs | `filePath.replace(/\\/g, '/')` before prefixing with `file://` |
 

--- a/backend/src/plugins/capabilityDetectors.test.js
+++ b/backend/src/plugins/capabilityDetectors.test.js
@@ -213,17 +213,33 @@ describe('the plugin-builder skill matches the code it documents', () => {
 
     const message = 'manifest.json must contain structured permissions.capabilities and permissions.domains arrays';
     expect(build).toContain(message);
-    // The doc wraps the sentence across lines, so compare on words rather than
-    // requiring the exact whitespace of either file.
-    for (const fragment of ['must contain structured permissions', 'permissions.domains']) {
-      expect(doc).toContain(fragment);
-    }
+
+    // Scope to the fenced block that shows the failure. Searching the whole
+    // document would let a paraphrase here pass on the strength of the pitfalls
+    // table further down, which is how this assertion first survived a mutant.
+    const errorBlock = doc.match(/```\n(\u274c[\s\S]*?)```/);
+    expect(errorBlock, 'SKILL.md must show the build failure in a fenced block').not.toBeNull();
+
+    // The doc wraps the sentence across lines; flatten before comparing so the
+    // test pins the words, not the line breaks.
+    expect(errorBlock[1].replace(/\s+/g, ' ').trim()).toContain(message);
   });
 
   it('shows a permissions block in the manifest example', async () => {
     const doc = await fsp.readFile(SKILL_MD, 'utf8');
-    expect(doc).toMatch(/"permissions":\s*\{/);
-    expect(doc).toContain('"capabilities"');
-    expect(doc).toContain('"domains"');
+
+    // The example an agent copies is the FIRST json block under this heading.
+    // Asserting against the whole document passed even with the block deleted
+    // from the example, because the explanatory section further down has one
+    // too — the test named a place it never looked at.
+    const section = doc.split('### `manifest.json` essentials')[1];
+    expect(section, 'SKILL.md must keep the manifest.json essentials section').toBeDefined();
+
+    const example = section.match(/```json\n([\s\S]*?)```/);
+    expect(example, 'that section must contain a json example').not.toBeNull();
+
+    expect(example[1]).toMatch(/"permissions":\s*\{/);
+    expect(example[1]).toContain('"capabilities"');
+    expect(example[1]).toContain('"domains"');
   });
 });

--- a/backend/src/plugins/capabilityDetectors.test.js
+++ b/backend/src/plugins/capabilityDetectors.test.js
@@ -2,10 +2,20 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import fsp from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 import { scanCapabilities } from '../../plugins/lib/validate-core.js';
 
-const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+// `fileURLToPath`, not `new URL(...).pathname`. On Windows the pathname of a
+// file URL is `/C:/Users/...` — a URL path, not a filesystem path — and the
+// leading slash makes `path.resolve` treat it as drive-relative, producing
+// `C:\C:\Users\...` and an ENOENT on all three reads below. Linux CI cannot
+// see this because there the two forms happen to coincide.
+//
+// This is the form server.js and every script in plugins/cli/ already uses;
+// sign-plugin.js carries a hand-rolled `.replace(/^\/([A-Za-z]:)/, '$1')` for
+// the same reason, which is the workaround this avoids needing.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 const SKILL_MD = path.join(REPO_ROOT, 'backend/skills/agnt-plugin-builder/SKILL.md');
 const BUILD_SCRIPT = path.join(REPO_ROOT, 'backend/plugins/cli/build-plugin.js');
 const VALIDATE_CORE = path.join(REPO_ROOT, 'backend/plugins/lib/validate-core.js');

--- a/backend/src/plugins/capabilityDetectors.test.js
+++ b/backend/src/plugins/capabilityDetectors.test.js
@@ -223,6 +223,12 @@ describe('the plugin-builder skill matches the code it documents', () => {
     // The doc wraps the sentence across lines; flatten before comparing so the
     // test pins the words, not the line breaks.
     expect(errorBlock[1].replace(/\s+/g, ' ').trim()).toContain(message);
+
+    // ...and because it wraps, that block cannot be found by anyone pasting the
+    // error into a search box. Somewhere in the document an unbroken fragment
+    // has to exist — today the pitfalls table carries it. Deliberately
+    // unscoped: the contract is "findable", not "findable in one place".
+    expect(doc).toContain('must contain structured permissions');
   });
 
   it('shows a permissions block in the manifest example', async () => {

--- a/backend/src/plugins/capabilityDetectors.test.js
+++ b/backend/src/plugins/capabilityDetectors.test.js
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fsp from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { scanCapabilities } from '../../plugins/lib/validate-core.js';
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+const SKILL_MD = path.join(REPO_ROOT, 'backend/skills/agnt-plugin-builder/SKILL.md');
+const BUILD_SCRIPT = path.join(REPO_ROOT, 'backend/plugins/cli/build-plugin.js');
+const VALIDATE_CORE = path.join(REPO_ROOT, 'backend/plugins/lib/validate-core.js');
+
+/**
+ * Capability disclosure must not depend on how a builtin is spelled.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `node:child_process` and `child_process` are the same module. The scanner
+ * detected only the second. The filesystem detectors already accepted both
+ * spellings (`fs` and `node:fs`), so the inconsistency was internal to one
+ * object literal — one rule written two ways, which is exactly the kind of
+ * thing nothing notices.
+ *
+ * It was not theoretical. A plugin built on this machine imports
+ * `node:child_process` and shells out to python3, and the build reported:
+ *
+ *     Detected: filesystem, env-access
+ *
+ * with no `spawn-process`. The two call-shape patterns did not cover it
+ * either — `execFile(...)` only matches when the first argument is a quoted
+ * literal, and a plugin resolving its binary from a variable or `process.env`
+ * never has one. That plugin declared spawn-process by hand, so the union
+ * model granted it; a plugin that stayed quiet would have shipped
+ * undisclosed.
+ *
+ * The parity test at the bottom is a ratchet: it fails when a NEW builtin is
+ * added to any detector in only one of its two spellings.
+ */
+
+/** Builtins the import detectors claim to recognise, in either spelling. */
+const DETECTED_BUILTINS = [
+  ['child_process', 'spawn-process'],
+  ['fs', 'filesystem'],
+  ['fs/promises', 'filesystem'],
+  ['http', 'network'],
+  ['https', 'network'],
+];
+
+let dir;
+
+beforeEach(async () => {
+  dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'agnt-capscan-'));
+});
+
+afterEach(async () => {
+  await fsp.rm(dir, { recursive: true, force: true }).catch(() => {});
+});
+
+/** Write one source file into the scan directory and return the capabilities found. */
+async function scan(source, filename = 'index.js') {
+  await fsp.writeFile(path.join(dir, filename), source, 'utf8');
+  const result = await scanCapabilities(dir);
+  return {
+    caps: Object.keys(result.capabilities).sort(),
+    detail: result.capabilities,
+    filesScanned: result.filesScanned,
+    scanFailed: result.scanFailed,
+  };
+}
+
+describe('spawn-process — the node: prefix', () => {
+  it.each([
+    ['static import', "import { execFile } from 'node:child_process';"],
+    ['require', "const cp = require('node:child_process');"],
+    ['dynamic import', "const cp = await import('node:child_process');"],
+  ])('detects a %s of node:child_process', async (_label, source) => {
+    const { caps } = await scan(source);
+    expect(caps).toContain('spawn-process');
+  });
+
+  it.each([
+    ['static import', "import { execFile } from 'child_process';"],
+    ['require', "const cp = require('child_process');"],
+    ['dynamic import', "const cp = await import('child_process');"],
+  ])('still detects a %s of bare child_process', async (_label, source) => {
+    const { caps } = await scan(source);
+    expect(caps).toContain('spawn-process');
+  });
+
+  it('reports evidence with a file and a line number', async () => {
+    const source = ['// header', '', "import { execFile } from 'node:child_process';"].join('\n');
+    const { detail } = await scan(source);
+
+    const hits = detail['spawn-process'];
+    expect(Array.isArray(hits)).toBe(true);
+    expect(hits[0].file).toBe('index.js');
+    // The consent modal renders this; an unlocatable finding is not evidence.
+    expect(hits[0].line).toBe(3);
+  });
+});
+
+describe('the real shape that evaded disclosure', () => {
+  it('detects a prefixed import whose exec call takes a variable', async () => {
+    // Reduced from a plugin that actually shipped: the binary is resolved at
+    // call time, so no call-shape pattern can see a quoted literal.
+    const source = [
+      "import { execFile } from 'node:child_process';",
+      '',
+      'export function run(args) {',
+      "  const python = process.env.GROKBOT_PYTHON || 'python3';",
+      '  return new Promise((resolve) => execFile(python, args, resolve));',
+      '}',
+    ].join('\n');
+
+    const { caps } = await scan(source);
+
+    expect(caps).toContain('spawn-process');
+    // env-access comes along for the ride; the point is spawn-process is there.
+    expect(caps).toContain('env-access');
+  });
+
+  it('would not have been caught by the call-shape patterns alone', async () => {
+    // Same call, no import line: proves the import detector is what does the
+    // work here, rather than the test passing for an incidental reason.
+    const source = [
+      'export function run(python, args) {',
+      '  return execFile(python, args, () => {});',
+      '}',
+    ].join('\n');
+
+    const { caps } = await scan(source);
+    expect(caps).not.toContain('spawn-process');
+  });
+});
+
+describe('other detectors are unchanged', () => {
+  it.each([
+    ['node:fs', 'filesystem'],
+    ['fs', 'filesystem'],
+    ['node:fs/promises', 'filesystem'],
+    ['node:https', 'network'],
+    ['https', 'network'],
+  ])('still detects an import of %s as %s', async (specifier, capability) => {
+    const { caps } = await scan(`import x from '${specifier}';`);
+    expect(caps).toContain(capability);
+  });
+
+  it('detects nothing in a file that does nothing', async () => {
+    const { caps, filesScanned } = await scan('export const answer = 42;\n');
+    expect(caps).toEqual([]);
+    expect(filesScanned).toBe(1);
+  });
+
+  it('skips full-line comments, so a mention is not a usage', async () => {
+    const source = ["// we deliberately avoid require('node:child_process') here", 'export const x = 1;'].join(
+      '\n'
+    );
+    const { caps } = await scan(source);
+    expect(caps).not.toContain('spawn-process');
+  });
+});
+
+describe('spelling parity — ratchet', () => {
+  /**
+   * Every builtin the import detectors recognise must be recognised in BOTH
+   * spellings. This is the test that fails when someone adds a new builtin in
+   * one form only, which is how the child_process gap arrived.
+   */
+  it.each(DETECTED_BUILTINS)('%s discloses %s whether or not it is node:-prefixed', async (mod, capability) => {
+    const bare = await scan(`import x from '${mod}';`, 'bare.js');
+    const prefixed = await scan(`import x from 'node:${mod}';`, 'prefixed.js');
+
+    expect(bare.caps).toContain(capability);
+    expect(prefixed.caps).toContain(capability);
+    // Not just "both non-empty" — the same conclusion from the same fact.
+    expect(prefixed.caps).toEqual(bare.caps);
+  });
+
+  it('documents net as a known gap rather than leaving it silent', async () => {
+    // `net` has a method-shape detector (`net.connect(...)`) but no import
+    // detector in EITHER spelling, so this is a missing module rather than a
+    // missing prefix — out of scope here, asserted so it stays visible.
+    const { caps } = await scan("import net from 'node:net';");
+    expect(caps).not.toContain('network');
+  });
+});
+
+describe('the plugin-builder skill matches the code it documents', () => {
+  /**
+   * The skill is the instructions an agent follows to build a plugin, and it
+   * described a manifest the build script rejects: `permissions` became
+   * mandatory and the skill never mentioned it, so every plugin built from
+   * these instructions failed at the build step until someone read the source.
+   *
+   * Documentation drifts silently. These assertions make it drift loudly.
+   */
+  it('documents every capability the scanner can detect', async () => {
+    const source = await fsp.readFile(VALIDATE_CORE, 'utf8');
+    const block = source.match(/const CAPABILITY_DETECTORS = \{([\s\S]*?)\n\};/);
+    expect(block).not.toBeNull();
+
+    const capabilities = [...block[1].matchAll(/^\s{2}'?([a-z-]+)'?:/gm)].map((m) => m[1]);
+    expect(capabilities.length).toBeGreaterThan(0);
+
+    const doc = await fsp.readFile(SKILL_MD, 'utf8');
+    const undocumented = capabilities.filter((c) => !doc.includes(`\`${c}\``));
+    expect(undocumented).toEqual([]);
+  });
+
+  it('quotes the build failure verbatim, so the message can be searched for', async () => {
+    const build = await fsp.readFile(BUILD_SCRIPT, 'utf8');
+    const doc = await fsp.readFile(SKILL_MD, 'utf8');
+
+    const message = 'manifest.json must contain structured permissions.capabilities and permissions.domains arrays';
+    expect(build).toContain(message);
+    // The doc wraps the sentence across lines, so compare on words rather than
+    // requiring the exact whitespace of either file.
+    for (const fragment of ['must contain structured permissions', 'permissions.domains']) {
+      expect(doc).toContain(fragment);
+    }
+  });
+
+  it('shows a permissions block in the manifest example', async () => {
+    const doc = await fsp.readFile(SKILL_MD, 'utf8');
+    expect(doc).toMatch(/"permissions":\s*\{/);
+    expect(doc).toContain('"capabilities"');
+    expect(doc).toContain('"domains"');
+  });
+});


### PR DESCRIPTION
Two defects in the plugin capability-disclosure path, found while building a plugin from the skill and watching the build reject it.

Independent of #70 and #71 — no shared files.

## 1. A `node:`-prefixed builtin disclosed nothing

`CAPABILITY_DETECTORS['spawn-process']` matched `child_process` but not `node:child_process`. They are the same module, and the `filesystem` detectors **two lines below already accept both spellings** (`fs` and `node:fs`) — so the inconsistency lived inside a single object literal, one rule written two ways.

It is not theoretical. A plugin on this machine imports `node:child_process` and shells out to `python3`. Its build reported:

```
🔍 Scanning capabilities (first-party source only)...
   Detected: filesystem, env-access
```

No `spawn-process`. The call-shape patterns did not cover it either — `execFile(...)`/`spawn(...)` only match when the first argument is a **quoted literal**, and a plugin resolving its binary from a variable or `process.env` never has one:

```js
import { execFile } from 'node:child_process';
const python = process.env.GROKBOT_PYTHON || 'python3';
execFile(python, args, cb);          // ← invisible to every pattern
```

Scanning that same plugin directory before and after:

| | detected |
|---|---|
| before | `env-access, filesystem` |
| **after** | `env-access, filesystem, **spawn-process**` |

That plugin declared `spawn-process` by hand, so the union model granted it. A plugin that stayed quiet would have shipped a shell-out with **no disclosure at the consent modal and no cost to its trust tier** — which is the whole point of the scan.

## 2. The plugin-builder skill never mentioned the block the build requires

`cli/build-plugin.js:216` refuses to package a manifest without a structured `permissions` block. `backend/skills/agnt-plugin-builder/SKILL.md` — the instructions an agent follows to build a plugin from chat — contained the word `permissions` **zero times**, and its manifest example omitted the block entirely.

So a plugin built by following the skill exactly fails at step 3, and the only way forward is to read the build script. That is how I found it.

Adds: the block in the manifest example, a rule stating it is required, a section covering all six capabilities and what `domains` means, the verbatim error string, and the `draft-permissions.js` escape hatch. It also states that declared and detected need **not** match — effective permissions are the union, so over-declaring is safe and is the right call when the plugin does something a regex scan cannot see.

The capability table is derived from `CAPABILITY_DETECTORS` rather than invented. `draft-permissions.js` takes **no arguments** and writes one draft per dev plugin — verified against the script, after I first documented it wrongly.

## Testing

**25 tests. 8 fail without this change** (5 scanner, 3 documentation contract).

The suite includes a **parity ratchet** over every builtin the import detectors recognise: both spellings must yield the same capability set. It fails when a new builtin is added in one form only — which is how this gap arrived.

Three contract tests keep the skill honest against the code: every detectable capability is documented, the failure message is quoted as `build-plugin.js` actually emits it, and the manifest example carries a permissions block.

**Mutation tested — 8 mutants, 7 killed, 1 equivalent:**

| mutant | result |
|---|---|
| un-prefix the static-import detector | killed (3) |
| un-prefix the require detector | killed (1) |
| un-prefix the dynamic-import detector | killed (1) |
| break filesystem parity (drop `node:fs`) | killed (2) |
| remove the block from the manifest example | killed (1) |
| stop documenting one capability | killed (1) |
| paraphrase the quoted build failure | killed (1) |
| paraphrase one of two searchable copies | **equivalent — survives by design** |

The last one changes the document without violating the contract: the message must be *findable*, two contiguous copies exist, and removing one leaves it findable. Killing it would require asserting an exact occurrence count, which breaks on any legitimate third mention.

**Two of these mutants initially survived, and both were real weaknesses in my own tests** — fixed in `03edc590` and `55b37622`. Both assertions searched the whole document while their names claimed a specific location, so deleting the copy that mattered left the other holding them green. One now extracts the manifest example and asserts inside it; the other scopes to the fenced error block and compares against the exact string the build script emits, plus a deliberately unscoped check for an unbroken copy — because the fenced block wraps mid-sentence and cannot be found by pasting the error into a search box.

Full backend suite: **290 passed / 291 files**. The single failure, `UpdateScheduler.status.test.js > replaces the previous pass rather than accumulating`, is pre-existing and unrelated — it passes in isolation, imports nothing here, and does not fire on CI.

## Notes for the reviewer

- **`net` is a known remaining gap, asserted rather than fixed.** It has a method-shape detector (`net.connect(...)`) but no import detector in *either* spelling, so it is a missing module rather than a missing prefix. A test documents it so it stays visible.
- `backend/plugins/tests/disclosure.test.js` reports `19/20` both before and after this change (`D4a spicy legacy plugin backfilled → unverified`) — pre-existing, verified on pristine `origin/main`. Those files are excluded from vitest as standalone scripts.
- `validate-core.js` is vendored into the api.agnt.gg server repo via `cli/sync-validate-core.js`, and **no CI job checks the copies agree**. This change alters the canonical file, so the server copy needs re-vendoring for the publish gate to enforce the same rule. I cannot reach that repo.
