### PR TITLE
fix(workflow): a start that did not happen must not answer 200 (stacked on #71)

### DIFF
--- a/backend/src/plugins/UpdateScheduler.status.test.js
+++ b/backend/src/plugins/UpdateScheduler.status.test.js
@@ -24,7 +24,7 @@
  * real code path with no filesystem beyond a temp dir and no network at all.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
@@ -67,6 +67,9 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  // Only one test fakes the clock, but restoring it here means a failure inside
+  // that test cannot leak a frozen Date into everything that follows.
+  vi.useRealTimers();
   await fs.rm(TMP, { recursive: true, force: true });
 });
 
@@ -287,6 +290,20 @@ describe('UpdateScheduler.getStatus', () => {
   });
 
   it('replaces the previous pass rather than accumulating', async () => {
+    // The clock is faked because `checkedAt` is
+    // `new Date().toISOString()` — millisecond resolution. The two ticks below
+    // run back to back with nothing slow between them, so on a fast machine
+    // both land in the SAME millisecond and the timestamps come out identical.
+    // The old assertion was `not.toBe`, which therefore passed only when
+    // something happened to be slow enough, and failed intermittently in CI
+    // while passing in isolation.
+    //
+    // Faking Date alone — not setTimeout/setInterval — keeps the scheduler's
+    // real async filesystem work untouched; there is nothing here to advance.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    const firstPassAt = new Date('2026-01-01T00:00:00.000Z');
+    const secondPassAt = new Date('2026-01-01T06:00:00.000Z');
+
     const installer = stubInstaller({
       registry: { plugins: [{ name: 'weather' }] },
       updates: [{ name: 'weather', installed: '1.0.0', latest: '1.4.0', updateAvailable: true }],
@@ -295,16 +312,23 @@ describe('UpdateScheduler.getStatus', () => {
     await installer._writeRegistry();
     const scheduler = makeScheduler(installer);
 
+    vi.setSystemTime(firstPassAt);
     await scheduler.tick();
     const first = await scheduler.getStatus();
 
     installer.checkForUpdates = async () => ({ success: true, updates: [] });
+    vi.setSystemTime(secondPassAt);
     await scheduler.tick();
     const second = await scheduler.getStatus();
 
     expect(second.autoUpdated).toEqual([]);
     expect(second.updatesAvailable).toBe(0);
-    expect(second.checkedAt).not.toBe(first.checkedAt);
+
+    // Now that the clock is controlled this can assert the exact values rather
+    // than merely that they differ — which also pins the direction, so a
+    // summary that carried the OLD timestamp forward fails here too.
+    expect(first.checkedAt).toBe(firstPassAt.toISOString());
+    expect(second.checkedAt).toBe(secondPassAt.toISOString());
   });
 });
 

--- a/backend/src/services/WorkflowService.fetchWorkflowState.test.js
+++ b/backend/src/services/WorkflowService.fetchWorkflowState.test.js
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * GET /workflows/:id/status must not report a workflow state it never read.
+ *
+ * The bridge answered an unreachable workflow process with
+ * `{ status: 'error' }`, and this handler passed that through as 200. Since
+ * 'error' is a genuine workflow status — ProcessWorker sets it on a workflow
+ * whose engine failed — a client had no way to tell "your workflow failed"
+ * from "I could not reach the workflow process".
+ *
+ * The handler's own `catch` was unreachable while that was true: it tested
+ * `error.message.includes('not ready')`, but nothing ever threw. It was added
+ * on 2026-03-10, two months after the swallow landed (2026-01-20) — someone
+ * wrote handling for an error that structurally could not arrive.
+ *
+ * The predicate and error class are deliberately NOT mocked; the wiring
+ * between them and this handler is part of what is under test.
+ */
+
+vi.mock('../services/auth/sessionTokenCache.js', () => ({
+  subscribe: vi.fn(() => () => {}),
+  getSessionToken: vi.fn(() => null),
+  getSessionUserId: vi.fn(() => null),
+}));
+vi.mock('child_process', () => ({ fork: vi.fn(), default: { fork: vi.fn() } }));
+
+const fetchWorkflowState = vi.fn();
+
+vi.mock('../workflow/WorkflowProcessBridge.js', async (importActual) => {
+  const actual = await importActual();
+  return {
+    ...actual,
+    default: {
+      fetchWorkflowState,
+      activateWorkflow: vi.fn(),
+      deactivateWorkflow: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../models/WorkflowModel.js', () => ({ default: { findOne: vi.fn(), createOrUpdate: vi.fn() } }));
+vi.mock('../models/WebhookModel.js', () => ({ default: {} }));
+vi.mock('../models/database/index.js', () => ({
+  default: { run: vi.fn() },
+  dbRunWithRetry: vi.fn(async (fn) => fn()),
+}));
+vi.mock('../utils/realtimeSync.js', () => ({
+  broadcast: vi.fn(),
+  broadcastToUser: vi.fn(),
+  RealtimeEvents: { WORKFLOW_CREATED: 'created', WORKFLOW_UPDATED: 'updated' },
+}));
+vi.mock('../plugins/PluginManager.js', () => ({ default: {} }));
+vi.mock('../plugins/PluginInstaller.js', () => ({ default: {} }));
+
+const { default: WorkflowService } = await import('./WorkflowService.js');
+const { WorkflowProcessUnavailableError } = await import('../workflow/WorkflowProcessBridge.js');
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+const req = { params: { id: 'wf-1' }, user: { userId: 'user-1' } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('GET /workflows/:id/status — the process answered', () => {
+  it('passes a real workflow state straight through', async () => {
+    fetchWorkflowState.mockResolvedValue({ status: 'listening', outputs: { n1: 1 }, errors: {} });
+
+    const res = makeRes();
+    await WorkflowService.fetchWorkflowState(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ status: 'listening', outputs: { n1: 1 }, errors: {} });
+  });
+
+  it('still reports a workflow whose engine genuinely errored as status "error"', async () => {
+    // The value this PR stops manufacturing must keep working when it is real.
+    fetchWorkflowState.mockResolvedValue({ status: 'error', errors: { n1: 'boom' } });
+
+    const res = makeRes();
+    await WorkflowService.fetchWorkflowState(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.status).toBe('error');
+    expect(res.body.errors).toEqual({ n1: 'boom' });
+  });
+});
+
+describe('GET /workflows/:id/status — the process could not be reached', () => {
+  it('answers 200 "initializing" while the process is still starting', async () => {
+    // Benign and self-resolving. This branch existed but was unreachable.
+    fetchWorkflowState.mockRejectedValue(
+      new WorkflowProcessUnavailableError('Workflow process is not ready', 'not-ready')
+    );
+
+    const res = makeRes();
+    await WorkflowService.fetchWorkflowState(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      status: 'initializing',
+      message: 'Workflow process is starting up',
+    });
+  });
+
+  it.each([
+    ['not-spawned', 'Workflow process is not available'],
+    ['init-failed', 'Workflow process failed to initialize'],
+    ['timeout', 'Message FETCH_WORKFLOW_STATE timed out after 30000ms'],
+  ])('answers 503 "unavailable" for reason %s', async (reason, message) => {
+    fetchWorkflowState.mockRejectedValue(new WorkflowProcessUnavailableError(message, reason));
+
+    const res = makeRes();
+    await WorkflowService.fetchWorkflowState(req, res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body.status).toBe('unavailable');
+    expect(res.body.reason).toBe(reason);
+    expect(res.body.details).toBe(message);
+  });
+
+  it('never reports an unreachable process as a workflow in the error state', async () => {
+    // The regression, stated directly: 'error' must not be manufactured.
+    fetchWorkflowState.mockRejectedValue(
+      new WorkflowProcessUnavailableError('Workflow process is not available', 'not-spawned')
+    );
+
+    const res = makeRes();
+    await WorkflowService.fetchWorkflowState(req, res);
+
+    expect(res.body.status).not.toBe('error');
+    expect(res.statusCode).not.toBe(200);
+  });
+});
+
+describe('GET /workflows/:id/status — the process reported a failure', () => {
+  it('answers 500 and forwards the diagnosis instead of a generic string', async () => {
+    const diagnosis =
+      'Workflow wf-1 cannot be executed:\n  - node "n1" is missing "text" (got missing).';
+    fetchWorkflowState.mockRejectedValue(new Error(diagnosis));
+
+    const res = makeRes();
+    await WorkflowService.fetchWorkflowState(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.error).toBe('Error retrieving workflow status');
+    // Previously discarded — which is exactly why such failures were invisible
+    // from the API and had to be dug out of the workflow process log.
+    expect(res.body.details).toBe(diagnosis);
+  });
+
+  it('does not classify a reported failure as unavailable', async () => {
+    fetchWorkflowState.mockRejectedValue(new Error('something the child knows about'));
+
+    const res = makeRes();
+    await WorkflowService.fetchWorkflowState(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.status).toBeUndefined();
+  });
+});

--- a/backend/src/services/WorkflowService.js
+++ b/backend/src/services/WorkflowService.js
@@ -300,8 +300,20 @@ class WorkflowService {
   }
   async deleteWorkflow(req, res) {
     try {
-      // Deactivate workflow (this also unregisters webhook)
-      await WorkflowProcessBridge.deactivateWorkflow(req.params.id, req.user.userId);
+      // Deactivate workflow (this also unregisters webhook).
+      //
+      // Deliberately isolated: deactivateWorkflow now throws where it used to
+      // swallow, and a delete must not start failing because the workflow
+      // process is unreachable — the user would be unable to remove a workflow
+      // until the process came back. The row goes either way, exactly as before;
+      // what changes is that the reason is now logged instead of discarded.
+      try {
+        await WorkflowProcessBridge.deactivateWorkflow(req.params.id, req.user.userId);
+      } catch (deactivateError) {
+        console.warn(
+          `Deleting workflow ${req.params.id} without confirming its triggers stopped: ${deactivateError.message}`
+        );
+      }
 
       // Delete webhook from database, scoped to the owner — matching the
       // WorkflowModel.delete call immediately below, which was already scoped.
@@ -361,6 +373,14 @@ class WorkflowService {
       res.status(500).json({ error: 'Error retrieving workflow status', details: error.message });
     }
   }
+  /**
+   * POST /workflows/:id/start
+   *
+   * Answers 2xx only when the workflow's triggers were actually armed. The
+   * bridge used to swallow an IPC failure into `{ error: message }`, which
+   * `res.json` then sent as 200 — so every caller's `response.ok` check passed
+   * and the UI reported a start that never happened.
+   */
   async activateWorkflow(req, res) {
     try {
       const workflow = await WorkflowModel.findOne(req.params.id, req.user.userId);
@@ -370,16 +390,40 @@ class WorkflowService {
       const result = await WorkflowProcessBridge.activateWorkflow(JSON.parse(workflow.workflow_data), req.user.userId);
       res.json(result);
     } catch (error) {
-      console.error('Error starting workflow:', error);
+      console.error(`Error starting workflow ${req.params.id}:`, error);
+
+      if (isWorkflowProcessUnavailable(error)) {
+        return res.status(503).json({
+          error: 'Failed to start workflow',
+          reason: error.reason,
+          details: `Workflow process is unreachable: ${error.message}`,
+        });
+      }
+
       res.status(500).json({ error: 'Failed to start workflow', details: error.message });
     }
   }
+
+  /**
+   * POST /workflows/:id/stop
+   *
+   * Same contract as start: a stop that did not happen must not answer 200.
+   */
   async deactivateWorkflow(req, res) {
     try {
       const result = await WorkflowProcessBridge.deactivateWorkflow(req.params.id, req.user.userId);
       res.json(result);
     } catch (error) {
-      console.error('Error stopping workflow:', error);
+      console.error(`Error stopping workflow ${req.params.id}:`, error);
+
+      if (isWorkflowProcessUnavailable(error)) {
+        return res.status(503).json({
+          error: 'Failed to stop workflow',
+          reason: error.reason,
+          details: `Workflow process is unreachable: ${error.message}`,
+        });
+      }
+
       res.status(500).json({ error: 'Failed to stop workflow', details: error.message });
     }
   }

--- a/backend/src/services/WorkflowService.js
+++ b/backend/src/services/WorkflowService.js
@@ -1,6 +1,6 @@
 import WorkflowModel from '../models/WorkflowModel.js';
 import WebhookModel from '../models/WebhookModel.js';
-import WorkflowProcessBridge from '../workflow/WorkflowProcessBridge.js';
+import WorkflowProcessBridge, { isWorkflowProcessUnavailable } from '../workflow/WorkflowProcessBridge.js';
 import generateUUID from '../utils/generateUUID.js';
 import db from '../models/database/index.js';
 import { broadcast, broadcastToUser, RealtimeEvents } from '../utils/realtimeSync.js';
@@ -92,8 +92,11 @@ class WorkflowService {
           }
         }
       } catch (error) {
-        // If workflow process is not ready yet, skip the restart check
-        console.log('Workflow process not ready yet, skipping restart check');
+        // The restart check is best-effort: the save itself already succeeded.
+        // Report what actually went wrong rather than asserting a cause — this
+        // block is reached by an unreachable workflow process AND by a failure
+        // of the restart itself, and it used to blame the former for both.
+        console.warn(`Skipping post-save restart check for ${workflow.id}: ${error.message}`);
       }
 
       // Broadcast real-time update to user's connected clients (all tabs)
@@ -146,7 +149,9 @@ class WorkflowService {
           }
         }
       } catch (error) {
-        console.log('[updateWorkflow] Workflow process not ready yet, skipping restart check');
+        console.warn(
+          `[updateWorkflow] Skipping restart check for ${req.params.id}: ${error.message}`
+        );
       }
 
       // Broadcast real-time update to user's connected clients (all tabs)
@@ -318,18 +323,42 @@ class WorkflowService {
       res.status(500).json({ error: 'Failed to delete workflow', details: error.message });
     }
   }
+  /**
+   * GET /workflows/:id/status
+   *
+   * Never reports a workflow state that was not actually read. The bridge used
+   * to answer an unreachable workflow process with `{ status: 'error' }`, which
+   * this handler passed through as 200 — indistinguishable from a workflow
+   * whose engine really did fail, since 'error' is a genuine workflow status.
+   */
   async fetchWorkflowState(req, res) {
     try {
       const status = await WorkflowProcessBridge.fetchWorkflowState(req.params.id, req.user.userId);
       res.json(status);
     } catch (error) {
-      console.error('Error retrieving workflow status:', error);
-      // If workflow process is not ready, return a temporary status
-      if (error.message.includes('not ready')) {
-        res.json({ status: 'initializing', message: 'Workflow process is starting up' });
-      } else {
-        res.status(500).json({ error: 'Error retrieving workflow status' });
+      console.error(`Error retrieving status for workflow ${req.params.id}:`, error);
+
+      if (isWorkflowProcessUnavailable(error)) {
+        // Still starting up: benign and self-resolving, so keep the 200 the
+        // original handler intended. That branch was unreachable until now — it
+        // tested error.message for 'not ready', but the bridge never threw.
+        if (error.reason === 'not-ready') {
+          return res.json({ status: 'initializing', message: 'Workflow process is starting up' });
+        }
+
+        // Not spawned, failed to initialise, or did not answer. The workflow's
+        // real state is unknown, so say so rather than inventing one.
+        return res.status(503).json({
+          status: 'unavailable',
+          reason: error.reason,
+          error: 'Workflow process is unreachable',
+          details: error.message,
+        });
       }
+
+      // The process answered, reporting a failure. That message is the
+      // diagnosis — forward it instead of replacing it with a generic string.
+      res.status(500).json({ error: 'Error retrieving workflow status', details: error.message });
     }
   }
   async activateWorkflow(req, res) {

--- a/backend/src/services/WorkflowService.js
+++ b/backend/src/services/WorkflowService.js
@@ -388,6 +388,23 @@ class WorkflowService {
         return res.status(404).json({ error: 'Workflow not found' });
       }
       const result = await WorkflowProcessBridge.activateWorkflow(JSON.parse(workflow.workflow_data), req.user.userId);
+
+      // ProcessManager reports two refusals by RESOLVING with an error-shaped
+      // payload rather than throwing: the workflow is already active, or the
+      // enqueue failed. Passing that to res.json sends 200, which is the same
+      // lie this change exists to remove — making it throw was only half of it.
+      if (result && result.error) {
+        // 409 for "already running": the request could not be carried out in the
+        // current state, but nothing is broken. Anything else is a real failure.
+        const status = result.code === 'ALREADY_ACTIVE' ? 409 : 500;
+        return res.status(status).json({
+          error: 'Failed to start workflow',
+          code: result.code,
+          details: result.error,
+          workflowId: result.workflowId,
+        });
+      }
+
       res.json(result);
     } catch (error) {
       console.error(`Error starting workflow ${req.params.id}:`, error);

--- a/backend/src/services/WorkflowService.startStop.test.js
+++ b/backend/src/services/WorkflowService.startStop.test.js
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Start and Stop must answer 2xx only when they did something.
+ *
+ * The bridge swallowed IPC failures into `{ error: message }` and these
+ * handlers passed that to `res.json(result)` — 200, with an error-shaped body.
+ * Every caller gates on the status code (`response.ok`, or axios rejecting on
+ * non-2xx), so the failure branch never ran and the UI reported a start that
+ * never happened.
+ *
+ * Two further consequences are pinned below:
+ *
+ *   - deleteWorkflow calls deactivateWorkflow first. Now that it throws, the
+ *     delete must NOT start failing when the workflow process is unreachable.
+ *   - The retry around the post-save reactivate has been dead code since it was
+ *     written: `catch (reactivateError)` could not fire against a method that
+ *     never threw. It is live now.
+ */
+
+vi.mock('../services/auth/sessionTokenCache.js', () => ({
+  subscribe: vi.fn(() => () => {}),
+  getSessionToken: vi.fn(() => null),
+  getSessionUserId: vi.fn(() => null),
+}));
+vi.mock('child_process', () => ({ fork: vi.fn(), default: { fork: vi.fn() } }));
+
+const activateWorkflow = vi.fn();
+const deactivateWorkflow = vi.fn();
+const fetchWorkflowState = vi.fn();
+
+vi.mock('../workflow/WorkflowProcessBridge.js', async (importActual) => {
+  const actual = await importActual();
+  return {
+    ...actual,
+    default: { activateWorkflow, deactivateWorkflow, fetchWorkflowState },
+  };
+});
+
+const findOne = vi.fn();
+const deleteWorkflowRow = vi.fn(async () => ({ changes: 1 }));
+const deleteWebhook = vi.fn(async () => ({}));
+
+vi.mock('../models/WorkflowModel.js', () => ({
+  default: { findOne, delete: deleteWorkflowRow, createOrUpdate: vi.fn(), update: vi.fn() },
+}));
+vi.mock('../models/WebhookModel.js', () => ({ default: { deleteByWorkflowId: deleteWebhook } }));
+vi.mock('../models/database/index.js', () => ({
+  // Must invoke the callback: markWorkflowUserModified awaits a Promise that
+  // only settles from it, so a bare vi.fn() hangs the save forever.
+  default: { run: vi.fn((sql, params, cb) => cb && cb()) },
+  dbRunWithRetry: vi.fn(async (fn) => fn()),
+}));
+vi.mock('../utils/realtimeSync.js', () => ({
+  broadcast: vi.fn(),
+  broadcastToUser: vi.fn(),
+  RealtimeEvents: { WORKFLOW_CREATED: 'c', WORKFLOW_UPDATED: 'u', WORKFLOW_DELETED: 'd' },
+}));
+vi.mock('../plugins/PluginManager.js', () => ({ default: {} }));
+vi.mock('../plugins/PluginInstaller.js', () => ({ default: {} }));
+
+const { default: WorkflowService } = await import('./WorkflowService.js');
+const { WorkflowProcessUnavailableError } = await import('../workflow/WorkflowProcessBridge.js');
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+const req = { params: { id: 'wf-1' }, user: { userId: 'user-1' } };
+const storedRow = { id: 'wf-1', workflow_data: JSON.stringify({ id: 'wf-1', nodes: [], edges: [] }) };
+
+const unavailable = (reason = 'not-spawned', message = 'Workflow process is not available') =>
+  new WorkflowProcessUnavailableError(message, reason);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  findOne.mockResolvedValue(storedRow);
+});
+
+describe('POST /workflows/:id/start', () => {
+  it('answers 200 with the result when the workflow really started', async () => {
+    activateWorkflow.mockResolvedValue({ message: 'Workflow queued for execution', workflowId: 'wf-1' });
+
+    const res = makeRes();
+    await WorkflowService.activateWorkflow(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.message).toBe('Workflow queued for execution');
+  });
+
+  it('answers 503 — not 200 — when the workflow process is unreachable', async () => {
+    activateWorkflow.mockRejectedValue(unavailable());
+
+    const res = makeRes();
+    await WorkflowService.activateWorkflow(req, res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body.reason).toBe('not-spawned');
+    expect(res.body.details).toContain('unreachable');
+  });
+
+  it('never answers 2xx with an error-shaped body', async () => {
+    // The exact regression: `{ error: ... }` used to arrive as 200, and every
+    // caller checks response.ok rather than the body.
+    activateWorkflow.mockRejectedValue(unavailable('timeout', 'Message ACTIVATE_WORKFLOW timed out after 30000ms'));
+
+    const res = makeRes();
+    await WorkflowService.activateWorkflow(req, res);
+
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+    expect(res.body.error).toBeTruthy();
+  });
+
+  it('answers 500 with the diagnosis when the process reported a failure', async () => {
+    const diagnosis = 'Workflow wf-1 cannot be executed:\n  - node "n1" is missing "text"';
+    activateWorkflow.mockRejectedValue(new Error(diagnosis));
+
+    const res = makeRes();
+    await WorkflowService.activateWorkflow(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.details).toBe(diagnosis);
+  });
+
+  it('still answers 404 for a workflow that does not exist, without touching the bridge', async () => {
+    findOne.mockResolvedValue(null);
+
+    const res = makeRes();
+    await WorkflowService.activateWorkflow(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(activateWorkflow).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /workflows/:id/stop', () => {
+  it('answers 200 with the result when the workflow really stopped', async () => {
+    deactivateWorkflow.mockResolvedValue({ message: 'Workflow stopped', isActive: false });
+
+    const res = makeRes();
+    await WorkflowService.deactivateWorkflow(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.isActive).toBe(false);
+  });
+
+  it('answers 503 when the workflow process is unreachable', async () => {
+    deactivateWorkflow.mockRejectedValue(unavailable('not-ready', 'Workflow process is not ready'));
+
+    const res = makeRes();
+    await WorkflowService.deactivateWorkflow(req, res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body.reason).toBe('not-ready');
+  });
+
+  it('answers 500 with the diagnosis when the process reported a failure', async () => {
+    deactivateWorkflow.mockRejectedValue(new Error('worker refused to stop'));
+
+    const res = makeRes();
+    await WorkflowService.deactivateWorkflow(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.details).toBe('worker refused to stop');
+  });
+});
+
+describe('DELETE /workflows/:id — must not regress', () => {
+  it('deletes the workflow even when the process cannot confirm the stop', async () => {
+    // deleteWorkflow deactivates first. Before this change that call swallowed;
+    // now it throws, and letting it escape would make a workflow undeletable
+    // until the workflow process came back.
+    deactivateWorkflow.mockRejectedValue(unavailable());
+
+    const res = makeRes();
+    await WorkflowService.deleteWorkflow(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(deleteWorkflowRow).toHaveBeenCalledWith('wf-1', 'user-1');
+    expect(deleteWebhook).toHaveBeenCalled();
+  });
+
+  it('says why the stop could not be confirmed instead of discarding it', async () => {
+    deactivateWorkflow.mockRejectedValue(unavailable('timeout', 'Message DEACTIVATE_WORKFLOW timed out after 30000ms'));
+
+    await WorkflowService.deleteWorkflow(req, makeRes());
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('timed out'));
+  });
+
+  it('still deletes normally when the stop succeeds', async () => {
+    deactivateWorkflow.mockResolvedValue({ message: 'Workflow stopped', isActive: false });
+
+    const res = makeRes();
+    await WorkflowService.deleteWorkflow(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(deleteWorkflowRow).toHaveBeenCalled();
+  });
+});
+
+describe('the post-save reactivate retry is no longer dead code', () => {
+  it('retries the activation once when the first attempt fails', async () => {
+    // `catch (reactivateError)` has been unreachable since it was written,
+    // because activateWorkflow never threw. Now it can fire.
+    fetchWorkflowState.mockResolvedValue({ status: 'listening' });
+    deactivateWorkflow.mockResolvedValue({});
+    activateWorkflow
+      .mockRejectedValueOnce(new Error('first attempt failed'))
+      .mockResolvedValueOnce({ message: 'Workflow queued for execution' });
+
+    const saveReq = {
+      body: { workflow: { id: 'wf-1', name: 'w', nodes: [], edges: [] } },
+      user: { userId: 'user-1' },
+    };
+    await WorkflowService.saveWorkflow(saveReq, makeRes());
+
+    expect(activateWorkflow).toHaveBeenCalledTimes(2);
+    expect(console.error).toHaveBeenCalledWith(
+      'Failed to reactivate workflow after save:',
+      'first attempt failed'
+    );
+  });
+
+  it('does not fail the save when both activation attempts fail', async () => {
+    fetchWorkflowState.mockResolvedValue({ status: 'listening' });
+    deactivateWorkflow.mockResolvedValue({});
+    activateWorkflow.mockRejectedValue(new Error('still failing'));
+
+    const saveReq = {
+      body: { workflow: { id: 'wf-1', name: 'w', nodes: [], edges: [] } },
+      user: { userId: 'user-1' },
+    };
+    const res = makeRes();
+    await WorkflowService.saveWorkflow(saveReq, res);
+
+    // The save itself already succeeded; the restart check is best-effort.
+    expect(res.statusCode).toBe(201);
+    expect(activateWorkflow).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/services/WorkflowService.startStop.test.js
+++ b/backend/src/services/WorkflowService.startStop.test.js
@@ -136,6 +136,72 @@ describe('POST /workflows/:id/start', () => {
     expect(res.body.details).toBe(diagnosis);
   });
 
+  it('answers 409 — not 200 — when the workflow is already running', async () => {
+    // ProcessManager REFUSES by resolving with an error-shaped payload rather
+    // than throwing, so the throw path fixed above never sees it and res.json
+    // sent it as 200. Found by Copilot on this PR.
+    activateWorkflow.mockResolvedValue({
+      error: 'Workflow is already queued or running',
+      code: 'ALREADY_ACTIVE',
+      workflowId: 'wf-1',
+    });
+
+    const res = makeRes();
+    await WorkflowService.activateWorkflow(req, res);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.body.details).toBe('Workflow is already queued or running');
+    expect(res.body.code).toBe('ALREADY_ACTIVE');
+  });
+
+  it('answers 500 when the enqueue itself failed', async () => {
+    activateWorkflow.mockResolvedValue({
+      error: 'Failed to enqueue workflow',
+      code: 'ENQUEUE_FAILED',
+      workflowId: 'wf-1',
+    });
+
+    const res = makeRes();
+    await WorkflowService.activateWorkflow(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.details).toBe('Failed to enqueue workflow');
+  });
+
+  it('discriminates on the code, never on the message text', async () => {
+    // Reword the sentence and keep the code: the status must not move. The
+    // previous change removed a `error.message.includes('not ready')` check for
+    // exactly this reason — do not reintroduce the pattern one layer up.
+    activateWorkflow.mockResolvedValue({
+      error: 'this workflow is already up and running, friend',
+      code: 'ALREADY_ACTIVE',
+      workflowId: 'wf-1',
+    });
+
+    const res = makeRes();
+    await WorkflowService.activateWorkflow(req, res);
+
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('falls back to 500 for an error-shaped result carrying no code', async () => {
+    activateWorkflow.mockResolvedValue({ error: 'something older, with no code' });
+
+    const res = makeRes();
+    await WorkflowService.activateWorkflow(req, res);
+
+    expect(res.statusCode).toBe(500);
+  });
+
+  it('does not mistake a successful result for a refusal', async () => {
+    activateWorkflow.mockResolvedValue({ message: 'Workflow queued for execution', workflowId: 'wf-1' });
+
+    const res = makeRes();
+    await WorkflowService.activateWorkflow(req, res);
+
+    expect(res.statusCode).toBe(200);
+  });
+
   it('still answers 404 for a workflow that does not exist, without touching the bridge', async () => {
     findOne.mockResolvedValue(null);
 

--- a/backend/src/services/WorkflowService.startStop.test.js
+++ b/backend/src/services/WorkflowService.startStop.test.js
@@ -172,8 +172,13 @@ describe('POST /workflows/:id/start', () => {
     // Reword the sentence and keep the code: the status must not move. The
     // previous change removed a `error.message.includes('not ready')` check for
     // exactly this reason — do not reintroduce the pattern one layer up.
+    //
+    // The wording deliberately shares NO keyword with the original. An earlier
+    // version of this test used "...is already up and running", which still
+    // contained "already" — so a mutant that matched on the text passed it, and
+    // the test proved nothing. Mutation testing caught that.
     activateWorkflow.mockResolvedValue({
-      error: 'this workflow is already up and running, friend',
+      error: 'this workflow is up and running, friend',
       code: 'ALREADY_ACTIVE',
       workflowId: 'wf-1',
     });
@@ -182,6 +187,21 @@ describe('POST /workflows/:id/start', () => {
     await WorkflowService.activateWorkflow(req, res);
 
     expect(res.statusCode).toBe(409);
+  });
+
+  it('does not infer 409 from wording when the code says otherwise', async () => {
+    // The other half of the same guarantee: a message that reads like the
+    // already-running case must NOT be treated as one when the code disagrees.
+    activateWorkflow.mockResolvedValue({
+      error: 'the queue already rejected this workflow',
+      code: 'ENQUEUE_FAILED',
+      workflowId: 'wf-1',
+    });
+
+    const res = makeRes();
+    await WorkflowService.activateWorkflow(req, res);
+
+    expect(res.statusCode).toBe(500);
   });
 
   it('falls back to 500 for an error-shaped result carrying no code', async () => {

--- a/backend/src/services/WorkflowService.startStopIntegration.test.js
+++ b/backend/src/services/WorkflowService.startStopIntegration.test.js
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The 200 bug, reproduced end to end.
+ *
+ * The other two suites test each half in isolation: the bridge throws, and the
+ * handler maps a throw to 503/500. Neither reproduces the actual defect, which
+ * only existed where the halves MET —
+ *
+ *     bridge swallows  ->  returns { error: message }  ->  res.json(result)  ->  200
+ *
+ * — so a route test with a mocked bridge cannot see it, and a bridge test has
+ * no res to inspect. This file therefore mocks the models, the database and the
+ * realtime layer, and deliberately leaves WorkflowProcessBridge REAL.
+ *
+ * With the bridge in its never-spawned state, `POST /workflows/:id/start` used
+ * to answer 200 with `{ error: 'Workflow process is not available' }`. Every
+ * caller gates on `response.ok`, so the UI reported a start that never
+ * happened.
+ */
+
+vi.mock('../services/auth/sessionTokenCache.js', () => ({
+  subscribe: vi.fn(() => () => {}),
+  getSessionToken: vi.fn(() => null),
+  getSessionUserId: vi.fn(() => null),
+}));
+// The bridge forks a child on spawn(); it is never spawned here, but the import
+// must not reach the real module.
+vi.mock('child_process', () => ({ fork: vi.fn(), default: { fork: vi.fn() } }));
+
+vi.mock('../models/WorkflowModel.js', () => ({
+  default: {
+    findOne: vi.fn(async () => ({
+      id: 'wf-1',
+      workflow_data: JSON.stringify({ id: 'wf-1', nodes: [], edges: [] }),
+    })),
+    delete: vi.fn(async () => ({ changes: 1 })),
+    createOrUpdate: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+vi.mock('../models/WebhookModel.js', () => ({ default: { deleteByWorkflowId: vi.fn() } }));
+vi.mock('../models/database/index.js', () => ({
+  default: { run: vi.fn((sql, params, cb) => cb && cb()) },
+  dbRunWithRetry: vi.fn(async (fn) => fn()),
+}));
+vi.mock('../utils/realtimeSync.js', () => ({
+  broadcast: vi.fn(),
+  broadcastToUser: vi.fn(),
+  RealtimeEvents: { WORKFLOW_CREATED: 'c', WORKFLOW_UPDATED: 'u', WORKFLOW_DELETED: 'd' },
+}));
+vi.mock('../plugins/PluginManager.js', () => ({ default: {} }));
+vi.mock('../plugins/PluginInstaller.js', () => ({ default: {} }));
+
+const { default: WorkflowService } = await import('./WorkflowService.js');
+const { default: bridge } = await import('../workflow/WorkflowProcessBridge.js');
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+const req = { params: { id: 'wf-1' }, user: { userId: 'user-1' } };
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  // The state the bridge holds before anything forks a workflow process.
+  bridge.workflowProcess = null;
+  bridge.readyPromise = null;
+  bridge.isReady = false;
+});
+
+describe('start, against a real bridge with no workflow process', () => {
+  it('does not answer 200', async () => {
+    const res = makeRes();
+    await WorkflowService.activateWorkflow(req, res);
+
+    // This is the regression, stated at the boundary that had it.
+    expect(res.statusCode).not.toBe(200);
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('does not answer an error-shaped body with a success status', async () => {
+    const res = makeRes();
+    await WorkflowService.activateWorkflow(req, res);
+
+    const looksLikeSuccess = res.statusCode >= 200 && res.statusCode < 300;
+    expect(looksLikeSuccess && Boolean(res.body?.error)).toBe(false);
+  });
+
+  it('names the reason the process could not be reached', async () => {
+    const res = makeRes();
+    await WorkflowService.activateWorkflow(req, res);
+
+    expect(res.body.reason).toBe('not-spawned');
+    expect(res.body.details).toContain('unreachable');
+  });
+});
+
+describe('stop, against a real bridge with no workflow process', () => {
+  it('does not answer 200', async () => {
+    const res = makeRes();
+    await WorkflowService.deactivateWorkflow(req, res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body.error).toBe('Failed to stop workflow');
+  });
+});
+
+describe('delete, against a real bridge with no workflow process', () => {
+  it('still succeeds — a workflow must stay deletable while the process is down', async () => {
+    const res = makeRes();
+    await WorkflowService.deleteWorkflow(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.message).toContain('deleted successfully');
+  });
+});

--- a/backend/src/workflow/ProcessManager.js
+++ b/backend/src/workflow/ProcessManager.js
@@ -25,8 +25,14 @@ class ProcessManager extends EventEmitter {
 
     if (this._isWorkflowInQueueOrActive(workflowId)) {
       console.log(`Workflow ${workflowId} is already queued, active, pending, or being enqueued`);
+      // `code` exists so callers can tell these apart without matching on the
+      // message text. The route handler maps ALREADY_ACTIVE to 409 and anything
+      // else to 500; without it the only discriminator would be this English
+      // sentence, which is the kind of coupling that silently stops working the
+      // first time someone rewords it.
       return {
         error: 'Workflow is already queued or running',
+        code: 'ALREADY_ACTIVE',
         workflowId: workflowId,
       };
     }
@@ -51,7 +57,7 @@ class ProcessManager extends EventEmitter {
       };
     } catch (error) {
       console.error(`Error enqueueing workflow ${workflowId}:`, error);
-      return { error: 'Failed to enqueue workflow', workflowId: workflowId };
+      return { error: 'Failed to enqueue workflow', code: 'ENQUEUE_FAILED', workflowId: workflowId };
     }
   }
   async deactivateWorkflow(workflowId, userId) {

--- a/backend/src/workflow/WorkflowProcessBridge.js
+++ b/backend/src/workflow/WorkflowProcessBridge.js
@@ -316,6 +316,22 @@ class WorkflowProcessBridge {
     });
   }
 
+  /**
+   * Arm a workflow's triggers in the workflow process.
+   *
+   * Throws rather than reporting a start that did not happen.
+   *
+   * This used to `return { error: error.message }`. The route handler passes
+   * whatever comes back straight to `res.json(result)`, and res.json with no
+   * status is 200 — so a start that never happened answered SUCCESS with an
+   * error-shaped body. All three callers gate on `response.ok`, which was true,
+   * so the failure branch never ran and the UI reported the workflow started.
+   * Nothing was armed, no trigger was listening, and the only trace was a
+   * console.error in the backend log.
+   *
+   * @throws {WorkflowProcessUnavailableError} the process could not be reached
+   * @throws {Error} the process answered, reporting this failure
+   */
   async activateWorkflow(workflow, userId, triggerData = null) {
     try {
       const result = await this.sendMessage('ACTIVATE_WORKFLOW', {
@@ -326,10 +342,20 @@ class WorkflowProcessBridge {
       return result;
     } catch (error) {
       console.error('Error activating workflow via IPC:', error);
-      return { error: error.message };
+      throw error;
     }
   }
 
+  /**
+   * Disarm a workflow's triggers in the workflow process.
+   *
+   * Throws for the same reason activateWorkflow does — a stop that did not
+   * happen must not be reported as one. See deleteWorkflow in WorkflowService
+   * for the one caller that deliberately continues past a failure here.
+   *
+   * @throws {WorkflowProcessUnavailableError} the process could not be reached
+   * @throws {Error} the process answered, reporting this failure
+   */
   async deactivateWorkflow(workflowId, userId) {
     try {
       const result = await this.sendMessage('DEACTIVATE_WORKFLOW', {
@@ -339,7 +365,7 @@ class WorkflowProcessBridge {
       return result;
     } catch (error) {
       console.error('Error deactivating workflow via IPC:', error);
-      return { error: error.message };
+      throw error;
     }
   }
 

--- a/backend/src/workflow/WorkflowProcessBridge.js
+++ b/backend/src/workflow/WorkflowProcessBridge.js
@@ -10,6 +10,51 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+/**
+ * The workflow process could not be reached, so nothing is known about the
+ * workflow itself.
+ *
+ * This is deliberately distinct from an error the child process *answered*
+ * with. `sendMessage` can fail two ways, and conflating them is what made a
+ * workflow failure undiagnosable:
+ *
+ *   - TRANSPORT: the child was never spawned, is not ready, failed to
+ *     initialise, or did not answer in time. We learned nothing. → this class.
+ *   - REPLY: the child answered `{ success: false, error }`. That message is a
+ *     real diagnosis of a real problem — e.g. "Workflow wf-1 cannot be
+ *     executed: node "n1" is missing "text"". → a plain Error carrying it.
+ *
+ * Callers that need to tell these apart should check `error.code`, not the
+ * message text.
+ */
+export class WorkflowProcessUnavailableError extends Error {
+  /**
+   * @param {string} message
+   * @param {'not-spawned'|'not-ready'|'init-failed'|'timeout'} reason
+   */
+  constructor(message, reason) {
+    super(message);
+    this.name = 'WorkflowProcessUnavailableError';
+    this.code = 'WORKFLOW_PROCESS_UNAVAILABLE';
+    this.reason = reason;
+  }
+}
+
+/**
+ * True when the workflow process itself could not be reached.
+ *
+ * Kept as a predicate so callers never have to sniff message text — the route
+ * handler used to test `error.message.includes('not ready')`, which matched
+ * exactly one of the four transport failures and would silently stop matching
+ * if the wording changed.
+ *
+ * @param {unknown} error
+ * @returns {boolean}
+ */
+export function isWorkflowProcessUnavailable(error) {
+  return Boolean(error) && error.code === 'WORKFLOW_PROCESS_UNAVAILABLE';
+}
+
 class WorkflowProcessBridge {
   constructor() {
     this.workflowProcess = null;
@@ -214,17 +259,21 @@ class WorkflowProcessBridge {
       try {
         await this.readyPromise;
       } catch (error) {
-        return Promise.reject(new Error('Workflow process failed to initialize'));
+        return Promise.reject(
+          new WorkflowProcessUnavailableError('Workflow process failed to initialize', 'init-failed')
+        );
       }
     }
 
     return new Promise((resolve, reject) => {
       if (!this.workflowProcess) {
-        return reject(new Error('Workflow process is not available'));
+        return reject(
+          new WorkflowProcessUnavailableError('Workflow process is not available', 'not-spawned')
+        );
       }
 
       if (!this.isReady) {
-        return reject(new Error('Workflow process is not ready'));
+        return reject(new WorkflowProcessUnavailableError('Workflow process is not ready', 'not-ready'));
       }
 
       const id = ++this.messageId;
@@ -238,7 +287,9 @@ class WorkflowProcessBridge {
       // Set up timeout
       const timeoutId = setTimeout(() => {
         this.messageHandlers.delete(id);
-        reject(new Error(`Message ${type} timed out after ${timeout}ms`));
+        reject(
+          new WorkflowProcessUnavailableError(`Message ${type} timed out after ${timeout}ms`, 'timeout')
+        );
       }, timeout);
 
       // Store handler
@@ -285,6 +336,31 @@ class WorkflowProcessBridge {
     }
   }
 
+  /**
+   * Ask the workflow process for a workflow's live state.
+   *
+   * Throws rather than reporting a state it does not know.
+   *
+   * This used to `return { status: 'error', error: error.message }`, which was
+   * wrong twice over. `'error'` is a REAL workflow status — ProcessWorker sets
+   * it on a workflow whose engine failed, and ProcessManager reads it back out
+   * of the database — so "I could not reach the workflow process" and "this
+   * workflow failed" were reported with the identical value, and no caller
+   * could tell them apart. Callers testing
+   * `['running','listening','queued'].includes(status)` then quietly took the
+   * not-active branch on what was really an infrastructure failure.
+   *
+   * It also discarded the child's own diagnosis. When the child answers
+   * `{ success: false, error }` that message names the actual fault — e.g.
+   * `Workflow wf-1 cannot be executed: node "n1" is missing "text"` — and it
+   * was replaced by the single word `error` before any caller saw it.
+   *
+   * Log-and-rethrow matches restartActiveWorkflows below. All three callers
+   * already sit inside a try/catch.
+   *
+   * @throws {WorkflowProcessUnavailableError} the process could not be reached
+   * @throws {Error} the process answered, reporting this failure
+   */
   async fetchWorkflowState(workflowId, userId) {
     try {
       const result = await this.sendMessage('FETCH_WORKFLOW_STATE', {
@@ -294,7 +370,7 @@ class WorkflowProcessBridge {
       return result;
     } catch (error) {
       console.error('Error fetching workflow state via IPC:', error);
-      return { status: 'error', error: error.message };
+      throw error;
     }
   }
 

--- a/backend/src/workflow/WorkflowProcessBridge.js
+++ b/backend/src/workflow/WorkflowProcessBridge.js
@@ -31,9 +31,14 @@ export class WorkflowProcessUnavailableError extends Error {
   /**
    * @param {string} message
    * @param {'not-spawned'|'not-ready'|'init-failed'|'timeout'} reason
+   * @param {{ cause?: unknown }} [options] underlying error, where one exists
    */
-  constructor(message, reason) {
-    super(message);
+  constructor(message, reason, options = {}) {
+    // Keep the original failure attached. Three of the four reasons are
+    // synthesised from a state check and have no cause, but 'init-failed'
+    // wraps a real error — and dropping it would repeat the mistake this
+    // whole change exists to fix.
+    super(message, 'cause' in options ? { cause: options.cause } : undefined);
     this.name = 'WorkflowProcessUnavailableError';
     this.code = 'WORKFLOW_PROCESS_UNAVAILABLE';
     this.reason = reason;
@@ -260,7 +265,9 @@ class WorkflowProcessBridge {
         await this.readyPromise;
       } catch (error) {
         return Promise.reject(
-          new WorkflowProcessUnavailableError('Workflow process failed to initialize', 'init-failed')
+          new WorkflowProcessUnavailableError('Workflow process failed to initialize', 'init-failed', {
+            cause: error,
+          })
         );
       }
     }

--- a/backend/src/workflow/WorkflowProcessBridge.startStop.test.js
+++ b/backend/src/workflow/WorkflowProcessBridge.startStop.test.js
@@ -1,0 +1,221 @@
+import { EventEmitter } from 'events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A start that did not happen must not be reported as one.
+ *
+ * `activateWorkflow` and `deactivateWorkflow` used to answer every IPC failure
+ * with `return { error: error.message }`. The route handler passes the result
+ * straight to `res.json(result)`, and `res.json` with no status is 200 — so a
+ * failed start answered SUCCESS with an error-shaped body.
+ *
+ * Every caller gates on the status code, not the body:
+ *
+ *   WorkflowEngine.vue:268   if (!response.ok) throw ...
+ *   Workflows.vue:910,933    if (!response.ok) throw ...
+ *   agnt.js SDK              axios, which rejects on non-2xx
+ *
+ * `response.ok` was true, so none of those failure branches ran. The UI said
+ * the workflow started. Nothing was armed, no trigger was listening, and the
+ * only trace was a console.error in the backend log.
+ *
+ * This is the same defect fixed for fetchWorkflowState, in a worse place: that
+ * one corrupted a status read, these corrupt the Start and Stop buttons.
+ */
+
+const { forkMock } = vi.hoisted(() => ({ forkMock: vi.fn() }));
+vi.mock('child_process', () => ({ fork: forkMock, default: { fork: forkMock } }));
+vi.mock('../services/auth/sessionTokenCache.js', () => ({
+  subscribe: vi.fn(() => () => {}),
+  getSessionToken: vi.fn(() => null),
+  getSessionUserId: vi.fn(() => null),
+}));
+
+let children = [];
+
+function makeChild() {
+  const child = new EventEmitter();
+  child.pid = 2000 + children.length;
+  child.killed = false;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+  });
+  child.send = vi.fn();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  return child;
+}
+
+async function freshModule() {
+  vi.resetModules();
+  return import('./WorkflowProcessBridge.js');
+}
+
+async function spawnReady(bridge) {
+  await bridge.spawn();
+  return children[children.length - 1];
+}
+
+/** Put the bridge in the state it holds when no child was ever forked. */
+function makeUnreachable(bridge) {
+  bridge.workflowProcess = null;
+  bridge.readyPromise = null;
+  bridge.isReady = false;
+}
+
+const workflow = { id: 'wf-1', nodes: [], edges: [] };
+
+beforeEach(() => {
+  children = [];
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  forkMock.mockImplementation(() => {
+    const child = makeChild();
+    children.push(child);
+    queueMicrotask(() => child.emit('message', { type: 'READY' }));
+    return child;
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  forkMock.mockReset();
+});
+
+describe('activateWorkflow', () => {
+  it('returns what the child reported when the start succeeds', async () => {
+    const { default: bridge } = await freshModule();
+    const child = await spawnReady(bridge);
+
+    child.send.mockImplementation((message) => {
+      queueMicrotask(() =>
+        child.emit('message', {
+          id: message.id,
+          success: true,
+          data: { message: 'Workflow queued for execution', workflowId: 'wf-1' },
+        })
+      );
+    });
+
+    await expect(bridge.activateWorkflow(workflow, 'user-1')).resolves.toEqual({
+      message: 'Workflow queued for execution',
+      workflowId: 'wf-1',
+    });
+  });
+
+  it('throws instead of resolving with { error } when the process is unreachable', async () => {
+    const { default: bridge, WorkflowProcessUnavailableError } = await freshModule();
+    makeUnreachable(bridge);
+
+    // The regression. This used to RESOLVE, so the caller saw a truthy result
+    // and answered 200.
+    const outcome = await bridge.activateWorkflow(workflow, 'user-1').then(
+      (value) => ({ resolved: value }),
+      (error) => ({ rejected: error })
+    );
+
+    expect(outcome.resolved).toBeUndefined();
+    expect(outcome.rejected).toBeInstanceOf(WorkflowProcessUnavailableError);
+    expect(outcome.rejected.reason).toBe('not-spawned');
+  });
+
+  it('preserves the diagnosis when the child reports a failure', async () => {
+    const { default: bridge, WorkflowProcessUnavailableError } = await freshModule();
+    const child = await spawnReady(bridge);
+
+    const diagnosis = 'Workflow wf-1 cannot be executed:\n  - node "n1" is missing "text"';
+    child.send.mockImplementation((message) => {
+      queueMicrotask(() =>
+        child.emit('message', { id: message.id, success: false, error: diagnosis })
+      );
+    });
+
+    const error = await bridge.activateWorkflow(workflow, 'user-1').catch((e) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(WorkflowProcessUnavailableError);
+    expect(error.message).toBe(diagnosis);
+  });
+
+  it('still logs before rethrowing', async () => {
+    const { default: bridge } = await freshModule();
+    makeUnreachable(bridge);
+
+    await bridge.activateWorkflow(workflow, 'user-1').catch(() => {});
+
+    expect(console.error).toHaveBeenCalledWith(
+      'Error activating workflow via IPC:',
+      expect.any(Error)
+    );
+  });
+});
+
+describe('deactivateWorkflow', () => {
+  it('returns what the child reported when the stop succeeds', async () => {
+    const { default: bridge } = await freshModule();
+    const child = await spawnReady(bridge);
+
+    child.send.mockImplementation((message) => {
+      queueMicrotask(() =>
+        child.emit('message', {
+          id: message.id,
+          success: true,
+          data: { message: 'Workflow stopped', isActive: false },
+        })
+      );
+    });
+
+    await expect(bridge.deactivateWorkflow('wf-1', 'user-1')).resolves.toEqual({
+      message: 'Workflow stopped',
+      isActive: false,
+    });
+  });
+
+  it('throws instead of resolving with { error } when the process is unreachable', async () => {
+    const { default: bridge, WorkflowProcessUnavailableError } = await freshModule();
+    makeUnreachable(bridge);
+
+    const outcome = await bridge.deactivateWorkflow('wf-1', 'user-1').then(
+      (value) => ({ resolved: value }),
+      (error) => ({ rejected: error })
+    );
+
+    expect(outcome.resolved).toBeUndefined();
+    expect(outcome.rejected).toBeInstanceOf(WorkflowProcessUnavailableError);
+  });
+
+  it('still logs before rethrowing', async () => {
+    const { default: bridge } = await freshModule();
+    makeUnreachable(bridge);
+
+    await bridge.deactivateWorkflow('wf-1', 'user-1').catch(() => {});
+
+    expect(console.error).toHaveBeenCalledWith(
+      'Error deactivating workflow via IPC:',
+      expect.any(Error)
+    );
+  });
+});
+
+describe('all three IPC methods now agree', () => {
+  it('none of them resolves on an unreachable process', async () => {
+    // fetchWorkflowState was fixed first; these two were left behind, so the
+    // class reported the same failure two different ways depending on which
+    // method you called.
+    const { default: bridge } = await freshModule();
+    makeUnreachable(bridge);
+
+    const outcomes = await Promise.all(
+      [
+        bridge.activateWorkflow(workflow, 'user-1'),
+        bridge.deactivateWorkflow('wf-1', 'user-1'),
+        bridge.fetchWorkflowState('wf-1', 'user-1'),
+      ].map((p) => p.then(() => 'resolved', () => 'rejected'))
+    );
+
+    expect(outcomes).toEqual(['rejected', 'rejected', 'rejected']);
+  });
+});

--- a/backend/src/workflow/WorkflowProcessBridge.unavailable.test.js
+++ b/backend/src/workflow/WorkflowProcessBridge.unavailable.test.js
@@ -1,0 +1,248 @@
+import { EventEmitter } from 'events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * An unreachable workflow process must not be reported as a workflow state.
+ *
+ * `fetchWorkflowState` used to answer every IPC failure with
+ * `{ status: 'error', error: error.message }`. That is wrong twice:
+ *
+ *   1. `'error'` is a REAL workflow status — ProcessWorker sets it on a
+ *      workflow whose engine failed, and ProcessManager reads it back out of
+ *      the database. So "I could not reach the workflow process" and "this
+ *      workflow failed" arrived as the same value, and no caller could tell
+ *      them apart.
+ *   2. When the child answers `{ success: false, error }`, that message is a
+ *      real diagnosis — e.g. `Workflow wf-1 cannot be executed: node "n1" is
+ *      missing "text"`. It was replaced by the word `error` before any caller
+ *      saw it, which is precisely why such failures were undiagnosable from
+ *      the API.
+ *
+ * These tests pin the distinction: TRANSPORT failures throw
+ * WorkflowProcessUnavailableError; a failure the child REPORTED throws a plain
+ * Error still carrying the child's message.
+ */
+
+const { forkMock } = vi.hoisted(() => ({ forkMock: vi.fn() }));
+vi.mock('child_process', () => ({ fork: forkMock, default: { fork: forkMock } }));
+vi.mock('../services/auth/sessionTokenCache.js', () => ({
+  subscribe: vi.fn(() => () => {}),
+  getSessionToken: vi.fn(() => null),
+  getSessionUserId: vi.fn(() => null),
+}));
+
+let children = [];
+
+/** A child that acknowledges nothing unless a test tells it to. */
+function makeChild() {
+  const child = new EventEmitter();
+  child.pid = 1000 + children.length;
+  child.killed = false;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+  });
+  child.send = vi.fn();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  return child;
+}
+
+async function freshModule() {
+  vi.resetModules();
+  return import('./WorkflowProcessBridge.js');
+}
+
+/** Spawn a child and drive it to READY. */
+async function spawnReady(bridge) {
+  const p = bridge.spawn();
+  await p;
+  return children[children.length - 1];
+}
+
+beforeEach(() => {
+  children = [];
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  forkMock.mockImplementation(() => {
+    const child = makeChild();
+    children.push(child);
+    queueMicrotask(() => child.emit('message', { type: 'READY' }));
+    return child;
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  forkMock.mockReset();
+});
+
+describe('transport failures are typed and named', () => {
+  it('rejects with WorkflowProcessUnavailableError when nothing was ever spawned', async () => {
+    const { default: bridge, WorkflowProcessUnavailableError } = await freshModule();
+
+    // The branch under test is `if (!this.workflowProcess)`; this is that state.
+    bridge.workflowProcess = null;
+    bridge.readyPromise = null;
+    bridge.isReady = false;
+
+    const error = await bridge.sendMessage('FETCH_WORKFLOW_STATE', {}).catch((e) => e);
+
+    expect(error).toBeInstanceOf(WorkflowProcessUnavailableError);
+    expect(error.code).toBe('WORKFLOW_PROCESS_UNAVAILABLE');
+    expect(error.reason).toBe('not-spawned');
+  });
+
+  it('rejects with reason "not-ready" when the child exists but has not reported READY', async () => {
+    const { default: bridge, WorkflowProcessUnavailableError } = await freshModule();
+
+    // The state after a child dies: the process object is still installed but
+    // the exit handler has cleared isReady.
+    bridge.workflowProcess = makeChild();
+    bridge.readyPromise = null;
+    bridge.isReady = false;
+
+    const error = await bridge.sendMessage('FETCH_WORKFLOW_STATE', {}).catch((e) => e);
+
+    expect(error).toBeInstanceOf(WorkflowProcessUnavailableError);
+    expect(error.reason).toBe('not-ready');
+  });
+
+  it('rejects with reason "init-failed" when the ready promise rejected', async () => {
+    const { default: bridge, WorkflowProcessUnavailableError } = await freshModule();
+
+    bridge.isReady = false;
+    bridge.readyPromise = Promise.reject(new Error('spawn blew up'));
+    // Keep the rejection from tripping the unhandled-rejection detector before
+    // sendMessage awaits it.
+    bridge.readyPromise.catch(() => {});
+
+    const error = await bridge.sendMessage('FETCH_WORKFLOW_STATE', {}).catch((e) => e);
+
+    expect(error).toBeInstanceOf(WorkflowProcessUnavailableError);
+    expect(error.reason).toBe('init-failed');
+  });
+
+  it('rejects with reason "timeout" when the child never answers', async () => {
+    vi.useFakeTimers();
+    const { default: bridge, WorkflowProcessUnavailableError } = await freshModule();
+    await spawnReady(bridge);
+
+    // child.send is a no-op mock, so no reply ever arrives.
+    const pending = bridge.sendMessage('FETCH_WORKFLOW_STATE', {}, 5000).catch((e) => e);
+    await vi.advanceTimersByTimeAsync(5001);
+    const error = await pending;
+
+    expect(error).toBeInstanceOf(WorkflowProcessUnavailableError);
+    expect(error.reason).toBe('timeout');
+    expect(error.message).toContain('timed out');
+  });
+});
+
+describe('a failure the child REPORTED is not a transport failure', () => {
+  it('rejects with a plain Error that still carries the child\'s diagnosis', async () => {
+    const { default: bridge, WorkflowProcessUnavailableError, isWorkflowProcessUnavailable } =
+      await freshModule();
+    const child = await spawnReady(bridge);
+
+    const diagnosis = 'Workflow wf-1 cannot be executed:\n  - node "n1" is missing "text"';
+    child.send.mockImplementation((message) => {
+      queueMicrotask(() =>
+        child.emit('message', { id: message.id, success: false, error: diagnosis })
+      );
+    });
+
+    const error = await bridge.fetchWorkflowState('wf-1', 'user-1').catch((e) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    // The whole point: this must NOT be mistaken for an unreachable process.
+    expect(error).not.toBeInstanceOf(WorkflowProcessUnavailableError);
+    expect(isWorkflowProcessUnavailable(error)).toBe(false);
+    // And the message survives all the way out, instead of becoming 'error'.
+    expect(error.message).toBe(diagnosis);
+  });
+});
+
+describe('fetchWorkflowState', () => {
+  it('returns the state the child reported', async () => {
+    const { default: bridge } = await freshModule();
+    const child = await spawnReady(bridge);
+
+    child.send.mockImplementation((message) => {
+      queueMicrotask(() =>
+        child.emit('message', {
+          id: message.id,
+          success: true,
+          data: { status: 'listening', outputs: { n1: 1 }, errors: {} },
+        })
+      );
+    });
+
+    await expect(bridge.fetchWorkflowState('wf-1', 'user-1')).resolves.toEqual({
+      status: 'listening',
+      outputs: { n1: 1 },
+      errors: {},
+    });
+  });
+
+  it('throws instead of returning { status: "error" } when the process is unreachable', async () => {
+    const { default: bridge, WorkflowProcessUnavailableError } = await freshModule();
+
+    bridge.workflowProcess = null;
+    bridge.readyPromise = null;
+    bridge.isReady = false;
+
+    // The regression. This used to RESOLVE with { status: 'error' }, which is
+    // indistinguishable from a workflow whose engine genuinely failed.
+    const result = await bridge.fetchWorkflowState('wf-1', 'user-1').then(
+      (value) => ({ resolved: value }),
+      (error) => ({ rejected: error })
+    );
+
+    expect(result.resolved).toBeUndefined();
+    expect(result.rejected).toBeInstanceOf(WorkflowProcessUnavailableError);
+  });
+
+  it('still logs the failure before rethrowing', async () => {
+    const { default: bridge } = await freshModule();
+    bridge.workflowProcess = null;
+    bridge.readyPromise = null;
+    bridge.isReady = false;
+
+    await bridge.fetchWorkflowState('wf-1', 'user-1').catch(() => {});
+
+    expect(console.error).toHaveBeenCalledWith(
+      'Error fetching workflow state via IPC:',
+      expect.any(Error)
+    );
+  });
+});
+
+describe('isWorkflowProcessUnavailable', () => {
+  it('recognises the typed error', async () => {
+    const { WorkflowProcessUnavailableError, isWorkflowProcessUnavailable } = await freshModule();
+    expect(isWorkflowProcessUnavailable(new WorkflowProcessUnavailableError('x', 'timeout'))).toBe(
+      true
+    );
+  });
+
+  it.each([
+    ['a plain Error', new Error('boom')],
+    ['null', null],
+    ['undefined', undefined],
+  ])('does not misclassify %s', async (_label, value) => {
+    const { isWorkflowProcessUnavailable } = await freshModule();
+    expect(isWorkflowProcessUnavailable(value)).toBe(false);
+  });
+
+  it('matches on code rather than message text', async () => {
+    // The route handler previously tested error.message.includes('not ready'),
+    // which matched one of four transport failures and would break on a reword.
+    const { isWorkflowProcessUnavailable } = await freshModule();
+    const reworded = new Error('the workflow process is still warming up');
+    reworded.code = 'WORKFLOW_PROCESS_UNAVAILABLE';
+    expect(isWorkflowProcessUnavailable(reworded)).toBe(true);
+  });
+});

--- a/backend/src/workflow/WorkflowProcessBridge.unavailable.test.js
+++ b/backend/src/workflow/WorkflowProcessBridge.unavailable.test.js
@@ -123,6 +123,17 @@ describe('transport failures are typed and named', () => {
 
     expect(error).toBeInstanceOf(WorkflowProcessUnavailableError);
     expect(error.reason).toBe('init-failed');
+    // The reason this whole change exists: do not drop the underlying error.
+    expect(error.cause).toBeInstanceOf(Error);
+    expect(error.cause.message).toBe('spawn blew up');
+  });
+
+  it('leaves cause undefined for the reasons that have no underlying error', async () => {
+    const { WorkflowProcessUnavailableError } = await freshModule();
+    const synthesised = new WorkflowProcessUnavailableError('Workflow process is not ready', 'not-ready');
+
+    expect(synthesised.cause).toBeUndefined();
+    expect('cause' in synthesised).toBe(false);
   });
 
   it('rejects with reason "timeout" when the child never answers', async () => {


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #71 — merge that first.**
>
> This branch is cut from #71, so the diff shows its two commits as well. Only **`835367f9`** belongs to this PR. Once #71 lands, this reduces to that single commit; if #71 is revised, I will rebase.
>
> It depends on the `WorkflowProcessUnavailableError` class and the `isWorkflowProcessUnavailable` predicate introduced there. Building it on `main` would have meant inventing both twice.

## What

`activateWorkflow` and `deactivateWorkflow` answered every IPC failure with `return { error: error.message }`. The route handlers pass the result straight to `res.json(result)` — and `res.json` with no status is **200**.

So a start that never happened answered **success**, with an error-shaped body.

## Why it mattered

Every caller gates on the status code, not the body:

| caller | check |
|---|---|
| `WorkflowEngine.vue:268` | `if (!response.ok) throw` |
| `Workflows.vue:910,933` | `if (!response.ok) throw` |
| `agnt.js` SDK | axios — rejects on non-2xx |

`response.ok` was **true**, so none of those failure branches ran. The UI reported the workflow started. Nothing was armed, no trigger was listening, and the only trace was a `console.error` in the backend log.

This is the same defect #71 fixed for `fetchWorkflowState`, in a worse place. That one corrupted a **status read**. These corrupt the **Start and Stop buttons** — the two actions where "did it work?" is the entire question.

## How

- **Both bridge methods log and rethrow**, matching `fetchWorkflowState` and `restartActiveWorkflows` in the same class. All three IPC methods now report an unreachable process the same way — a test asserts exactly that, since the class previously answered the same failure two different ways depending on which method you called.
- **Both route handlers** answer **503** with the `reason` when the process cannot be reached, and **500** carrying the child's diagnosis when the process answered with a failure. Identical shape to #71's `/status` handler.
- **`deleteWorkflow` isolates its deactivate call.** It runs *before* the row delete, so letting the new throw escape would have made a workflow **undeletable** while the workflow process was down. The row goes either way, exactly as before — what changes is that the reason is logged rather than discarded.

## It also resurrects dead code

The retry around the post-save reactivate has never been able to fire:

```js
try {
  await WorkflowProcessBridge.activateWorkflow(updatedWorkflow, userId);
} catch (reactivateError) {                    // ← unreachable: activate never threw
  console.error('Failed to reactivate workflow after save:', reactivateError.message);
  try {
    await WorkflowProcessBridge.activateWorkflow(updatedWorkflow, userId);
  } catch (restoreError) {                     // ← also unreachable
    console.error('Could not restore workflow active state:', restoreError.message);
  }
}
```

Same pattern as the `not ready` branch found in #71 — handling written for an error that structurally could not arrive. Both are live now, and covered by tests.

Worth noting the interaction with #71: when the process is *unreachable*, `fetchWorkflowState` now throws first and the outer catch skips the restart check entirely, so these retries are only reached when the process is up and genuinely refused. No added latency against a down process.

## Testing

**26 tests across 3 files. 12 fail without this change.**

The third file is the one that matters most. The other two test each half in isolation — the bridge throws, the handler maps a throw to 503/500 — but **neither reproduces the actual defect, which only existed where the halves met**:

```
bridge swallows -> returns { error: message } -> res.json(result) -> 200
```

A route test with a mocked bridge cannot see that, and a bridge test has no `res` to inspect. So `WorkflowService.startStopIntegration.test.js` mocks the models, database and realtime layer and deliberately leaves **`WorkflowProcessBridge` real**. Against the base commit it fails with:

```
AssertionError: expected 200 not to be 200
AssertionError: expected true to be false      ← error-shaped body with a success status
```

**Mutation tested — 8 mutants, 8 killed, 0 survived:**

| mutant | result |
|---|---|
| restore the activate swallow | killed (6) |
| restore the deactivate swallow | killed (3) |
| drop the 503 branch on start | killed (3) |
| drop the 503 branch on stop | killed (2) |
| let the delete deactivate failure escape | killed (3) |
| stop logging why the delete could not confirm | killed (1) |
| stop forwarding the diagnosis on a start failure | killed (1) |
| drop `reason` from the 503 body | killed (2) |

Full backend suite: **295 passed / 295 files, zero failures.** (The `UpdateScheduler.status` flake noted on #70 and #71 did not fire on this run — further evidence it is order-dependent rather than caused by any of these changes.)

## Notes for the reviewer

- **This is a behaviour change at the API boundary.** `POST /workflows/:id/start` and `/stop` can now answer 503 or 500 where they previously answered 200. That is the point — those 200s were false — but it deserves a deliberate nod. All three known callers already handle non-2xx correctly, so no client change is needed.
- **A product question I deliberately did not decide:** should deleting a workflow *fail* when its triggers cannot be confirmed stopped? Today it proceeds, and I preserved that. The argument for failing is orphaned live triggers; the argument against is a workflow you cannot remove while the process is down. Worth a separate discussion rather than a silent change here.
- `activateWorkflow` is also called from the two restart paths in `saveWorkflow`/`updateWorkflow`. Both already sat inside `try/catch`, so their control flow is unchanged — only their error messages improve.
