### PR TITLE
test(plugins): the update-status test raced the millisecond clock

### DIFF
--- a/backend/src/plugins/UpdateScheduler.status.test.js
+++ b/backend/src/plugins/UpdateScheduler.status.test.js
@@ -24,7 +24,7 @@
  * real code path with no filesystem beyond a temp dir and no network at all.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
@@ -67,6 +67,9 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  // Only one test fakes the clock, but restoring it here means a failure inside
+  // that test cannot leak a frozen Date into everything that follows.
+  vi.useRealTimers();
   await fs.rm(TMP, { recursive: true, force: true });
 });
 
@@ -287,6 +290,20 @@ describe('UpdateScheduler.getStatus', () => {
   });
 
   it('replaces the previous pass rather than accumulating', async () => {
+    // The clock is faked because `checkedAt` is
+    // `new Date().toISOString()` — millisecond resolution. The two ticks below
+    // run back to back with nothing slow between them, so on a fast machine
+    // both land in the SAME millisecond and the timestamps come out identical.
+    // The old assertion was `not.toBe`, which therefore passed only when
+    // something happened to be slow enough, and failed intermittently in CI
+    // while passing in isolation.
+    //
+    // Faking Date alone — not setTimeout/setInterval — keeps the scheduler's
+    // real async filesystem work untouched; there is nothing here to advance.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    const firstPassAt = new Date('2026-01-01T00:00:00.000Z');
+    const secondPassAt = new Date('2026-01-01T06:00:00.000Z');
+
     const installer = stubInstaller({
       registry: { plugins: [{ name: 'weather' }] },
       updates: [{ name: 'weather', installed: '1.0.0', latest: '1.4.0', updateAvailable: true }],
@@ -295,16 +312,23 @@ describe('UpdateScheduler.getStatus', () => {
     await installer._writeRegistry();
     const scheduler = makeScheduler(installer);
 
+    vi.setSystemTime(firstPassAt);
     await scheduler.tick();
     const first = await scheduler.getStatus();
 
     installer.checkForUpdates = async () => ({ success: true, updates: [] });
+    vi.setSystemTime(secondPassAt);
     await scheduler.tick();
     const second = await scheduler.getStatus();
 
     expect(second.autoUpdated).toEqual([]);
     expect(second.updatesAvailable).toBe(0);
-    expect(second.checkedAt).not.toBe(first.checkedAt);
+
+    // Now that the clock is controlled this can assert the exact values rather
+    // than merely that they differ — which also pins the direction, so a
+    // summary that carried the OLD timestamp forward fails here too.
+    expect(first.checkedAt).toBe(firstPassAt.toISOString());
+    expect(second.checkedAt).toBe(secondPassAt.toISOString());
   });
 });
 


### PR DESCRIPTION
`backend/src/plugins/UpdateScheduler.status.test.js > replaces the previous pass rather than accumulating` has been intermittently red on `main` and on every PR opened today. This is the cause and the fix.

Standalone and independent — one test file, no production code, no overlap with #70, #71, #72 or #73.

## The race

`UpdateScheduler.tick()` stamps its summary with a millisecond-resolution timestamp:

```js
// UpdateScheduler.js:161
const summary = { checkedAt: new Date().toISOString(), ... };
```

The test runs two ticks back to back with nothing slow between them, and asserted only that the two timestamps **differ**:

```js
await scheduler.tick();   const first  = await scheduler.getStatus();
await scheduler.tick();   const second = await scheduler.getStatus();

expect(second.checkedAt).not.toBe(first.checkedAt);
```

When both ticks start inside the same millisecond, the timestamps are identical:

```
AssertionError: expected '2026-08-22T11:43:29.404Z' not to be '2026-08-22T11:43:29.404Z'
```

**On this machine the unmodified test fails 23 times out of 30 runs.** It passes only when something happens to be slow enough between the two ticks.

The failure message is the part that makes this worth fixing rather than tolerating: it names no clock and reads like a logic bug in the scheduler, so anyone who hits it starts by investigating `UpdateScheduler` — which is fine.

## The fix

Fake `Date` for that one test and stamp the two passes six hours apart.

- **Only `Date` is faked**, not `setTimeout`/`setInterval`, so the scheduler's real async filesystem work is untouched and there is nothing to advance. `useFakeTimers` is already used in four other backend suites (`rateLimit`, `remoteTokenVerifier`, and both `WorkflowProcessBridge` suites), so this is house style.
- **The assertion gets stronger, not merely stable.** With a controlled clock it pins both exact values instead of just their inequality:

```js
expect(first.checkedAt).toBe(firstPassAt.toISOString());
expect(second.checkedAt).toBe(secondPassAt.toISOString());
```

That also catches a summary that carried the **old** timestamp forward, which `not.toBe` would have reported as a pass in the very case the test exists to detect.

- `afterEach` restores real timers, so a failure inside this test cannot leak a frozen clock into the rest of the file.

## Verification

| | result |
|---|---|
| unmodified test, 30 isolated runs | **23 failed** |
| fixed test, 15 consecutive runs | **0 failed** |
| full backend suite, run 1 | 290/290 |
| full backend suite, run 2 | 290/290 |

## Note

I previously described this as order-dependent, on the strength of a single isolated run that happened to pass. With a ~77% failure rate, one passing run is a 23% event — not evidence. Measuring it properly showed it fails in isolation too, and the real cause is the clock. Correcting that here so the record is right.
