### PR TITLE
fix(oauth): a provider connect must send the credential the remote authenticates

### DIFF
--- a/frontend/src/__guards__/oauthCredentialContract.spec.js
+++ b/frontend/src/__guards__/oauthCredentialContract.spec.js
@@ -1,0 +1,235 @@
+/**
+ * CONTRACT: a call to the remote auth host must carry the credential that host
+ * identifies the user by.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Connecting any OAuth provider failed at the last step with a raw database
+ * error in a user-facing dialog:
+ *
+ *     Failed to connect to Github: SQLITE_CONSTRAINT: NOT NULL constraint
+ *     failed: oauth_tokens.user_id
+ *
+ * The remote does not read the bearer token on /auth/connect and
+ * /auth/callback: those routes answer identically with a valid JWT, a
+ * malformed JWT, and no Authorization header at all. Its CORS reply echoes
+ * the specific origin and sets `access-control-allow-credentials: true`,
+ * which is the configuration a server uses when it expects cookie
+ * credentials. Sign-in already talks to that host that way
+ * (store/auth/userAuth.js passes withCredentials on every magic-link call),
+ * but the OAuth call sites did not -- so the one request that had to be
+ * attributed to a user carried nothing the remote reads, the token INSERT ran
+ * with user_id = NULL, and SQLite rejected the row.
+ *
+ * It was a *class* of bug rather than one mistake, for the same reason
+ * apiAuthContract.spec.js exists: `connectOAuthApp` and the callback exchange
+ * are copy-pasted across six screens. Ten call sites, not the three a reader
+ * of the composable would find. A subset fix is worse than none -- it makes
+ * connecting work or fail depending on which screen the user clicked Connect
+ * from, which is far harder to report than a consistent failure.
+ *
+ * This derives the call sites from the source itself rather than a
+ * hand-maintained list, so a seventh copy cannot be added without either
+ * carrying the credential or failing here.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FRONTEND_SRC = path.resolve(HERE, '..');
+
+/**
+ * Remote auth paths that identify the caller. Every entry is a route observed
+ * to depend on the session, not on the bearer token.
+ */
+const CREDENTIALED_PATHS = ['/auth/connect/', '/auth/callback'];
+
+/**
+ * Call sites that intentionally omit credentials. Every entry needs a reason.
+ * The stale-entry test below fails if one stops being a violation, so dead
+ * exceptions cannot quietly accumulate.
+ */
+const INTENTIONALLY_ANONYMOUS = [
+  // e.g. { file: 'services/foo.js', line: 12, reason: 'pre-login bootstrap' }
+];
+
+// ---------------------------------------------------------------------------
+// Source walking
+// ---------------------------------------------------------------------------
+function walk(dir, out = []) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out; // Another spec's fixture dir may vanish mid-walk.
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // Vendored libraries are not ours to hold to this contract.
+      if (entry.name === 'libs' || entry.name === 'node_modules') continue;
+      walk(full, out);
+    } else if (/\.(vue|js)$/.test(entry.name) && !/\.spec\.js$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Index of the `(` that opens the call enclosing `from`, or -1.
+ *
+ * Walks backward counting depth so that a URL built with a nested call --
+ * `?origin=${encodeURIComponent(window.location.origin)}` -- resolves to the
+ * outer fetch/post rather than to encodeURIComponent.
+ */
+function openingParenBefore(text, from) {
+  let depth = 0;
+  for (let i = from; i >= 0; i--) {
+    const ch = text[i];
+    if (ch === ')') depth += 1;
+    else if (ch === '(') {
+      if (depth === 0) return i;
+      depth -= 1;
+    }
+  }
+  return -1;
+}
+
+/**
+ * The full source of the call starting at `openIdx`, paren-matched.
+ *
+ * Bounding to the call itself matters: a fixed-width slice bleeds into the
+ * NEXT call site in the same file and would report an uncredentialed call as
+ * credentialed because a later one nearby happens to carry the flag. That is
+ * a false negative, the only direction that matters for a guard.
+ */
+function callTextAt(text, openIdx) {
+  let depth = 0;
+  let quote = null;
+  for (let i = openIdx; i < text.length; i++) {
+    const ch = text[i];
+    if (quote) {
+      if (ch === '\\') i += 1;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      continue;
+    }
+    if (ch === '(') depth += 1;
+    else if (ch === ')') {
+      depth -= 1;
+      if (depth === 0) return text.slice(openIdx, i + 1);
+    }
+  }
+  return text.slice(openIdx); // unbalanced -- take the rest
+}
+
+/**
+ * Every call to a credentialed remote auth path in a source file, with a
+ * verdict on whether it sends credentials.
+ *
+ * Exported so the self-test below can exercise the detector on a fixture
+ * rather than trusting it.
+ */
+export function findRemoteAuthCalls(source, label = '<inline>') {
+  const calls = [];
+  const needle = '${API_CONFIG.REMOTE_URL}';
+
+  let at = source.indexOf(needle);
+  while (at !== -1) {
+    const rest = source.slice(at + needle.length, at + needle.length + 80);
+    const matchedPath = CREDENTIALED_PATHS.find((p) => rest.startsWith(p));
+    if (matchedPath) {
+      const open = openingParenBefore(source, at);
+      const call = open === -1 ? '' : callTextAt(source, open);
+      const sendsCredentials =
+        /credentials:\s*['"]include['"]/.test(call) || /withCredentials:\s*true/.test(call);
+      calls.push({
+        file: label,
+        line: source.slice(0, at).split(/\r?\n/).length,
+        path: matchedPath,
+        sendsCredentials,
+      });
+    }
+    at = source.indexOf(needle, at + needle.length);
+  }
+  return calls;
+}
+
+const ALL_CALLS = walk(FRONTEND_SRC).flatMap((file) =>
+  findRemoteAuthCalls(fs.readFileSync(file, 'utf8'), path.relative(FRONTEND_SRC, file))
+);
+
+const isAllowed = (call) =>
+  INTENTIONALLY_ANONYMOUS.some((entry) => entry.file === call.file && entry.line === call.line);
+
+describe('remote auth calls carry the credential the remote authenticates', () => {
+  it('finds the call sites at all, so a silent zero cannot pass', () => {
+    // If a refactor renames API_CONFIG.REMOTE_URL this guard would find
+    // nothing and vacuously pass. Assert it still sees the known duplication.
+    expect(ALL_CALLS.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('every /auth/connect and /auth/callback call sends credentials', () => {
+    const violations = ALL_CALLS.filter((c) => !c.sendsCredentials && !isAllowed(c));
+    expect(
+      violations.map((v) => `${v.file}:${v.line} -> ${v.path}`),
+      'these calls reach the remote auth host without the session credential, so the '
+        + 'remote cannot attribute them to a user and stores the token with user_id = NULL'
+    ).toEqual([]);
+  });
+
+  it('keeps the allowlist honest (no stale entries)', () => {
+    const stale = INTENTIONALLY_ANONYMOUS.filter(
+      (entry) =>
+        !ALL_CALLS.some((c) => c.file === entry.file && c.line === entry.line && !c.sendsCredentials)
+    );
+    expect(stale, 'allowlisted call sites that are no longer violations').toEqual([]);
+  });
+
+  it('detects a call that omits credentials (self-test)', () => {
+    const fixture = `
+      const response = await fetch(\`\${API_CONFIG.REMOTE_URL}/auth/connect/\${app.id}?origin=\${encodeURIComponent(window.location.origin)}\`, {
+        headers: { Authorization: \`Bearer \${token}\` },
+      });
+    `;
+    const found = findRemoteAuthCalls(fixture, 'fixture.js');
+    expect(found).toHaveLength(1);
+    expect(found[0].sendsCredentials).toBe(false);
+  });
+
+  it('accepts fetch credentials and axios withCredentials alike (self-test)', () => {
+    const withFetch = `
+      await fetch(\`\${API_CONFIG.REMOTE_URL}/auth/callback\`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+      });
+    `;
+    const withAxios = `
+      axios.post(
+        \`\${API_CONFIG.REMOTE_URL}/auth/callback\`,
+        { code, state },
+        { withCredentials: true, headers: { 'Content-Type': 'application/json' } },
+      );
+    `;
+    expect(findRemoteAuthCalls(withFetch, 'a.js')[0].sendsCredentials).toBe(true);
+    expect(findRemoteAuthCalls(withAxios, 'b.js')[0].sendsCredentials).toBe(true);
+  });
+
+  it('does not let a neighbouring call vouch for an uncredentialed one (self-test)', () => {
+    // The failure mode a fixed-width window would produce: the second call
+    // borrows the first call's flag and the guard reports all clear.
+    const fixture = `
+      await fetch(\`\${API_CONFIG.REMOTE_URL}/auth/callback\`, { credentials: 'include' });
+      await fetch(\`\${API_CONFIG.REMOTE_URL}/auth/connect/\${id}\`, { headers: {} });
+    `;
+    const found = findRemoteAuthCalls(fixture, 'c.js');
+    expect(found.map((f) => f.sendsCredentials)).toEqual([true, false]);
+  });
+});

--- a/frontend/src/__guards__/oauthCredentialContract.spec.js
+++ b/frontend/src/__guards__/oauthCredentialContract.spec.js
@@ -130,6 +130,62 @@ function callTextAt(text, openIdx) {
 }
 
 /**
+ * `text` with comments blanked out, so that a commented-out flag cannot
+ * satisfy the contract.
+ *
+ * Without this, `// credentials: 'include',` left behind by someone debugging
+ * reads as compliant and the guard waves through a real violation -- a false
+ * negative, which is the failure this whole file exists to prevent.
+ *
+ * It has to be string-aware rather than a `//.*$` sweep: these call sites are
+ * built around URLs, and a naive strip turns
+ * `'github:http://localhost:3333'` into `'github:http:` -- corrupting the
+ * source it is meant to be reading, and deleting any flag that sits after a
+ * URL on the same line. That direction is a false POSITIVE, which is how a
+ * guard loses the room's trust.
+ *
+ * Known limit: a regex literal containing `//` would confuse it. None of
+ * these call sites contain one, and the assertion below would fail loudly
+ * rather than silently pass if that changed.
+ */
+function stripComments(text) {
+  let out = '';
+  let quote = null;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (quote) {
+      out += ch;
+      if (ch === '\\') {
+        out += next ?? '';
+        i += 1;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      out += ch;
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      while (i < text.length && text[i] !== '\n') i += 1;
+      out += '\n';
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      i += 2;
+      while (i < text.length && !(text[i] === '*' && text[i + 1] === '/')) i += 1;
+      i += 1;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+/**
  * Every call to a credentialed remote auth path in a source file, with a
  * verdict on whether it sends credentials.
  *
@@ -146,7 +202,7 @@ export function findRemoteAuthCalls(source, label = '<inline>') {
     const matchedPath = CREDENTIALED_PATHS.find((p) => rest.startsWith(p));
     if (matchedPath) {
       const open = openingParenBefore(source, at);
-      const call = open === -1 ? '' : callTextAt(source, open);
+      const call = open === -1 ? '' : stripComments(callTextAt(source, open));
       const sendsCredentials =
         /credentials:\s*['"]include['"]/.test(call) || /withCredentials:\s*true/.test(call);
       calls.push({
@@ -220,6 +276,42 @@ describe('remote auth calls carry the credential the remote authenticates', () =
     `;
     expect(findRemoteAuthCalls(withFetch, 'a.js')[0].sendsCredentials).toBe(true);
     expect(findRemoteAuthCalls(withAxios, 'b.js')[0].sendsCredentials).toBe(true);
+  });
+
+  it('does not accept a commented-out credential (self-test)', () => {
+    // Reported by Copilot on this PR, and confirmed: before stripComments the
+    // detector matched the flag inside a comment and reported compliance.
+    const fixture = `
+      await fetch(\`\${API_CONFIG.REMOTE_URL}/auth/connect/\${id}\`, {
+        // credentials: 'include',  <- disabled while debugging
+        headers: { Authorization: \`Bearer \${token}\` },
+      });
+    `;
+    const found = findRemoteAuthCalls(fixture, 'd.js');
+    expect(found).toHaveLength(1);
+    expect(found[0].sendsCredentials).toBe(false);
+  });
+
+  it('does not accept a block-commented credential either (self-test)', () => {
+    const fixture = `
+      await fetch(\`\${API_CONFIG.REMOTE_URL}/auth/callback\`, {
+        /* credentials: 'include', */
+        headers: {},
+      });
+    `;
+    expect(findRemoteAuthCalls(fixture, 'e.js')[0].sendsCredentials).toBe(false);
+  });
+
+  it('is not fooled by a URL inside a string (self-test)', () => {
+    // The other direction: a `//.*$` sweep truncates the state string and can
+    // delete a real flag, failing a call site that is perfectly correct.
+    const fixture = `
+      await fetch(\`\${API_CONFIG.REMOTE_URL}/auth/callback\`, {
+        credentials: 'include',
+        body: JSON.stringify({ state: 'github:http://localhost:3333' }),
+      });
+    `;
+    expect(findRemoteAuthCalls(fixture, 'f.js')[0].sendsCredentials).toBe(true);
   });
 
   it('does not let a neighbouring call vouch for an uncredentialed one (self-test)', () => {

--- a/frontend/src/components/OnboardingModal.vue
+++ b/frontend/src/components/OnboardingModal.vue
@@ -588,6 +588,8 @@ export default {
         const token = localStorage.getItem('token');
         // Pass origin as query parameter for reliable Electron support
         const response = await fetch(`${API_CONFIG.REMOTE_URL}/auth/connect/${provider.id}?origin=${encodeURIComponent(window.location.origin)}`, {
+          // Identity on the remote auth routes rides a session cookie.
+          credentials: 'include',
           headers: {
             Authorization: `Bearer ${token}`,
           },

--- a/frontend/src/composables/useProviderConnection.js
+++ b/frontend/src/composables/useProviderConnection.js
@@ -328,7 +328,9 @@ export function useProviderConnection(modalRef) {
       const normalizedId = resolveProviderKey(app.id) || app.id;
       const response = await fetch(
         `${API_CONFIG.REMOTE_URL}/auth/connect/${normalizedId}?origin=${encodeURIComponent(window.location.origin)}`,
-        { headers: { Authorization: `Bearer ${token}` } },
+        // Same reason as the /auth/callback exchange: identity on the remote
+        // auth routes rides a session cookie, not the bearer token.
+        { credentials: 'include', headers: { Authorization: `Bearer ${token}` } },
       );
       if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
       const data = await response.json();

--- a/frontend/src/services/providerAuthService.js
+++ b/frontend/src/services/providerAuthService.js
@@ -83,7 +83,11 @@ export default {
       .post(
         `${API_CONFIG.REMOTE_URL}/auth/callback`,
         { code, state },
-        { headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' } },
+        {
+          // The remote resolves the user from a session cookie on this route.
+          withCredentials: true,
+          headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        },
       )
       .then((r) => r.data)
       .finally(() => {

--- a/frontend/src/services/providerAuthService.spec.js
+++ b/frontend/src/services/providerAuthService.spec.js
@@ -42,6 +42,7 @@ describe('providerAuthService.completeRemoteOAuthCallback', () => {
       'https://api.agnt.gg/auth/callback',
       { code: 'abc123', state: 'twitter:http://localhost:3333' },
       {
+        withCredentials: true,
         headers: {
           Authorization: 'Bearer test-jwt',
           'Content-Type': 'application/json',
@@ -49,6 +50,24 @@ describe('providerAuthService.completeRemoteOAuthCallback', () => {
       },
     );
     expect(result).toEqual({ success: true, provider: 'twitter' });
+  });
+
+  // The remote resolves the user from a session cookie on this route. Without
+  // the cookie it runs the token INSERT with user_id = NULL and the browser is
+  // shown a raw SQLite error:
+  //   "SQLITE_CONSTRAINT: NOT NULL constraint failed: oauth_tokens.user_id"
+  // Asserted on its own so a future refactor of the options object cannot drop
+  // the cookie without a failing test that names exactly what broke.
+  it('sends credentials, because the remote identifies the user by session cookie', async () => {
+    axios.post.mockResolvedValueOnce({ data: { success: true } });
+
+    await providerAuthService.completeRemoteOAuthCallback({
+      code: 'abc123',
+      state: 'twitter:http://localhost:3333',
+    });
+
+    const [, , options] = axios.post.mock.calls[0];
+    expect(options.withCredentials).toBe(true);
   });
 
   it('rejects when code is missing without making any HTTP call', async () => {

--- a/frontend/src/views/Terminal/CenterPanel/screens/Chat/components/ProviderSetup.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Chat/components/ProviderSetup.vue
@@ -188,6 +188,8 @@ export default {
         const token = localStorage.getItem('token');
         // Pass origin as query parameter for reliable Electron support
         const response = await fetch(`${API_CONFIG.REMOTE_URL}/auth/connect/${provider.id}?origin=${encodeURIComponent(window.location.origin)}`, {
+          // Identity on the remote auth routes rides a session cookie.
+          credentials: 'include',
           headers: {
             Authorization: `Bearer ${token}`,
           },

--- a/frontend/src/views/Terminal/CenterPanel/screens/Connectors/Connectors.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Connectors/Connectors.vue
@@ -1206,6 +1206,8 @@ export default {
         const token = localStorage.getItem('token');
         // Pass origin as query parameter for reliable Electron support
         const response = await fetch(`${API_CONFIG.REMOTE_URL}/auth/connect/${app.id}?origin=${encodeURIComponent(window.location.origin)}`, {
+          // Identity on the remote auth routes rides a session cookie.
+          credentials: 'include',
           headers: {
             Authorization: `Bearer ${token}`,
           },
@@ -2084,6 +2086,11 @@ export default {
 
         const response = await fetch(`${API_CONFIG.REMOTE_URL}/auth/callback`, {
           method: 'POST',
+          // The remote resolves the user from a session cookie on this
+          // route; the bearer token alone is ignored and the INSERT runs with
+          // user_id = NULL, surfacing as
+          // "NOT NULL constraint failed: oauth_tokens.user_id".
+          credentials: 'include',
           headers: {
             Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',

--- a/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/_OauthManager/OauthManager.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/_OauthManager/OauthManager.vue
@@ -220,6 +220,8 @@ const connectOAuthApp = async (app) => {
     const token = localStorage.getItem('token');
     // Pass origin as query parameter for reliable Electron support
     const response = await fetch(`${API_CONFIG.REMOTE_URL}/auth/connect/${app.id}?origin=${encodeURIComponent(window.location.origin)}`, {
+      // Identity on the remote auth routes rides a session cookie.
+      credentials: 'include',
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -359,6 +361,9 @@ const completeOAuth = async (code, state, provider) => {
 
     const response = await fetch(`${API_CONFIG.REMOTE_URL}/auth/callback`, {
       method: 'POST',
+      // The remote resolves the user from a session cookie on this route; the
+      // bearer token alone is ignored and the INSERT runs with user_id = NULL.
+      credentials: 'include',
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',

--- a/frontend/src/views/Terminal/RightPanel/types/ChatPanel/components/IntegrationHealth.vue
+++ b/frontend/src/views/Terminal/RightPanel/types/ChatPanel/components/IntegrationHealth.vue
@@ -353,6 +353,8 @@ export default {
         const token = localStorage.getItem('token');
         // Pass origin as query parameter for reliable Electron support
         const response = await fetch(`${API_CONFIG.REMOTE_URL}/auth/connect/${app.id}?origin=${encodeURIComponent(window.location.origin)}`, {
+          // Identity on the remote auth routes rides a session cookie.
+          credentials: 'include',
           headers: {
             Authorization: `Bearer ${token}`,
           },

--- a/frontend/src/views/_components/utility/OAuthCallback.vue
+++ b/frontend/src/views/_components/utility/OAuthCallback.vue
@@ -66,6 +66,11 @@ export default {
         const token = localStorage.getItem('token');
         const response = await fetch(`${API_CONFIG.REMOTE_URL}/auth/callback`, {
           method: 'POST',
+          // The remote identifies the user by session cookie on this route: the
+          // bearer token alone is ignored, the INSERT runs with user_id = NULL
+          // and SQLite rejects it. Without this the failure surfaces as
+          // "NOT NULL constraint failed: oauth_tokens.user_id".
+          credentials: 'include',
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${token}`,


### PR DESCRIPTION
Connecting any OAuth provider fails at the last step with a raw database error in a user-facing dialog, after the user has already authorised the third-party app:

```
Connection Error
Failed to connect to Github: SQLITE_CONSTRAINT: NOT NULL constraint failed: oauth_tokens.user_id
```

The handshake with the provider succeeds. The failure is on the remote's write: it stores the token with `user_id = NULL` against a `user_id TEXT NOT NULL` column.

**The remote does not read the bearer token on these routes.** Against `api.agnt.gg`, `POST /auth/callback` returns that identical error with a valid JWT, with a deliberately malformed JWT, and with no `Authorization` header at all — three requests differing only in the credential, one response. Its CORS reply says what it *does* read:

```
access-control-allow-origin: http://localhost:3333      (echoed, not *)
access-control-allow-credentials: true
```

A server only echoes a specific origin and sets `allow-credentials: true` when it expects cookie credentials. Sign-in already talks to that host that way — `store/auth/userAuth.js` passes `withCredentials: true` on every magic-link call — but none of the OAuth call sites did. The one request that has to be attributed to a user was the one carrying nothing the remote reads.

## What this changes

`credentials: 'include'` (fetch) / `withCredentials: true` (axios) on every call to `/auth/connect/` and `/auth/callback`.

**Ten call sites, not three.** `connectOAuthApp` and the callback exchange are copy-pasted across six screens:

| Call site | Route |
|---|---|
| `views/_components/utility/OAuthCallback.vue:67` | callback — the one that produced the error above |
| `services/providerAuthService.js:84` | callback (Electron postMessage path) |
| `…/screens/Connectors/Connectors.vue:2083` | callback |
| `…/_OauthManager/OauthManager.vue:360` | callback |
| `composables/useProviderConnection.js:331` | connect |
| `…/screens/Connectors/Connectors.vue:1209` | connect |
| `…/_OauthManager/OauthManager.vue:223` | connect |
| `…/ChatPanel/components/IntegrationHealth.vue:356` | connect |
| `components/OnboardingModal.vue:590` | connect |
| `…/Chat/components/ProviderSetup.vue:190` | connect |

Fixing a subset would be worse than fixing none: connecting would work or fail depending on which screen the user clicked **Connect** from. I found this the hard way — my first pass patched three, and inspecting the built bundle showed the Connectors chunk still shipping an unpatched call.

## What is **not** verified

**This is a hypothesis fix and should be reviewed as one.** No `Set-Cookie` is observable from `api.agnt.gg` on any endpoint reachable without completing a fresh sign-in, so the existence and `SameSite` attributes of the session cookie are inferred from the CORS configuration and the sign-in code, not observed. If that cookie is `SameSite=Lax` it will not be sent cross-site and this change is inert.

**A maintainer can settle this instantly** — does `/auth/callback` resolve the user from a session cookie? If no, close this; the real bug is entirely #75.

It cannot regress anything either way: it adds a credential to requests to the app's own auth host and changes no control flow.

## The server-side defect stands regardless

Filed as **#75**. `/auth/callback` accepts a request it cannot attribute to any user, attempts the insert anyway, and returns the storage error rather than refusing with `401`. Reproducible with one `curl` and no account. That is why this took a *database* error to diagnose instead of an *auth* one — same shape as #71, where an infrastructure failure was reported as a domain value.

## Tests

`frontend/src/services/providerAuthService.spec.js` already pinned the exact request shape for the callback exchange, so it correctly failed on this change and is updated. The cookie is additionally asserted on its own, so a refactor of the options object cannot drop it without a failing test that names what broke. Removing `withCredentials` from the service fails both (verified).

That covers 1 of the 10 call sites. The second commit adds `frontend/src/__guards__/oauthCredentialContract.spec.js`, following `apiAuthContract.spec.js`, whose reason for existing is the same shape: a rule no single module owns, copy-pasted until someone forgets it. It derives the call sites from the source, so a seventh copy cannot be added without either carrying the credential or failing CI.

Run against the tree without the fix, the guard names all ten — an independent check on the claim that ten is the whole set, since it scans rather than reusing the grep that found them:

```
AssertionError: these calls reach the remote auth host without the session credential …
+   "components/OnboardingModal.vue:590 -> /auth/connect/",
+   "composables/useProviderConnection.js:330 -> /auth/connect/",
+   "services/providerAuthService.js:84 -> /auth/callback",
…10 total
```

Three of its self-tests target failure modes of the guard rather than of the code: call text is paren-matched rather than windowed (Connectors.vue holds two calls, and a window lets a credentialed neighbour vouch for an uncredentialed one — a false negative, the only direction that matters); the backward scan counts depth because the URLs embed `encodeURIComponent(...)`; and a minimum call-site count is asserted so that renaming `API_CONFIG.REMOTE_URL` cannot make the contract pass vacuously.

Full frontend suite: **224 files / 3925 tests, all passing.**

### Review round

Copilot caught a real hole in the guard: the flag was matched against the raw call text, so a commented-out `// credentials: 'include',` read as compliant. Confirmed by reproducing it, then fixed in `741ffb81`. The obvious fix is unsafe in the other direction — a `//.*$` sweep turns `'github:http://localhost:3333'` into `'github:http:`, corrupting the source and deleting any flag after a URL on the same line — so the strip is string-aware, and both directions now have self-tests.

## Relationship to other open PRs

Independent of #70–#74 — no shared files (those are backend workflow/plugin changes; this is frontend only). Branched from `origin/main` at `2bffa7e2`.

