### PR TITLE
fix(hooks): a long body is reflowed, not rejected

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -10,7 +10,14 @@ npm run hooks:install     # or: git config core.hooksPath .githooks
 
 ## commit-msg
 
-Refuses a commit message that would read as truncated:
+Two scripts run in order:
+
+| Script | Role |
+| --- | --- |
+| `commit-msg-reflow.mjs` | Pre-pass. Rewraps an over-long body in place. Never fails a commit. |
+| `commit-msg-lint.mjs` | Decides. Rejects a message that would still read as truncated. |
+
+The rules the linter enforces:
 
 | Rule | Why |
 | --- | --- |
@@ -23,15 +30,74 @@ or more spaces (pasted code, logs, diffs), `Trailer-Name:` lines, and a line
 that is one unbreakable token such as a URL. `Merge`, `Revert`, `fixup!`,
 `squash!` and `amend!` subjects are skipped entirely.
 
-### When it rejects you
+### Over-long bodies are reflowed, not rejected
+
+The pre-pass rewraps the body at 72 columns and lets the commit through, so a
+paragraph that arrives as one enormous line is repaired rather than bounced
+back at you:
+
+```
+commit-msg: reflowed the body to 72 columns (1 line(s) in, 3 out, longest was 166).
+```
+
+It edits only the message region. The `# Please enter the commit message`
+block, the `# ------------------------ >8 ------------------------` scissors
+line and the `--verbose` diff below it, trailers, preformatted blocks and CRLF
+line endings all survive byte-for-byte. Running it twice changes nothing the
+second time.
+
+It declines to touch the file at all — leaving the linter to report the
+problem — in every shape where reflowing could lose information:
+
+| Shape | Why it is left alone |
+| --- | --- |
+| A body line starting with `#` | git stores it (see below), so dropping it would delete something you wrote. |
+| Line 2 is not blank | The body is read as `lines.slice(2)`, so line 2 would be silently discarded. |
+| A comment interleaved with body text | Not a shape it understands. Guessing is worse than declining. |
+| `Merge`, `Revert`, `fixup!`, `squash!`, `amend!` | Exempt from the rules entirely. |
+| The reflow would not fix the body, or introduces a new problem | Being unable to help is fine; making it worse is not. |
+
+The pre-pass never exits non-zero. If it throws it prints `commit-msg: reflow
+skipped (...)` and the linter runs anyway, so it can never be the reason a
+commit fails.
+
+### When it still rejects you
+
+An over-long **subject** is never rewritten automatically — that is a decision
+about what the commit says, not about formatting. A subject states one thing:
+move the qualifying clause, the part after the comma or the dash, into the
+body.
+
+For a shape the pre-pass declined, edit the file the linter names and commit
+it as-is:
 
 ```sh
-node .githooks/commit-msg-lint.mjs --fix .git/COMMIT_EDITMSG   # rewrap body at 72
 git commit -F .git/COMMIT_EDITMSG
 ```
 
-The subject is never rewritten automatically — that is a decision about what
-the commit says, not about formatting.
+### Why the hook does not call `commit-msg-lint.mjs --fix`
+
+`--fix` is safe on a scratch file you wrote yourself, and destructive on a real
+`.git/COMMIT_EDITMSG`. It writes back `reflowBody(parseMessage(raw))`, and
+`parseMessage` deliberately reduces the file to *the message git will actually
+store* — `.split(SCISSORS)[0]` and `.filter(l => !l.startsWith('#'))`. That is
+correct for linting and wrong for rewriting. Measured against a realistic
+commit-msg file, `--fix`:
+
+- deletes the `# Please enter the commit message...` block
+- deletes the `# ---- >8 ----` scissors line and the `--verbose` diff
+- deletes line 2 entirely when line 2 is not blank, because the body is
+  taken as `lines.slice(2)`
+- deletes any body line beginning with `#`
+
+The last two are silent data loss rather than cosmetics. The `#` case is not
+hypothetical: git's default cleanup is `strip` only when the message is
+*edited*, and `whitespace` otherwise, so with `-F` or `-m` a body line such as
+`#123 is the upstream issue` is stored verbatim in the commit today.
+
+`commit-msg-reflow.mjs` exists to get the same repair without those four
+losses. Its behaviour — including every refusal above — is covered by
+`scripts/commitMsgReflow.test.js`.
 
 ### Write bodies with `-F`, not `-m`
 
@@ -39,5 +105,10 @@ the commit says, not about formatting.
 `-m` body arrives as one enormous line. In this repo's history that is exactly
 what happened: every message authored with `-F` measures 72-80 columns, every
 one authored with `-m` measures 190-660.
+
+The pre-pass now repairs that automatically, so `-m` no longer blocks a
+commit. `-F` is still the better habit: you choose where the paragraph breaks
+fall, and anything structured — several paragraphs, a bullet list, a trailer
+block — survives exactly as you wrote it instead of being rewrapped.
 
 Bypass in an emergency with `git commit --no-verify`.

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -4,4 +4,13 @@
 # --show-toplevel, not a path relative to this file: with core.hooksPath the
 # hook is resolved against the working tree it is running in, so this fires
 # correctly from linked worktrees as well as the primary checkout.
-exec node "$(git rev-parse --show-toplevel)/.githooks/commit-msg-lint.mjs" "$1"
+ROOT="$(git rev-parse --show-toplevel)"
+
+# Pre-pass: reflow an over-long body in place, so the hook repairs what can be
+# repaired mechanically. It never exits non-zero and never rewrites a subject;
+# deliberately not `commit-msg-lint.mjs --fix`, which also strips the comment
+# block, the scissors diff and any body line starting with '#'.
+node "$ROOT/.githooks/commit-msg-reflow.mjs" "$1"
+
+# The linter is the only thing that decides whether this commit is allowed.
+exec node "$ROOT/.githooks/commit-msg-lint.mjs" "$1"

--- a/.githooks/commit-msg-reflow.mjs
+++ b/.githooks/commit-msg-reflow.mjs
@@ -72,6 +72,14 @@ function main() {
   const eol = raw.includes('\r\n') ? '\r\n' : '\n';
   const all = raw.split(/\r?\n/);
 
+  // A file that ends in a newline splits to a trailing "" that is an artifact
+  // of the EOF, not a blank line. Left in, it is counted as a separator, then
+  // re-emitted AND followed by a restored EOL — one extra blank line at EOF
+  // every time the file is rewritten. Drop it here and restore exactly one
+  // EOL on the way out.
+  const endsWithEol = all.length > 0 && all[all.length - 1] === '';
+  if (endsWithEol) all.pop();
+
   // Everything from the scissors line on is preserved untouched.
   const cut = all.findIndex((l) => SCISSORS_LINE.test(l));
   const head = cut === -1 ? all : all.slice(0, cut);
@@ -111,7 +119,7 @@ function main() {
   if (after.problems.length > before.problems.length) return;
 
   const out = [...reflowed, ...Array(blanks).fill(''), ...comments, ...tail];
-  writeFileSync(file, out.join(eol) + (raw.endsWith('\n') ? eol : ''), 'utf8');
+  writeFileSync(file, out.join(eol) + (endsWithEol ? eol : ''), 'utf8');
 
   const worst = content.reduce((n, l) => Math.max(n, l.length), 0);
   console.error(

--- a/.githooks/commit-msg-reflow.mjs
+++ b/.githooks/commit-msg-reflow.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Reflow an over-long commit BODY in place, so the hook fixes what it can
+ * mechanically fix instead of rejecting the commit and making a human do it.
+ *
+ * This runs BEFORE commit-msg-lint.mjs and never decides anything. It exits 0
+ * unconditionally; the linter remains the sole authority on whether a commit
+ * is allowed. If this script cannot help, it changes nothing and the linter
+ * prints its usual diagnostic.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY NOT JUST CALL `commit-msg-lint.mjs --fix`
+ * ---------------------------------------------------------------------------
+ * Because `--fix` writes back `reflowBody(parseMessage(raw))`, and
+ * `parseMessage` deliberately reduces the file to "the message git will
+ * actually store" — it drops every `#` line and everything past the scissors.
+ * That is correct for LINTING and destructive for REWRITING. Measured against
+ * the real implementation on 2026-08-24, `--fix` on a commit-msg file:
+ *
+ *   - deletes the `# Please enter the commit message...` block
+ *   - deletes the `# ---- >8 ----` scissors line and the --verbose diff
+ *   - deletes line 2 entirely when line 2 is not blank, because reflowBody
+ *     takes the body as `lines.slice(2)`
+ *   - deletes any body line beginning with `#`
+ *
+ * The last two are silent data loss rather than cosmetics. The `#` case is not
+ * theoretical: git's default cleanup is `strip` only when the message is
+ * edited, and `whitespace` otherwise, so with `-F`/`-m` a body line starting
+ * with `#` is stored verbatim in the commit today. Verified 2026-08-24 on git
+ * 2.55.0 — a `#123 is the upstream issue` line survives into `git log`.
+ *
+ * So this script reflows the message region ONLY, preserves the comment block,
+ * the scissors and the diff byte-for-byte, and refuses to act at all in the
+ * shapes where reflowing would lose information.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IT WILL NOT DO
+ * ---------------------------------------------------------------------------
+ * The subject is never rewritten. An over-long subject is a statement that
+ * says two things, and choosing which one to keep is editorial. The linter
+ * still rejects it, with the diagnostic that shows exactly which tail GitHub
+ * would hide.
+ *
+ * Usage:  node .githooks/commit-msg-reflow.mjs <msgfile>
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { reflowBody, lintCommitMessage } from './commit-msg-lint.mjs';
+
+const SCISSORS_LINE = /^# -+ >8 -+$/;
+const BODY_PROBLEM = /body line\(s\) exceed/;
+const BLOCKING_SHAPE = /^(Line 2 must be blank|Empty subject line)/;
+
+/** Index of the trailing run of `#` lines, or -1. Only a run that reaches the
+ *  end of the region counts: an interleaved comment is not a trailing block. */
+function trailingCommentStart(lines) {
+  let i = lines.length;
+  while (i > 0) {
+    const line = lines[i - 1];
+    if (line.startsWith('#') || !line.trim()) i -= 1;
+    else break;
+  }
+  while (i < lines.length && !lines[i].startsWith('#')) i += 1;
+  return i < lines.length ? i : -1;
+}
+
+function main() {
+  const file = process.argv[2];
+  if (!file) return;
+
+  const raw = readFileSync(file, 'utf8');
+  const eol = raw.includes('\r\n') ? '\r\n' : '\n';
+  const all = raw.split(/\r?\n/);
+
+  // Everything from the scissors line on is preserved untouched.
+  const cut = all.findIndex((l) => SCISSORS_LINE.test(l));
+  const head = cut === -1 ? all : all.slice(0, cut);
+  const tail = cut === -1 ? [] : all.slice(cut);
+
+  // The trailing `# Please enter...` block is preserved untouched too.
+  const commentAt = trailingCommentStart(head);
+  const content = commentAt === -1 ? head.slice() : head.slice(0, commentAt);
+  const comments = commentAt === -1 ? [] : head.slice(commentAt);
+
+  // Preserve the exact blank-line separator that was already there.
+  let blanks = 0;
+  while (content.length && !content[content.length - 1].trim()) {
+    content.pop();
+    blanks += 1;
+  }
+
+  // A comment among the real content means the shape is not one this script
+  // understands. Leave it alone rather than guess.
+  if (content.some((l) => l.startsWith('#'))) return;
+  // Subject only, or subject + blank: nothing to reflow.
+  if (content.length < 3) return;
+  // Body would be read as `slice(2)`, so a non-blank line 2 would be dropped.
+  if (content[1].trim() !== '') return;
+
+  const before = lintCommitMessage(content);
+  if (before.skipped) return;
+  if (before.problems.some((p) => BLOCKING_SHAPE.test(p))) return;
+  if (!before.problems.some((p) => BODY_PROBLEM.test(p))) return;
+
+  const reflowed = reflowBody(content);
+
+  // Only rewrite if this actually resolved the body problem and introduced
+  // nothing new. Being unable to help is fine; making it worse is not.
+  const after = lintCommitMessage(reflowed);
+  if (after.problems.some((p) => BODY_PROBLEM.test(p))) return;
+  if (after.problems.length > before.problems.length) return;
+
+  const out = [...reflowed, ...Array(blanks).fill(''), ...comments, ...tail];
+  writeFileSync(file, out.join(eol) + (raw.endsWith('\n') ? eol : ''), 'utf8');
+
+  const worst = content.reduce((n, l) => Math.max(n, l.length), 0);
+  console.error(
+    `commit-msg: reflowed the body to 72 columns `
+    + `(${content.length - 2} line(s) in, ${reflowed.length - 2} out, `
+    + `longest was ${worst}).`,
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  // A pre-pass must never be the reason a commit fails. The linter runs next
+  // and will report anything genuinely wrong with the message.
+  console.error(`commit-msg: reflow skipped (${error.message}).`);
+}

--- a/scripts/commitMsgReflow.test.js
+++ b/scripts/commitMsgReflow.test.js
@@ -43,6 +43,16 @@ function run(lines, eol = '\n') {
 const bodyLines = (text) =>
   text.split(/\r?\n/).slice(2).filter((l) => l.trim() && !l.startsWith('#'));
 
+/** Write bytes verbatim, run the pre-pass, return the bytes afterwards. */
+function runRaw(raw) {
+  const file = path.join(dir, 'COMMIT_EDITMSG');
+  writeFileSync(file, raw, 'utf8');
+  execFileSync('node', [REFLOW, file], { encoding: 'utf8', stdio: 'pipe' });
+  return readFileSync(file, 'utf8');
+}
+
+const trailingNewlines = (text) => (text.match(/\n*$/) ?? [''])[0].length;
+
 describe('commit-msg reflow pre-pass', () => {
   describe('repairs what it can', () => {
     it('rewraps an over-long body at 72 columns', () => {
@@ -111,6 +121,53 @@ describe('commit-msg reflow pre-pass', () => {
       const { after } = run(['fix(scope): fine', '', LONG], '\r\n');
       expect(after).toContain('\r\n');
       expect(/[^\r]\n/.test(after)).toBe(false);
+    });
+  });
+
+  describe('leaves the end of the file exactly as it found it', () => {
+    // `raw.split(/\r?\n/)` yields a trailing "" for a file ending in a newline.
+    // Treating that artifact as a blank line and then restoring the EOL adds a
+    // blank line at EOF on every rewrite.
+    it('keeps exactly one trailing newline', () => {
+      const after = runRaw(`fix(scope): fine\n\n${LONG}\n`);
+      expect(trailingNewlines(after)).toBe(1);
+    });
+
+    it('keeps exactly one trailing newline with a comment block', () => {
+      const after = runRaw(
+        `fix(scope): fine\n\n${LONG}\n\n# Please enter the commit message.\n`,
+      );
+      expect(trailingNewlines(after)).toBe(1);
+    });
+
+    it('keeps exactly one trailing newline with a scissors diff', () => {
+      const after = runRaw(
+        `fix(scope): fine\n\n${LONG}\n\n`
+        + '# ------------------------ >8 ------------------------\n'
+        + 'diff --git a/x b/x\n',
+      );
+      expect(trailingNewlines(after)).toBe(1);
+    });
+
+    it('does not add a newline to a file that had none', () => {
+      const after = runRaw(`fix(scope): fine\n\n${LONG}`);
+      expect(trailingNewlines(after)).toBe(0);
+    });
+
+    it('ends CRLF files with exactly one CRLF', () => {
+      const after = runRaw(`fix(scope): fine\r\n\r\n${LONG}\r\n`);
+      expect(after.endsWith('\r\n')).toBe(true);
+      expect(after.endsWith('\r\n\r\n')).toBe(false);
+    });
+
+    it('does not grow the file end when a long line is reintroduced', () => {
+      const file = path.join(dir, 'COMMIT_EDITMSG');
+      writeFileSync(file, `fix(scope): fine\n\n${LONG}\n`, 'utf8');
+      for (let i = 0; i < 3; i += 1) {
+        execFileSync('node', [REFLOW, file], { stdio: 'pipe' });
+        expect(trailingNewlines(readFileSync(file, 'utf8'))).toBe(1);
+        writeFileSync(file, readFileSync(file, 'utf8') + `${LONG}\n`, 'utf8');
+      }
     });
   });
 

--- a/scripts/commitMsgReflow.test.js
+++ b/scripts/commitMsgReflow.test.js
@@ -1,0 +1,188 @@
+/**
+ * The commit-msg reflow pre-pass.
+ *
+ * These are integration tests: they run the real script against real files,
+ * because the whole point of the pre-pass is what it does to bytes on disk.
+ * The cases that matter are the REFUSALS — `commit-msg-lint.mjs --fix` cannot
+ * be called directly precisely because it strips comments, the scissors diff,
+ * a non-blank line 2 and any body line starting with '#'. If these refusals
+ * ever regress, the hook starts silently deleting parts of commit messages.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REFLOW = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '.githooks',
+  'commit-msg-reflow.mjs',
+);
+
+const LONG =
+  'This body line is deliberately authored as one very long single line '
+  + 'exactly like git commit -m would produce on Windows and must be reflowed.';
+
+let dir;
+beforeEach(() => { dir = mkdtempSync(path.join(tmpdir(), 'reflow-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+/** Write a message, run the pre-pass, return the file contents afterwards. */
+function run(lines, eol = '\n') {
+  const file = path.join(dir, 'COMMIT_EDITMSG');
+  const raw = lines.join(eol) + eol;
+  writeFileSync(file, raw, 'utf8');
+  execFileSync('node', [REFLOW, file], { encoding: 'utf8', stdio: 'pipe' });
+  return { raw, after: readFileSync(file, 'utf8') };
+}
+
+const bodyLines = (text) =>
+  text.split(/\r?\n/).slice(2).filter((l) => l.trim() && !l.startsWith('#'));
+
+describe('commit-msg reflow pre-pass', () => {
+  describe('repairs what it can', () => {
+    it('rewraps an over-long body at 72 columns', () => {
+      const { after } = run(['fix(scope): a fine subject', '', LONG]);
+      expect(bodyLines(after).every((l) => l.length <= 72)).toBe(true);
+      expect(bodyLines(after).length).toBeGreaterThan(1);
+    });
+
+    it('keeps every word — reflow moves text, it does not drop it', () => {
+      const { raw, after } = run(['fix(scope): a fine subject', '', LONG]);
+      const words = (t) => t.split(/\s+/).filter(Boolean).join(' ');
+      expect(words(after)).toBe(words(raw));
+    });
+
+    it('reflows the body even when the subject is also too long', () => {
+      const subject = `fix(workflow): ${'x'.repeat(80)}`;
+      const { after } = run([subject, '', LONG]);
+      expect(bodyLines(after).every((l) => l.length <= 72)).toBe(true);
+      // The subject is a judgement call and is never rewritten.
+      expect(after.split('\n')[0]).toBe(subject);
+    });
+
+    it('is idempotent', () => {
+      const file = path.join(dir, 'COMMIT_EDITMSG');
+      writeFileSync(file, ['fix(scope): fine', '', LONG].join('\n') + '\n', 'utf8');
+      execFileSync('node', [REFLOW, file], { stdio: 'pipe' });
+      const once = readFileSync(file, 'utf8');
+      execFileSync('node', [REFLOW, file], { stdio: 'pipe' });
+      expect(readFileSync(file, 'utf8')).toBe(once);
+    });
+  });
+
+  describe('preserves what git and the author put there', () => {
+    it("keeps the '# Please enter the commit message' block", () => {
+      const { after } = run([
+        'fix(scope): a fine subject', '', LONG, '',
+        '# Please enter the commit message for your changes.',
+        '# On branch main',
+      ]);
+      expect(after).toContain('# Please enter the commit message');
+      expect(after).toContain('# On branch main');
+    });
+
+    it('keeps the scissors line and the --verbose diff', () => {
+      const { after } = run([
+        'fix(scope): a fine subject', '', LONG, '',
+        '# ------------------------ >8 ------------------------',
+        'diff --git a/x b/x', '+added line',
+      ]);
+      expect(after).toContain('>8');
+      expect(after).toContain('diff --git a/x b/x');
+      expect(after).toContain('+added line');
+    });
+
+    it('keeps trailers and preformatted blocks byte-for-byte', () => {
+      const { after } = run([
+        'fix(scope): a fine subject', '', LONG, '',
+        '    preformatted   spacing   kept', '',
+        'Co-authored-by: Someone <a@b.co>',
+      ]);
+      expect(after).toContain('    preformatted   spacing   kept');
+      expect(after).toContain('Co-authored-by: Someone <a@b.co>');
+    });
+
+    it('preserves CRLF line endings', () => {
+      const { after } = run(['fix(scope): fine', '', LONG], '\r\n');
+      expect(after).toContain('\r\n');
+      expect(/[^\r]\n/.test(after)).toBe(false);
+    });
+  });
+
+  describe('refuses to act where reflowing would lose information', () => {
+    it('leaves the file alone when line 2 is not blank', () => {
+      // reflowBody reads the body as slice(2), so line 1 would be dropped.
+      const { raw, after } = run([
+        'fix(scope): a fine subject',
+        'THIS-LINE-MUST-SURVIVE',
+        LONG,
+      ]);
+      expect(after).toBe(raw);
+      expect(after).toContain('THIS-LINE-MUST-SURVIVE');
+    });
+
+    it("leaves the file alone when a body line starts with '#'", () => {
+      // git's default cleanup is `whitespace` for -F/-m, so such a line is
+      // stored verbatim in the commit and must not be silently deleted.
+      const { raw, after } = run([
+        'fix(scope): a fine subject', '',
+        '#123 is the upstream issue this closes',
+        LONG,
+      ]);
+      expect(after).toBe(raw);
+      expect(after).toContain('#123');
+    });
+
+    it('does not touch a message that already complies', () => {
+      const { raw, after } = run(['fix(scope): fine', '', 'A short body line.']);
+      expect(after).toBe(raw);
+    });
+
+    it('does not touch a generated subject such as a merge', () => {
+      const { raw, after } = run(["Merge branch 'feature' into main", '', LONG]);
+      expect(after).toBe(raw);
+    });
+
+    it('does not touch a subject-only message', () => {
+      const { raw, after } = run(['fix(scope): fine']);
+      expect(after).toBe(raw);
+    });
+  });
+
+  describe('never blocks a commit on its own', () => {
+    it('exits 0 for every shape, including ones it refuses', () => {
+      const shapes = [
+        ['fix(scope): fine', '', LONG],
+        ['fix(scope): fine', 'no blank line 2', LONG],
+        ['fix(scope): fine'],
+        [''],
+      ];
+      for (const lines of shapes) {
+        const file = path.join(dir, 'msg.txt');
+        writeFileSync(file, lines.join('\n') + '\n', 'utf8');
+        const status = (() => {
+          try {
+            execFileSync('node', [REFLOW, file], { stdio: 'pipe' });
+            return 0;
+          } catch (e) { return e.status; }
+        })();
+        expect(status).toBe(0);
+      }
+    });
+
+    it('exits 0 when the file does not exist', () => {
+      const status = (() => {
+        try {
+          execFileSync('node', [REFLOW, path.join(dir, 'nope.txt')], { stdio: 'pipe' });
+          return 0;
+        } catch (e) { return e.status; }
+      })();
+      expect(status).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
The `commit-msg` hook added in f24b1dee rejects an over-long body and leaves a
human to rewrap it. That is mechanical work, and the repo already contains the
code to do it — `reflowBody`, exposed by `commit-msg-lint.mjs --fix`.

This adds a pre-pass so an over-long body is **repaired and the commit goes
through**, instead of bouncing back:

```
commit-msg: reflowed the body to 72 columns (9 line(s) in, 25 out, longest was 493).
[fix/hooks-reflow-body 25021079] fix(hooks): a long body is reflowed, not rejected
```

That output is from this PR's own commit. The body below was authored with
four lines of 222, 493, 314 and 191 chars; what is stored is wrapped at 72.

An over-long **subject** is still rejected. A subject states one thing, and
choosing which clause to drop is editorial, not mechanical.

## Why this does not call `commit-msg-lint.mjs --fix`

That was the obvious implementation, and it is unsafe on a real
`.git/COMMIT_EDITMSG`. `--fix` writes back `reflowBody(parseMessage(raw))`,
and `parseMessage` deliberately reduces the file to *the message git will
actually store*:

```js
const lines = raw
  .split(SCISSORS)[0]
  .split(/\r?\n/)
  .filter((line) => !line.startsWith('#'));
```

Correct for linting. Destructive for rewriting. Run against realistic
commit-msg files, `--fix` currently:

- deletes the `# Please enter the commit message...` block
- deletes the `# ---- >8 ----` scissors line and the `--verbose` diff
- deletes line 2 entirely when line 2 is not blank, because the body is taken
  as `lines.slice(2)`
- deletes any body line beginning with `#`

The last two are silent data loss rather than cosmetics.

The `#` case is not hypothetical. git's default cleanup is `strip` only when
the message is *edited*, and `whitespace` otherwise, so with `-F` or `-m` a
body line beginning with `#` is stored verbatim today. Verified on git 2.55.0:

```
$ git commit --allow-empty --no-verify -F msg.txt
$ git log -1 --format='%B'
fix(scope): probe git cleanup mode

#123 is the upstream issue this closes
plain body line
```

`--fix` is left as-is — it is documented as operating on a message, and it is
fine on a scratch file. The hook just does not use it.

## What the pre-pass does

`.githooks/commit-msg-reflow.mjs` edits only the message region and re-emits
everything else byte-for-byte: the comment block, the scissors line, the
`--verbose` diff, trailers, preformatted blocks, and CRLF endings. It is
idempotent.

It declines to touch the file at all where reflowing could lose information:

| Shape | Why |
| --- | --- |
| A body line starting with `#` | git stores it; dropping it would delete something the author wrote |
| Line 2 is not blank | body is `lines.slice(2)`, so line 2 would vanish |
| A comment interleaved with body text | not a shape it understands; guessing is worse than declining |
| `Merge`, `Revert`, `fixup!`, `squash!`, `amend!` | already exempt from the rules |
| The reflow would not fix the body, or adds a new problem | being unable to help is fine; making it worse is not |

It never exits non-zero — it is wrapped in try/catch and prints
`commit-msg: reflow skipped (...)` on error — so `commit-msg-lint.mjs`
remains the only thing that decides whether a commit is allowed.

## Verification

- `scripts/commitMsgReflow.test.js` — 15 tests covering the repairs, the
  preservation, and every refusal above. The pre-pass imports the linter's
  internals, so without these a change to `reflowBody` or `lintCommitMessage`
  would break it silently.
- `scripts/commitMsgLint.test.js` — 31 tests, unchanged, still green.
- Full backend suite: 305/307 files, 4859/4860 tests. The 2 failures are
  pre-existing on my checkout and come from untracked local files, not from
  tracked code.
- End-to-end through a real `git commit` in the primary checkout: long body
  via `-F` reflowed and committed; `git commit -m '<paragraph>'` reflowed to
  exactly 72; over-long subject still rejected; a `#` body line refused and
  left intact.
- No mode changes: `git diff --summary 5d3b5794 HEAD` reports only the two
  `create mode` lines. `.githooks/commit-msg` stays `100755`.

## Notes

- `.githooks/README.md` is updated: the "When it rejects you" section told
  readers to run `--fix` by hand, which is now the thing to avoid.
- Since `-m` bodies are repaired automatically, the README no longer implies
  `-m` will block a commit — it still recommends `-F`, because you choose the
  break points and structured content survives instead of being rewrapped.
