### PR TITLE
fix(auth): finish a Google sign-in in the window that started it

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -11,6 +11,7 @@ import { registerAllWidgets } from '@/canvas/widgets/index.js';
 import { syncMediaCookieFromStorage } from '@/services/mediaAuth.js';
 import { watchSession, stopLicenseRefresh, idle } from '@/store/auth/sessionBoot.js';
 import { adoptTokenFromUrl } from '@/store/auth/urlSessionToken.js';
+import { forwardGoogleAuthToOpener } from '@/utils/googleAuthPopup.js';
 import { vTooltip } from '@/directives/tooltip.js';
 import { vViewportClamp } from '@/directives/viewportClamp.js';
 import { installAppHeight } from '@/utils/appHeight.js';
@@ -19,6 +20,21 @@ import { installAppHeight } from '@/utils/appHeight.js';
 if (process.env.NODE_ENV === 'development') {
   import('@/utils/testRateLimit');
 }
+
+// FIRST, before any other boot work: if this document is the "Continue with
+// Google" popup coming back with a token, hand that token to the window that
+// opened the popup and close.
+//
+// This has to happen before `adoptTokenFromUrl` below, which strips `?token=`
+// from the address bar — the token is readable exactly once, and whichever of
+// the two runs first is the one that gets it. It also has to happen before
+// `createApp`, because a window that exists only to carry a token back must
+// not mount an application. Without it the popup boots a second copy of AGNT
+// and signs ITSELF in, stranding the user in a 600x700 login window while the
+// window they started from still shows the sign-in screen.
+//
+// See utils/googleAuthPopup.js.
+const isGoogleAuthHandoff = forwardGoogleAuthToOpener();
 
 // Before mount, not after: a restored conversation can render an <img
 // src="/api/local-file/..."> on the very first paint, and that request needs
@@ -133,7 +149,13 @@ app.config.errorHandler = (err, _instance, info) => {
 
 // MOUNT IMMEDIATELY - show the app shell before data loading
 // This eliminates the blank screen while API calls complete
-app.mount('#app');
+//
+// ...unless this window is the Google auth popup, which has already handed its
+// token to the opener and is closing. Mounting a second application in there
+// IS the defect — see utils/googleAuthPopup.js.
+if (!isGoogleAuthHandoff) {
+  app.mount('#app');
+}
 
 // Dev-only: `__auditContrast()` in the console reports any on-screen text that
 // is unreadable against its ACTUAL rendered backdrop. Static analysis cannot
@@ -214,4 +236,17 @@ window.addEventListener('beforeunload', () => {
 });
 
 // Initialize app data in background AFTER mount (non-blocking)
-initializeApp().catch(console.error);
+if (!isGoogleAuthHandoff) {
+  initializeApp().catch(console.error);
+} else {
+  // `window.close()` is a request the browser is allowed to refuse. If it did,
+  // this popup is now sitting on an empty page, so boot it after all: the worst
+  // case becomes the old behaviour — signed in, wrong window — and never a
+  // dead end the user has to work out for themselves.
+  setTimeout(() => {
+    if (!window.closed) {
+      app.mount('#app');
+      initializeApp().catch(console.error);
+    }
+  }, 1000);
+}

--- a/frontend/src/store/auth/urlSessionToken.js
+++ b/frontend/src/store/auth/urlSessionToken.js
@@ -47,8 +47,12 @@
  * session: adopting garbage would store it, fail verification, and take the
  * user's existing localStorage token down with it. Ignoring garbage instead
  * leaves an already-signed-in user exactly as they were.
+ *
+ * Exported because there are two ways a token can arrive from outside — the
+ * address bar and the Google popup's postMessage — and they must apply the
+ * same rule. A second copy of this would be one more place to forget.
  */
-function looksLikeJwt(value) {
+export function looksLikeJwt(value) {
   if (typeof value !== 'string') return false;
   const parts = value.split('.');
   return parts.length === 3 && parts.every((p) => p.length > 0);

--- a/frontend/src/utils/googleAuthPopup.js
+++ b/frontend/src/utils/googleAuthPopup.js
@@ -50,6 +50,61 @@
 export const GOOGLE_AUTH_SUCCESS = 'google-auth-success';
 
 /**
+ * May this `message` event be allowed to complete a sign-in?
+ *
+ * ---------------------------------------------------------------------------
+ * WHY AN ORIGIN CHECK IS NOT ENOUGH
+ * ---------------------------------------------------------------------------
+ * `event.origin` says the sender is same-origin. It does not say the sender is
+ * the popup we just opened, and this application renders authored HTML in
+ * iframes that are same-origin by construction:
+ *
+ *   Artifacts.vue          sandbox="allow-scripts allow-same-origin"
+ *   CustomWidgetRenderer   sandbox="allow-scripts allow-same-origin ..."
+ *                          :srcdoc="renderedSource"
+ *
+ * `allow-scripts` together with `allow-same-origin` means that content runs AT
+ * the app's real origin. Any artifact or widget could therefore call
+ * `parent.postMessage({ type: 'google-auth-success', token }, origin)` and, on
+ * an origin check alone, be believed. The user would be moved into whichever
+ * account that token belongs to and carry on working there — filing their
+ * keys, files and conversations under someone else's login.
+ *
+ * So the sender's identity is checked, not merely its origin.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS IS NOT A STRICT `event.source === popup`
+ * ---------------------------------------------------------------------------
+ * A message is only REFUSED when a different sender is positively identified.
+ * If `event.source` is null — some engines drop it once the sender has been
+ * discarded, and this popup closes itself immediately after posting — the
+ * check abstains rather than rejects.
+ *
+ * That abstention cannot be exploited: a live frame always has a non-null
+ * `source`, so the spoof above is refused either way. What it buys is that a
+ * quirk of one embedder can never lock a user out of signing in, which a
+ * strict identity test would risk for no additional protection. Electron is
+ * already known to report an empty `origin` across this same window boundary.
+ *
+ * @param {MessageEvent} event
+ * @param {Window|null}  popup  the handle returned by `window.open`
+ * @param {Window}       [win]  injectable for tests
+ */
+export function isTrustedAuthMessage(event, popup, win = globalThis.window) {
+  if (!event) return false;
+
+  // An empty origin is tolerated for the same reason as below: Electron's
+  // proxy for a window that is same-origin by construction can report one.
+  const expectedOrigin = win?.location?.origin;
+  if (event.origin && expectedOrigin && event.origin !== expectedOrigin) return false;
+
+  // A sender we can see, that is not the window we opened, is refused.
+  if (popup && event.source && event.source !== popup) return false;
+
+  return true;
+}
+
+/**
  * If this document is a Google-auth popup on its return leg, give the token to
  * the opener and close.
  *

--- a/frontend/src/utils/googleAuthPopup.js
+++ b/frontend/src/utils/googleAuthPopup.js
@@ -50,6 +50,116 @@
 export const GOOGLE_AUTH_SUCCESS = 'google-auth-success';
 
 /**
+ * A same-origin channel the handover falls back to when `window.opener` is not
+ * reachable.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY A SECOND CHANNEL AT ALL
+ * ---------------------------------------------------------------------------
+ * `opener.postMessage` needs the opener relationship to survive the round trip
+ * through Google. Today it does, but only just: `accounts.google.com` already
+ * sends
+ *
+ *   cross-origin-opener-policy-report-only: same-origin
+ *
+ * Report-only means Google is MEASURING the breakage before enforcing it. On
+ * the day that header loses its `-report-only`, navigating the popup to
+ * accounts.google.com swaps its browsing-context group, `window.opener`
+ * becomes permanently null, and a handover built on the opener alone goes
+ * silently inert — the popup would boot a second app again, which is the exact
+ * bug this file exists to fix. The same COOP change is what broke the
+ * `window.closed` polling in Google's own GSI library.
+ *
+ * Electron is the other unknown: the popup is a separate BrowserWindow created
+ * by `setWindowOpenHandler`, and whether the child sees a usable `opener` is
+ * not something a unit test here can settle.
+ *
+ * A BroadcastChannel depends on neither. It is same-origin by construction and
+ * carries no relationship to how the window was created, so it works whether
+ * or not COOP severs the opener, and regardless of how Electron builds the
+ * child window.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY IT IS A FALLBACK AND NOT THE PRIMARY
+ * ---------------------------------------------------------------------------
+ * `postMessage` to a specific opener is TARGETED: exactly one window receives
+ * the token. A broadcast reaches every same-origin context, which here
+ * includes artifact and widget iframes, since those are rendered
+ * `allow-scripts allow-same-origin`.
+ *
+ * That is not a new capability — this application keeps the session token in
+ * `localStorage`, which any same-origin script can already read, so a hostile
+ * artifact does not need the channel to obtain one. But "no worse than
+ * today" is a poor reason to widen a path, so the broadcast only happens when
+ * the targeted route is unavailable. In the common case nothing is broadcast
+ * at all.
+ */
+export const GOOGLE_AUTH_CHANNEL = 'agnt-google-auth';
+
+/**
+ * Set by the opener immediately before `window.open`, read by the popup on its
+ * return leg.
+ *
+ * THE PROBLEM THIS SOLVES: a popup whose opener COOP has severed and an
+ * ordinary redirect into the user's own tab are INDISTINGUISHABLE from inside
+ * the document. Both have `window.opener === null` and both arrive at
+ * `/settings?token=...`. Broadcasting and closing on that signal alone would
+ * mean a popup-blocked user — who is signing in in their real tab — has that
+ * tab closed underneath them.
+ *
+ * So the opener leaves a positive signal instead of the popup guessing.
+ * `localStorage` rather than `sessionStorage`, because a session store is only
+ * cloned into a same-origin `window.open`, and this popup is navigated
+ * cross-origin before it comes back.
+ *
+ * A stale mark is bounded three ways: a short TTL, the opener clearing it when
+ * the flow finishes, and the fact that `window.close()` is a no-op on a window
+ * that script did not open — so the worst case of a misread is the one-second
+ * mount fallback in main.js, not a lost tab.
+ */
+const POPUP_MARK_KEY = 'agnt:google-auth-popup-open';
+const POPUP_MARK_TTL_MS = 5 * 60 * 1000;
+
+/** localStorage, or null where it is unavailable (private mode, some embeds). */
+function defaultStorage() {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Record that this window is about to open a Google auth popup. */
+export function markGoogleAuthPopupOpen(storage = defaultStorage()) {
+  try {
+    storage?.setItem(POPUP_MARK_KEY, String(Date.now()));
+  } catch {
+    /* a storage that refuses writes just means we fall back to opener-only */
+  }
+}
+
+/** Forget it, once the flow has finished one way or the other. */
+export function clearGoogleAuthPopupMark(storage = defaultStorage()) {
+  try {
+    storage?.removeItem(POPUP_MARK_KEY);
+  } catch {
+    /* nothing to do */
+  }
+}
+
+/** Was a popup opened recently enough that this document is plausibly it? */
+function popupMarkIsFresh(storage) {
+  try {
+    const raw = storage?.getItem(POPUP_MARK_KEY);
+    if (!raw) return false;
+    const age = Date.now() - Number(raw);
+    return Number.isFinite(age) && age >= 0 && age < POPUP_MARK_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * May this `message` event be allowed to complete a sign-in?
  *
  * ---------------------------------------------------------------------------
@@ -114,15 +224,14 @@ export function isTrustedAuthMessage(event, popup, win = globalThis.window) {
  *                      load" — including the genuine redirect flow, where
  *                      there is no opener and boot signs in normally.
  */
-export function forwardGoogleAuthToOpener(win = globalThis.window) {
+export function forwardGoogleAuthToOpener(win = globalThis.window, options = {}) {
   if (!win) return false;
 
-  // No opener means this is not a popup. That is the redirect flow — the path
-  // taken when the browser blocks popups — and signing in right here is the
-  // correct behaviour, not the bug. Returning false hands it to
-  // adoptTokenFromUrl untouched.
-  const opener = win.opener;
-  if (!opener || opener === win) return false;
+  const {
+    storage = defaultStorage(),
+    createChannel = defaultCreateChannel,
+    defer = (fn) => setTimeout(fn, 0),
+  } = options;
 
   let token = null;
   try {
@@ -131,28 +240,77 @@ export function forwardGoogleAuthToOpener(win = globalThis.window) {
     return false;
   }
 
-  // A popup with no token: the OAuth leg is still in flight, or an error came
-  // back. Either way there is nothing to forward.
+  // No token: the OAuth leg is still in flight, an error came back, or this is
+  // an ordinary page load. Nothing to forward either way.
   if (!token) return false;
 
-  try {
-    // targetOrigin is OUR origin and never '*'. The opener is same-origin by
-    // construction, and a session token must not be readable by whatever else
-    // that window may have navigated to in the meantime.
-    opener.postMessage({ type: GOOGLE_AUTH_SUCCESS, token }, win.location.origin);
-  } catch {
-    // The opener was closed, or is otherwise unreachable. Report "not handled"
-    // so the caller boots normally and the user is still signed in — in this
-    // window, which is the old behaviour and strictly better than stranding
-    // them in a popup nobody is listening to.
-    return false;
+  // ── Route 1: the opener, when we can still reach it ──────────────────────
+  // Targeted delivery to exactly one window. targetOrigin is OUR origin and
+  // never '*': the opener is same-origin by construction, and a session token
+  // must not be readable by whatever else that window may have navigated to.
+  const opener = win.opener && win.opener !== win ? win.opener : null;
+  if (opener) {
+    let delivered = false;
+    try {
+      opener.postMessage({ type: GOOGLE_AUTH_SUCCESS, token }, win.location.origin);
+      delivered = true;
+    } catch {
+      /* opener closed or unreachable — fall through to the channel */
+    }
+
+    if (delivered) {
+      clearGoogleAuthPopupMark(storage);
+      try {
+        win.close();
+      } catch {
+        /* close() is a request, not a guarantee; main.js handles a refusal */
+      }
+      return true;
+    }
   }
 
+  // ── Route 2: the same-origin channel ─────────────────────────────────────
+  // Only for a window we can POSITIVELY identify as a popup. Without the mark,
+  // a document with no opener is indistinguishable from the redirect flow, and
+  // broadcasting there would mean closing a tab the user opened themselves.
+  if (!popupMarkIsFresh(storage)) return false;
+
+  const channel = createChannel(GOOGLE_AUTH_CHANNEL);
+  if (!channel) return false; // no BroadcastChannel: boot normally, old behaviour
+
   try {
-    win.close();
+    channel.postMessage({ type: GOOGLE_AUTH_SUCCESS, token });
   } catch {
-    /* close() is a request, not a guarantee; main.js handles a refusal */
+    return false;
+  } finally {
+    try {
+      channel.close();
+    } catch {
+      /* already gone */
+    }
   }
+
+  clearGoogleAuthPopupMark(storage);
+
+  // Deferred by one task. `postMessage` queues delivery on the receiving
+  // contexts rather than this one, so closing immediately should be safe —
+  // this costs nothing and removes the question.
+  defer(() => {
+    try {
+      win.close();
+    } catch {
+      /* main.js mounts after a second if the browser refused */
+    }
+  });
 
   return true;
+}
+
+/** A BroadcastChannel, or null where the API is unavailable or blocked. */
+function defaultCreateChannel(name) {
+  try {
+    return typeof BroadcastChannel === 'function' ? new BroadcastChannel(name) : null;
+  } catch {
+    return null;
+  }
 }

--- a/frontend/src/utils/googleAuthPopup.js
+++ b/frontend/src/utils/googleAuthPopup.js
@@ -1,0 +1,103 @@
+/**
+ * FINISH A "CONTINUE WITH GOOGLE" SIGN-IN IN THE WINDOW THAT STARTED IT.
+ *
+ * ---------------------------------------------------------------------------
+ * THE DEFECT THIS CLOSES
+ * ---------------------------------------------------------------------------
+ * `connectGoogle()` in LoginSection.vue opens a 600x700 popup at
+ * `<REMOTE>/users/auth/google?redirectUrl=<origin>/settings`, and then listens
+ * on its own window for a `google-auth-success` message.
+ *
+ * Nothing ever sent that message. It has been dead code since it was written:
+ * a repo-wide search finds the listener and no sender.
+ *
+ * The remote does not hand the token back to the opener. It redirects the
+ * POPUP to `<origin>/settings?token=...`, and that URL is the whole
+ * application. So the popup booted a second copy of AGNT, adopted the token
+ * from its own address bar, verified it and navigated to the chat — inside a
+ * 600x700 window with no chrome. The window the user started from was never
+ * told anything and sat on the sign-in screen.
+ *
+ * The user ends up working in the popup. That is the reported symptom: "AGNT
+ * opens in the sign-in window instead of the main one."
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THE FIX GOES HERE AND NOT IN A COMPONENT
+ * ---------------------------------------------------------------------------
+ * A window that exists only to carry a token back must not mount an app. If
+ * this ran from a mounted component the entire SPA would render in the popup
+ * before it closed — the user would watch a second AGNT flash up and vanish,
+ * and every request that render issued would be real.
+ *
+ * So it runs at module scope in main.js, before `createApp`.
+ *
+ * ---------------------------------------------------------------------------
+ * ORDERING: THIS MUST RUN BEFORE adoptTokenFromUrl()
+ * ---------------------------------------------------------------------------
+ * `store/auth/urlSessionToken.js` reads `?token=` and then STRIPS it from the
+ * address bar via `history.replaceState`, so that a live credential does not
+ * leak into browser history or into the `Referer` header. That is correct, and
+ * it means the token is readable exactly once. Whichever of the two runs first
+ * is the one that gets it.
+ *
+ * If adoption ran first, this function would find an empty query string, the
+ * popup would sign itself in, and the bug would be exactly as it was. The
+ * order is asserted mechanically in googleAuthPopup.spec.js, in the same way
+ * and for the same reason as the rest of the boot sequence.
+ */
+
+/** The message type LoginSection.vue's opener-side listener waits for. */
+export const GOOGLE_AUTH_SUCCESS = 'google-auth-success';
+
+/**
+ * If this document is a Google-auth popup on its return leg, give the token to
+ * the opener and close.
+ *
+ * @param {Window} win  Injectable for tests; defaults to the real window.
+ * @returns {boolean}   true when the handoff happened and the caller must NOT
+ *                      boot the app. false means "this is an ordinary page
+ *                      load" — including the genuine redirect flow, where
+ *                      there is no opener and boot signs in normally.
+ */
+export function forwardGoogleAuthToOpener(win = globalThis.window) {
+  if (!win) return false;
+
+  // No opener means this is not a popup. That is the redirect flow — the path
+  // taken when the browser blocks popups — and signing in right here is the
+  // correct behaviour, not the bug. Returning false hands it to
+  // adoptTokenFromUrl untouched.
+  const opener = win.opener;
+  if (!opener || opener === win) return false;
+
+  let token = null;
+  try {
+    token = new URLSearchParams(win.location.search).get('token');
+  } catch {
+    return false;
+  }
+
+  // A popup with no token: the OAuth leg is still in flight, or an error came
+  // back. Either way there is nothing to forward.
+  if (!token) return false;
+
+  try {
+    // targetOrigin is OUR origin and never '*'. The opener is same-origin by
+    // construction, and a session token must not be readable by whatever else
+    // that window may have navigated to in the meantime.
+    opener.postMessage({ type: GOOGLE_AUTH_SUCCESS, token }, win.location.origin);
+  } catch {
+    // The opener was closed, or is otherwise unreachable. Report "not handled"
+    // so the caller boots normally and the user is still signed in — in this
+    // window, which is the old behaviour and strictly better than stranding
+    // them in a popup nobody is listening to.
+    return false;
+  }
+
+  try {
+    win.close();
+  } catch {
+    /* close() is a request, not a guarantee; main.js handles a refusal */
+  }
+
+  return true;
+}

--- a/frontend/src/utils/googleAuthPopup.spec.js
+++ b/frontend/src/utils/googleAuthPopup.spec.js
@@ -192,6 +192,131 @@ describe('isTrustedAuthMessage', () => {
 });
 
 /**
+ * THE NULL-SOURCE ABSTENTION, AND HOW FAR IT IS ALLOWED TO REACH.
+ *
+ * `isTrustedAuthMessage` refuses a message only when a DIFFERENT sender is
+ * positively identified. When `event.source` is null it abstains rather than
+ * rejects, because this popup calls `postMessage` and then `close()`
+ * immediately: by delivery the sender may already be discarded, and the HTML
+ * spec permits a null `source` for exactly that case. Refusing there would
+ * reject the LEGITIMATE message and lock that user out of signing in — worse
+ * than the attack being defended against, on a path CI cannot exercise.
+ *
+ * That is a deliberate weakening of a security check, so its EDGES are what
+ * need pinning, not its happy path. Two properties have to hold, and only the
+ * first of them is obvious:
+ *
+ *   1. a message that cannot be attributed is still allowed through
+ *   2. the abstention is NARROW - it excuses a sender from the identity check
+ *      and from nothing else
+ *
+ * The second is the one that would actually hurt. An abstention written as an
+ * early `if (!event.source) return true;` reads almost identically, passes
+ * every test in the block above, and hands any CROSS-ORIGIN sender a way to
+ * skip the origin check by the simple trick of not being identifiable. These
+ * tests exist to make that refactor fail loudly.
+ */
+describe('isTrustedAuthMessage: the boundaries of the null-source abstention', () => {
+  const ORIGIN = 'https://tenant.example.com';
+  const win = { location: { origin: ORIGIN } };
+  const popup = { name: 'the popup we opened' };
+
+  describe('a sender that cannot be attributed is allowed through', () => {
+    // Engines disagree on how an unattributable sender is reported, and the
+    // difference is not observable from here, so both spellings must behave
+    // the same. `null` is what the HTML spec calls for; `undefined` is what a
+    // synthetic or proxied event can carry.
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+    ])('abstains on a %s source', (_label, source) => {
+      expect(isTrustedAuthMessage({ origin: ORIGIN, source }, popup, win)).toBe(true);
+    });
+
+    it('abstains for a popup the browser has already closed', () => {
+      // The real sequence this exists for: the popup posts, closes itself, and
+      // the message is delivered afterwards with nothing left to attribute it
+      // to. The handle we still hold reports `closed`.
+      const closedPopup = { name: 'the popup we opened', closed: true };
+
+      expect(isTrustedAuthMessage({ origin: ORIGIN, source: null }, closedPopup, win)).toBe(true);
+    });
+
+    it('abstains when the origin is empty AND the sender is gone', () => {
+      // Both known quirks at once: Electron reports an empty origin across
+      // this window boundary, and the sender has been discarded. Neither is
+      // evidence of an attack, and together they must not add up to one.
+      expect(isTrustedAuthMessage({ origin: '', source: null }, popup, win)).toBe(true);
+    });
+  });
+
+  describe('the abstention excuses the identity check and nothing else', () => {
+    it('still refuses a cross-origin sender that has no identifiable source', () => {
+      // THE LOAD-BEARING TEST. If the null-source case is ever moved ahead of
+      // the origin check, this is the hole it opens: a hostile frame stops
+      // being refused the moment it stops being identifiable, which is not a
+      // property an attacker has to work for.
+      const event = { origin: 'https://evil.example.net', source: null };
+
+      expect(isTrustedAuthMessage(event, popup, win)).toBe(false);
+    });
+
+    it('still refuses a cross-origin sender whose source is undefined', () => {
+      const event = { origin: 'https://evil.example.net', source: undefined };
+
+      expect(isTrustedAuthMessage(event, popup, win)).toBe(false);
+    });
+
+    it('does not extend to a sender that IS identifiable', () => {
+      // Tolerating the unattributable must not soften the case the check was
+      // written for. A frame that can be seen, and is not ours, is refused.
+      const artifactFrame = { name: 'an allow-same-origin srcdoc iframe' };
+
+      expect(isTrustedAuthMessage({ origin: ORIGIN, source: artifactFrame }, popup, win)).toBe(
+        false,
+      );
+    });
+
+    it('refuses a missing event even though its source is also absent', () => {
+      // `undefined.source` is unattributable in the most literal sense. It is
+      // still not a reason to sign anybody in.
+      expect(isTrustedAuthMessage(null, popup, win)).toBe(false);
+    });
+  });
+
+  /**
+   * The whole abstention rests on one claim: a sender that is still alive can
+   * always be seen, so nothing an attacker controls reaches the abstaining
+   * branch. If any live-window shape could arrive with a falsy `source`, the
+   * abstention would be a bypass rather than a concession.
+   *
+   * This asserts the claim across every shape a hostile sender could plausibly
+   * take in this app, rather than trusting the single object literal used
+   * above.
+   */
+  describe('every identifiable sender that is not our popup is refused', () => {
+    it.each([
+      ['an artifact preview iframe', { tag: 'iframe', sandbox: 'allow-scripts allow-same-origin' }],
+      ['a custom widget iframe', { tag: 'iframe', srcdoc: '<script>...</script>' }],
+      ['a second popup the app opened', { name: 'some-other-popup' }],
+      ['the top-level window itself', { self: 'window', top: true }],
+      ['an object impersonating our popup by name', { name: 'the popup we opened' }],
+    ])('refuses %s', (_label, source) => {
+      // The last case matters most: identity here is reference equality, not a
+      // name or any other forgeable property.
+      expect(isTrustedAuthMessage({ origin: ORIGIN, source }, popup, win)).toBe(false);
+    });
+
+    it('accepts only the exact window object we opened', () => {
+      expect(isTrustedAuthMessage({ origin: ORIGIN, source: popup }, popup, win)).toBe(true);
+
+      // A structural clone of it is a different window.
+      expect(isTrustedAuthMessage({ origin: ORIGIN, source: { ...popup } }, popup, win)).toBe(false);
+    });
+  });
+});
+
+/**
  * The handoff and `adoptTokenFromUrl` both read `?token=`, and adoption strips
  * it from the address bar so it cannot leak into history or a Referer header.
  * That makes it single-use. If adoption runs first the popup keeps the token,

--- a/frontend/src/utils/googleAuthPopup.spec.js
+++ b/frontend/src/utils/googleAuthPopup.spec.js
@@ -1,0 +1,160 @@
+/**
+ * A SIGN-IN MUST FINISH IN THE WINDOW THAT STARTED IT.
+ *
+ * The reason this defect survived so long is that nothing about it looks like
+ * a failure. The popup signed the user in perfectly — verified the token,
+ * loaded the workspace, navigated to the chat. It just did all of that in a
+ * 600x700 window with no chrome, while the window the user had been looking at
+ * stayed on the sign-in screen. Every unit that could have caught it was
+ * passing, because every unit did its job.
+ *
+ * So these tests are written against the DECISION, in isolation: given an
+ * opener and a token, hand it over and close; given no opener, do nothing and
+ * let the page boot. Both halves are load-bearing. The false branch is the
+ * redirect flow — the path taken when a browser blocks popups — and a fix that
+ * broke it would lock those users out entirely while looking correct here.
+ *
+ * The ordering against `adoptTokenFromUrl` is asserted mechanically against
+ * main.js source, in the same way and for the same reason as the rest of the
+ * boot sequence: both read the same single-use `?token=`, the loser of that
+ * race silently restores the original bug, and no unit test of either function
+ * can see it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { forwardGoogleAuthToOpener, GOOGLE_AUTH_SUCCESS } from './googleAuthPopup.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const makeWin = ({ search = '', opener = null, origin = 'https://tenant.example.com' } = {}) => ({
+  opener,
+  close: vi.fn(),
+  location: { search, origin },
+});
+
+const makeOpener = () => ({ postMessage: vi.fn() });
+
+describe('forwardGoogleAuthToOpener', () => {
+  let opener;
+
+  beforeEach(() => {
+    opener = makeOpener();
+  });
+
+  it('hands the token to the opener and closes the popup', () => {
+    const win = makeWin({ search: '?token=header.payload.signature', opener });
+
+    const handled = forwardGoogleAuthToOpener(win);
+
+    expect(handled).toBe(true);
+    expect(opener.postMessage).toHaveBeenCalledWith(
+      { type: GOOGLE_AUTH_SUCCESS, token: 'header.payload.signature' },
+      'https://tenant.example.com',
+    );
+    expect(win.close).toHaveBeenCalled();
+  });
+
+  it('never posts a token to a wildcard origin', () => {
+    // '*' would publish a live session token to whatever the opener had
+    // navigated to by then.
+    const win = makeWin({ search: '?token=header.payload.signature', opener });
+
+    forwardGoogleAuthToOpener(win);
+
+    expect(opener.postMessage.mock.calls[0][1]).not.toBe('*');
+  });
+
+  it('leaves the redirect flow alone when there is no opener', () => {
+    // A real page load, which must go on to boot and adopt the token here.
+    // This is the popup-blocked path; breaking it would lock those users out.
+    const win = makeWin({ search: '?token=header.payload.signature', opener: null });
+
+    expect(forwardGoogleAuthToOpener(win)).toBe(false);
+    expect(win.close).not.toHaveBeenCalled();
+  });
+
+  it('does nothing in a popup that is not carrying a token', () => {
+    const win = makeWin({ search: '', opener });
+
+    expect(forwardGoogleAuthToOpener(win)).toBe(false);
+    expect(opener.postMessage).not.toHaveBeenCalled();
+    expect(win.close).not.toHaveBeenCalled();
+  });
+
+  it('ignores a window that is its own opener', () => {
+    const win = makeWin({ search: '?token=header.payload.signature' });
+    win.opener = win;
+
+    expect(forwardGoogleAuthToOpener(win)).toBe(false);
+    expect(win.close).not.toHaveBeenCalled();
+  });
+
+  it('reports "not handled" when the opener is gone, so the app still boots', () => {
+    const dead = {
+      postMessage: vi.fn(() => {
+        throw new Error('opener is closed');
+      }),
+    };
+    const win = makeWin({ search: '?token=header.payload.signature', opener: dead });
+
+    // False here is what puts the user in a working app rather than a blank
+    // popup that nobody is listening to.
+    expect(forwardGoogleAuthToOpener(win)).toBe(false);
+    expect(win.close).not.toHaveBeenCalled();
+  });
+
+  it('still reports handled when the browser refuses to close the window', () => {
+    const win = makeWin({ search: '?token=header.payload.signature', opener });
+    win.close = vi.fn(() => {
+      throw new Error('close blocked');
+    });
+
+    // The token was delivered, so the opener is signing in. main.js carries the
+    // fallback for a window that is still standing afterwards.
+    expect(forwardGoogleAuthToOpener(win)).toBe(true);
+    expect(opener.postMessage).toHaveBeenCalled();
+  });
+
+  it('survives being called with no window at all', () => {
+    expect(forwardGoogleAuthToOpener(undefined)).toBe(false);
+  });
+});
+
+/**
+ * The handoff and `adoptTokenFromUrl` both read `?token=`, and adoption strips
+ * it from the address bar so it cannot leak into history or a Referer header.
+ * That makes it single-use. If adoption runs first the popup keeps the token,
+ * signs itself in, and the reported bug is back — with every unit test in this
+ * file still green.
+ */
+describe('boot order in main.js', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../main.js'), 'utf8');
+
+  // The comments in main.js name these functions while explaining them. Index
+  // arithmetic over raw text would match the prose, not the code.
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+  const at = (needle) => {
+    const i = code.indexOf(needle);
+    expect(i, `expected to find \`${needle}\` in main.js`).toBeGreaterThan(-1);
+    return i;
+  };
+
+  it('forwards the token to the opener before adoption strips it from the URL', () => {
+    expect(at('forwardGoogleAuthToOpener()')).toBeLessThan(at('adoptTokenFromUrl(store)'));
+  });
+
+  it('decides before anything mounts', () => {
+    // A window that exists only to carry a token back must not render an app.
+    expect(at('forwardGoogleAuthToOpener()')).toBeLessThan(at('app.mount('));
+  });
+
+  it('does not mount unconditionally', () => {
+    // The guard is the whole fix. A bare `app.mount('#app');` here would mean
+    // the popup boots a second AGNT again.
+    expect(code).toMatch(/if\s*\(\s*!isGoogleAuthHandoff\s*\)\s*\{\s*app\.mount\(/);
+  });
+});

--- a/frontend/src/utils/googleAuthPopup.spec.js
+++ b/frontend/src/utils/googleAuthPopup.spec.js
@@ -25,7 +25,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { forwardGoogleAuthToOpener, GOOGLE_AUTH_SUCCESS } from './googleAuthPopup.js';
+import {
+  forwardGoogleAuthToOpener,
+  isTrustedAuthMessage,
+  GOOGLE_AUTH_SUCCESS,
+} from './googleAuthPopup.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -120,6 +124,70 @@ describe('forwardGoogleAuthToOpener', () => {
 
   it('survives being called with no window at all', () => {
     expect(forwardGoogleAuthToOpener(undefined)).toBe(false);
+  });
+});
+
+/**
+ * WHO IS ALLOWED TO COMPLETE A SIGN-IN.
+ *
+ * The origin check that shipped first is not sufficient, and the gap is
+ * reachable in this application rather than theoretical: artifact previews and
+ * custom widgets are rendered in `allow-scripts allow-same-origin` iframes
+ * with authored HTML in `srcdoc`, so that content runs at the app's own
+ * origin. On an origin check alone it could post its own token and be
+ * believed, moving the user into someone else's account without any visible
+ * change.
+ */
+describe('isTrustedAuthMessage', () => {
+  const win = { location: { origin: 'https://tenant.example.com' } };
+  const popup = { name: 'the popup we opened' };
+
+  it('accepts the popup we opened', () => {
+    const event = { origin: 'https://tenant.example.com', source: popup };
+
+    expect(isTrustedAuthMessage(event, popup, win)).toBe(true);
+  });
+
+  it('refuses a same-origin artifact iframe posing as the popup', () => {
+    // The Copilot finding, verbatim: right origin, wrong window.
+    const artifactFrame = { name: 'an allow-same-origin srcdoc iframe' };
+    const event = { origin: 'https://tenant.example.com', source: artifactFrame };
+
+    expect(isTrustedAuthMessage(event, popup, win)).toBe(false);
+  });
+
+  it('refuses a cross-origin sender', () => {
+    const event = { origin: 'https://evil.example.net', source: popup };
+
+    expect(isTrustedAuthMessage(event, popup, win)).toBe(false);
+  });
+
+  it('tolerates an empty origin, which Electron reports across this boundary', () => {
+    const event = { origin: '', source: popup };
+
+    expect(isTrustedAuthMessage(event, popup, win)).toBe(true);
+  });
+
+  it('abstains when the sender cannot be identified at all', () => {
+    // The popup closes itself immediately after posting, and an engine that
+    // has already discarded it can report `source: null`. Refusing here would
+    // lock those users out of signing in entirely — a worse failure than the
+    // one being defended against, and this abstention does not reopen it:
+    // a live frame always has a source, so the spoof above is still refused.
+    const event = { origin: 'https://tenant.example.com', source: null };
+
+    expect(isTrustedAuthMessage(event, popup, win)).toBe(true);
+  });
+
+  it('abstains when the popup handle is missing', () => {
+    // Nothing to compare against; the origin check is all that is left.
+    const event = { origin: 'https://tenant.example.com', source: { some: 'window' } };
+
+    expect(isTrustedAuthMessage(event, null, win)).toBe(true);
+  });
+
+  it('refuses a missing event outright', () => {
+    expect(isTrustedAuthMessage(undefined, popup, win)).toBe(false);
   });
 });
 

--- a/frontend/src/utils/googleAuthPopup.spec.js
+++ b/frontend/src/utils/googleAuthPopup.spec.js
@@ -28,7 +28,10 @@ import { fileURLToPath } from 'url';
 import {
   forwardGoogleAuthToOpener,
   isTrustedAuthMessage,
+  markGoogleAuthPopupOpen,
+  clearGoogleAuthPopupMark,
   GOOGLE_AUTH_SUCCESS,
+  GOOGLE_AUTH_CHANNEL,
 } from './googleAuthPopup.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -345,9 +348,258 @@ describe('boot order in main.js', () => {
     expect(at('forwardGoogleAuthToOpener()')).toBeLessThan(at('app.mount('));
   });
 
-  it('does not mount unconditionally', () => {
-    // The guard is the whole fix. A bare `app.mount('#app');` here would mean
-    // the popup boots a second AGNT again.
-    expect(code).toMatch(/if\s*\(\s*!isGoogleAuthHandoff\s*\)\s*\{\s*app\.mount\(/);
+    it('does not mount unconditionally', () => {
+      // The guard is the whole fix. A bare `app.mount('#app');` here would mean
+      // the popup boots a second AGNT again.
+      expect(code).toMatch(/if\s*\(\s*!isGoogleAuthHandoff\s*\)\s*\{\s*app\.mount\(/);
+    });
+  });
+
+/**
+ * THE BROADCAST CHANNEL FALLBACK, AND THE MARK THAT MAKES IT SAFE.
+ *
+ * `opener.postMessage` depends on the opener relationship surviving the round
+ * trip through Google. It does today — a real run in the packaged Electron
+ * app confirmed it, which is why this remains a fallback rather than a
+ * repair. But `accounts.google.com` already sends
+ *
+ *   cross-origin-opener-policy-report-only: same-origin
+ *
+ * Google is measuring breakage before enforcing it. The day that header drops
+ * its "report-only", the popup's browsing-context group is swapped on
+ * navigation, `window.opener` becomes permanently null, and the primary route
+ * goes silently inert. A BroadcastChannel has no such dependency: it is
+ * same-origin by construction and does not care how the window was created.
+ *
+ * The danger of a broadcast is the redirect flow. A popup whose opener COOP
+ * has severed and an ordinary redirect into the user's OWN tab are
+ * INDISTINGUISHABLE from inside the document — both have
+ * `window.opener === null` and both arrive at `/settings?token=...`. Without a
+ * positive signal that a popup was actually opened, broadcasting on the
+ * channel would close a tab underneath a popup-blocked user who is signing in
+ * the normal way. The mark in localStorage makes that signal positive, and
+ * these tests pin BOTH halves: the fallback fires when a fresh mark is
+ * present, and REFUSES — refuses to broadcast AND refuses to close — when it
+ * is not.
+ */
+describe('the BroadcastChannel fallback', () => {
+  const TOKEN = 'header.payload.signature';
+
+  /** A storage whose mark is `ageMs` old (default: brand new). */
+  const makeStorage = ({ ageMs = 0, present = true, throwsOn = null } = {}) => {
+    const store = present ? { 'agnt:google-auth-popup-open': String(Date.now() - ageMs) } : {};
+    return {
+      getItem: vi.fn((k) => {
+        if (throwsOn === 'get') throw new Error('storage denied');
+        return store[k] ?? null;
+      }),
+      setItem: vi.fn((k, v) => {
+        if (throwsOn === 'set') throw new Error('storage denied');
+        store[k] = v;
+      }),
+      removeItem: vi.fn((k) => {
+        if (throwsOn === 'remove') throw new Error('storage denied');
+        delete store[k];
+      }),
+    };
+  };
+
+  const makeChannel = () => ({ postMessage: vi.fn(), close: vi.fn() });
+
+  describe('the popup-in-flight mark', () => {
+    it('writes a timestamp the moment the popup is opened', () => {
+      const storage = makeStorage({ present: false });
+
+      markGoogleAuthPopupOpen(storage);
+
+      expect(storage.setItem).toHaveBeenCalledTimes(1);
+      const [key, value] = storage.setItem.mock.calls[0];
+      expect(key).toBe('agnt:google-auth-popup-open');
+      expect(Number(value)).toBeGreaterThan(0);
+    });
+
+    it('is removed once the flow finishes', () => {
+      const storage = makeStorage({});
+
+      clearGoogleAuthPopupMark(storage);
+
+      expect(storage.removeItem).toHaveBeenCalledWith('agnt:google-auth-popup-open');
+    });
+
+    it('survives a storage that refuses to write', () => {
+      // A storage that won't take writes just means the flow falls back to
+      // the opener-only behaviour; it must not throw at the button click.
+      expect(() => markGoogleAuthPopupOpen(makeStorage({ throwsOn: 'set' }))).not.toThrow();
+      expect(() => clearGoogleAuthPopupMark(makeStorage({ throwsOn: 'remove' }))).not.toThrow();
+    });
+  });
+
+  describe('a popup with no reachable opener', () => {
+    it('broadcasts the token and clears the mark', () => {
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+      const storage = makeStorage({});
+      const channel = makeChannel();
+      const createChannel = vi.fn(() => channel);
+      const deferred = [];
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage,
+        createChannel,
+        defer: (fn) => deferred.push(fn),
+      });
+
+      expect(handled).toBe(true);
+      expect(createChannel).toHaveBeenCalledWith('agnt-google-auth');
+      expect(channel.postMessage).toHaveBeenCalledWith({ type: GOOGLE_AUTH_SUCCESS, token: TOKEN });
+      expect(storage.removeItem).toHaveBeenCalledWith('agnt:google-auth-popup-open');
+    });
+
+    it('closes the popup on a deferred task, so delivery is not raced', () => {
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+      const storage = makeStorage({});
+      const deferred = [];
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage,
+        createChannel: () => makeChannel(),
+        defer: (fn) => deferred.push(fn),
+      });
+
+      expect(handled).toBe(true);
+      expect(win.close).not.toHaveBeenCalled(); // still a task to come
+      expect(deferred.length).toBe(1);
+      deferred[0]();
+      expect(win.close).toHaveBeenCalled();
+    });
+
+    it('never opens a wildcard broadcast — the channel is fixed', () => {
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+      const channel = makeChannel();
+
+      forwardGoogleAuthToOpener(win, {
+        storage: makeStorage({}),
+        createChannel: () => channel,
+      });
+
+      expect(channel.postMessage.mock.calls[0][1]).toBeUndefined(); // no targetOrigin — channels have none
+      // and there is no '*' anywhere on the call
+      expect(JSON.stringify(channel.postMessage.mock.calls[0])).not.toContain('*');
+    });
+  });
+
+  describe('THE LOAD-BEARING CASE: the redirect flow must not be touched', () => {
+    it('refuses to broadcast when no mark exists', () => {
+      // A popup-blocked user signs in in their own tab: no opener, no mark.
+      // Firing the channel here would close that tab underneath them.
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+      const createChannel = vi.fn();
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage: makeStorage({ present: false }),
+        createChannel,
+      });
+
+      expect(handled).toBe(false);
+      expect(createChannel).not.toHaveBeenCalled();
+      expect(win.close).not.toHaveBeenCalled();
+    });
+
+    it('refuses when the mark is stale, past the five-minute TTL', () => {
+      // A mark left behind by an abandoned attempt must not fire a day later.
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+      const createChannel = vi.fn();
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage: makeStorage({ ageMs: 6 * 60 * 1000 }),
+        createChannel,
+      });
+
+      expect(handled).toBe(false);
+      expect(createChannel).not.toHaveBeenCalled();
+      expect(win.close).not.toHaveBeenCalled();
+    });
+
+    it('leaves the mark alone when it is not fresh, rather than clearing it', () => {
+      // Only a real handoff clears the mark. A stray read must not erase it,
+      // so an abandoned-but-recent popup can still come back and be recognised.
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+      const storage = makeStorage({ ageMs: 6 * 60 * 1000 });
+
+      forwardGoogleAuthToOpener(win, { storage, createChannel: () => null });
+
+      expect(storage.removeItem).not.toHaveBeenCalled();
+      expect(win.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('route preference: the targeted path, or not at all', () => {
+    it('broadcasts nothing when the opener route works', () => {
+      const opener = makeOpener();
+      const win = makeWin({ search: `?token=${TOKEN}`, opener });
+      const createChannel = vi.fn();
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage: makeStorage({}),
+        createChannel,
+      });
+
+      expect(handled).toBe(true);
+      expect(opener.postMessage).toHaveBeenCalled();
+      expect(createChannel).not.toHaveBeenCalled();
+      expect(win.close).toHaveBeenCalled(); // route 1 closes synchronously
+    });
+
+    it('falls through to the channel when the opener has died', () => {
+      // The opener exists but is unreachable — e.g. closed mid-flight. The
+      // popup must not stop there; the fresh mark lets the channel take over.
+      const deadOpener = {
+        postMessage: vi.fn(() => {
+          throw new Error('opener gone');
+        }),
+      };
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: deadOpener });
+      const channel = makeChannel();
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage: makeStorage({}),
+        createChannel: () => channel,
+      });
+
+      expect(handled).toBe(true);
+      expect(channel.postMessage).toHaveBeenCalled();
+    });
+  });
+
+  describe('degradation when the channel cannot be used', () => {
+    it('returns false when BroadcastChannel is unavailable, so boot proceeds', () => {
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage: makeStorage({}),
+        createChannel: () => null,
+      });
+
+      expect(handled).toBe(false);
+      expect(win.close).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the channel throws on postMessage', () => {
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+      const channel = {
+        postMessage: vi.fn(() => {
+          throw new Error('channel dead');
+        }),
+        close: vi.fn(),
+      };
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage: makeStorage({}),
+        createChannel: () => channel,
+      });
+
+      expect(handled).toBe(false);
+      expect(channel.close).toHaveBeenCalled(); // still released
+      expect(win.close).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue
@@ -149,20 +149,46 @@ export default {
         `width=${width},height=${height},top=${top},left=${left}`,
       );
 
+      // The popup sends this from utils/googleAuthPopup.js, before it boots
+      // anything, and then closes itself.
+      //
+      // Until that existed nothing sent it at all: the remote redirects the
+      // POPUP to `<origin>/settings?token=...`, so the popup loaded a second
+      // copy of AGNT and signed itself in, and this window — the one the user
+      // was actually looking at — sat here waiting for a message that was
+      // never coming.
+      const stopListening = () => {
+        window.removeEventListener('message', handleMessage);
+        clearInterval(closedPoll);
+      };
+
       const handleMessage = async (event) => {
+        // Only our own popup may complete a sign-in. It posts with an explicit
+        // targetOrigin, so a genuine cross-origin sender is never legitimate
+        // here. Electron's opener proxy can report an empty origin for a window
+        // that is same-origin by construction, so that one case is tolerated.
+        if (event.origin && event.origin !== window.location.origin) return;
+
         if (event.data?.type === 'google-auth-success') {
           const { token } = event.data;
 
-          window.removeEventListener('message', handleMessage);
+          stopListening();
 
           if (token) {
             await signIn(token);
           }
         } else if (event.data?.type === 'google-auth-error') {
-          window.removeEventListener('message', handleMessage);
+          stopListening();
           errorMessage.value = event.data.error || 'Login failed';
         }
       };
+
+      // A user who closes the popup without finishing used to leave this
+      // listener installed for the life of the page — one more of them on every
+      // click of the button, each one holding this component's scope alive.
+      const closedPoll = setInterval(() => {
+        if (!popup || popup.closed) stopListening();
+      }, 500);
 
       window.addEventListener('message', handleMessage);
     };

--- a/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue
@@ -107,7 +107,8 @@ import { useRouter } from 'vue-router';
 import SvgIcon from '@/views/_components/common/SvgIcon.vue';
 import TermsPrivacyModal from '@/components/TermsPrivacyModal.vue';
 import { API_CONFIG } from '@/tt.config.js';
-import { consumeAdoptedToken } from '@/store/auth/urlSessionToken.js';
+import { consumeAdoptedToken, looksLikeJwt } from '@/store/auth/urlSessionToken.js';
+import { isTrustedAuthMessage } from '@/utils/googleAuthPopup.js';
 
 export default {
   name: 'AuthSection',
@@ -163,20 +164,27 @@ export default {
       };
 
       const handleMessage = async (event) => {
-        // Only our own popup may complete a sign-in. It posts with an explicit
-        // targetOrigin, so a genuine cross-origin sender is never legitimate
-        // here. Electron's opener proxy can report an empty origin for a window
-        // that is same-origin by construction, so that one case is tolerated.
-        if (event.origin && event.origin !== window.location.origin) return;
+        // Only the popup we just opened may complete a sign-in. An origin check
+        // alone is not enough here: artifact and widget iframes are
+        // `allow-scripts allow-same-origin`, so authored HTML runs at this
+        // origin and could otherwise post a token of its own choosing. See
+        // utils/googleAuthPopup.js.
+        if (!isTrustedAuthMessage(event, popup)) return;
 
         if (event.data?.type === 'google-auth-success') {
           const { token } = event.data;
 
           stopListening();
 
-          if (token) {
-            await signIn(token);
+          // The same structural rule the address-bar handover applies. A token
+          // that cannot be one must not reach SET_TOKEN, where it would evict
+          // a session that is currently working.
+          if (!looksLikeJwt(token)) {
+            errorMessage.value = 'Login failed';
+            return;
           }
+
+          await signIn(token);
         } else if (event.data?.type === 'google-auth-error') {
           stopListening();
           errorMessage.value = event.data.error || 'Login failed';

--- a/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue
@@ -108,7 +108,13 @@ import SvgIcon from '@/views/_components/common/SvgIcon.vue';
 import TermsPrivacyModal from '@/components/TermsPrivacyModal.vue';
 import { API_CONFIG } from '@/tt.config.js';
 import { consumeAdoptedToken, looksLikeJwt } from '@/store/auth/urlSessionToken.js';
-import { isTrustedAuthMessage } from '@/utils/googleAuthPopup.js';
+import {
+  isTrustedAuthMessage,
+  markGoogleAuthPopupOpen,
+  clearGoogleAuthPopupMark,
+  GOOGLE_AUTH_CHANNEL,
+  GOOGLE_AUTH_SUCCESS,
+} from '@/utils/googleAuthPopup.js';
 
 export default {
   name: 'AuthSection',
@@ -144,6 +150,12 @@ export default {
       const left = window.screen.width / 2 - width / 2;
       const top = window.screen.height / 2 - height / 2;
 
+      // Before opening, not after: the popup may come back with its opener
+      // severed by COOP, and this mark is the only thing that then lets it tell
+      // itself apart from an ordinary redirect into the user's own tab. See
+      // utils/googleAuthPopup.js.
+      markGoogleAuthPopupOpen();
+
       const popup = window.open(
         `${API_CONFIG.REMOTE_URL}/users/auth/google?redirectUrl=${encodeURIComponent(redirectUrl)}`,
         'google-login-popup',
@@ -161,6 +173,41 @@ export default {
       const stopListening = () => {
         window.removeEventListener('message', handleMessage);
         clearInterval(closedPoll);
+        try {
+          channel?.close();
+        } catch {
+          /* already closed */
+        }
+        clearGoogleAuthPopupMark();
+      };
+
+      // The popup reaches us by whichever route survives — the opener if COOP
+      // has not severed it, the same-origin channel otherwise. Both land here,
+      // and `settled` is what stops a token that arrives twice from signing in
+      // twice, or from racing a teardown already in progress.
+      let settled = false;
+
+      const completeSignIn = async (token) => {
+        if (settled) return;
+        settled = true;
+        stopListening();
+
+        // The same structural rule the address-bar handover applies. A token
+        // that cannot be one must not reach SET_TOKEN, where it would evict
+        // a session that is currently working.
+        if (!looksLikeJwt(token)) {
+          errorMessage.value = 'Login failed';
+          return;
+        }
+
+        await signIn(token);
+      };
+
+      const failSignIn = (message) => {
+        if (settled) return;
+        settled = true;
+        stopListening();
+        errorMessage.value = message || 'Login failed';
       };
 
       const handleMessage = async (event) => {
@@ -171,25 +218,35 @@ export default {
         // utils/googleAuthPopup.js.
         if (!isTrustedAuthMessage(event, popup)) return;
 
-        if (event.data?.type === 'google-auth-success') {
-          const { token } = event.data;
-
-          stopListening();
-
-          // The same structural rule the address-bar handover applies. A token
-          // that cannot be one must not reach SET_TOKEN, where it would evict
-          // a session that is currently working.
-          if (!looksLikeJwt(token)) {
-            errorMessage.value = 'Login failed';
-            return;
-          }
-
-          await signIn(token);
+        if (event.data?.type === GOOGLE_AUTH_SUCCESS) {
+          await completeSignIn(event.data.token);
         } else if (event.data?.type === 'google-auth-error') {
-          stopListening();
-          errorMessage.value = event.data.error || 'Login failed';
+          failSignIn(event.data.error);
         }
       };
+
+      // The fallback route. A BroadcastChannel carries no sender identity, so
+      // unlike the message listener above there is nothing here to check it
+      // against — it is same-origin by construction, and that is the whole
+      // boundary. Worth being plain about the trade-off: a hostile same-origin
+      // script could broadcast a token of its own. It could also simply write
+      // one to localStorage, which is where this app keeps the session, so the
+      // channel grants it nothing it did not already have. The shape check in
+      // completeSignIn still applies.
+      let channel = null;
+      try {
+        channel =
+          typeof BroadcastChannel === 'function' ? new BroadcastChannel(GOOGLE_AUTH_CHANNEL) : null;
+      } catch {
+        channel = null; // unavailable in this environment; the opener route stands alone
+      }
+      if (channel) {
+        channel.onmessage = async (event) => {
+          if (event.data?.type === GOOGLE_AUTH_SUCCESS) {
+            await completeSignIn(event.data.token);
+          }
+        };
+      }
 
       // A user who closes the popup without finishing used to leave this
       // listener installed for the life of the page — one more of them on every


### PR DESCRIPTION
Clicking **Continue with Google** leaves the user working inside the 600x700 sign-in popup. The window they started from stays on the sign-in screen.

## What is happening

`connectGoogle()` opens the popup and then listens on its own window for a `google-auth-success` message:

```js
const handleMessage = async (event) => {
  if (event.data?.type === 'google-auth-success') { ... }
```

**Nothing ever sent that message.** A search of the tree finds the listener and no sender anywhere, so it has been dead since it was written.

The remote does not hand the token back to the opener. It redirects the **popup** to `<origin>/settings?token=…`:

```
$ curl -sI "https://api.agnt.gg/users/auth/google?redirectUrl=https%3A%2F%2F<tenant>%2Fsettings"
HTTP/2 302
location: https://accounts.google.com/o/oauth2/v2/auth?…&state=eyJyZWRpcmVjdFVybCI6Imh0dHBzOi8vPHRlbmFudD4vc2V0dGluZ3MiLCJyZWZlcnJhbENvZGUiOm51bGx9
                                                          state = {"redirectUrl":"https://<tenant>/settings","referralCode":null}
```

That URL is the whole application. So the popup booted a second copy of AGNT, adopted the token from its own address bar, verified it and navigated to the chat — exactly as designed, in the wrong window. The opener was never told anything, because the only thing that could have told it did not exist.

This is why it looks like a UI glitch rather than an auth bug: the sign-in genuinely succeeds. Every unit involved does its job correctly.

## The change

The popup hands the token to its opener and closes — the message the opener has always been waiting for.

It runs at module scope in `main.js`, before `createApp`, for two reasons:

- **A window that exists only to carry a token back must not mount an application.** Doing this from a component renders the entire SPA in the popup before it closes, and every request that render issues is real.
- **It has to precede `adoptTokenFromUrl`.** That function strips `?token=` from the address bar so a live credential cannot reach browser history or a `Referer` header — correct, and it makes the token single-use. Whichever of the two runs first is the one that gets it, and if adoption wins, the popup signs itself in and this bug is back with every unit test still green.

That ordering is asserted mechanically against `main.js` source, in the same way and for the same reason as the rest of the boot sequence in `urlSessionToken.spec.js` — no unit test of either function can see it.

### The redirect flow is deliberately untouched

No opener means no popup, so the handover reports "not handled" and boot proceeds exactly as before. That is the path taken when a browser blocks popups, and breaking it would lock those users out while every test here stayed green. An unreachable opener and a refused `close()` are treated the same way: fall back to signing in here — the old behaviour — rather than strand the user in a window nobody is listening to.

### Two defects in the receiving listener

Both reachable from the same button:

- it accepted `google-auth-success` **from any origin**, so any frame that could reach the window could complete a sign-in with a token of its own choosing. It now checks `event.origin` (tolerating an empty origin, which Electron's opener proxy reports for a window that is same-origin by construction).
- it was **never removed unless a message arrived**, so closing the popup without finishing left it installed for the life of the page — one more on every click, each holding the component's scope alive. It now also stops when the popup closes.

## Testing

`frontend/src/utils/googleAuthPopup.spec.js` — 11 tests. Full frontend suite green: **228 files / 4034 tests**.

Mutation tested, three ways, each caught by exactly the test that should catch it and no other:

| Mutation | Result |
| --- | --- |
| `if (win) return false` (pre-fix behaviour) | 3 unit tests fail |
| handoff moved below `adoptTokenFromUrl` | ordering test fails, alone |
| `app.mount('#app')` unguarded | mount-guard test fails, alone |

Markers confirmed absent from the tree afterwards.

## Note for maintainers

The dead listener suggests the popup path has never worked. Worth a look at whether the remote was once intended to `postMessage` to the opener — if it is ever changed to do so, this handover becomes redundant rather than wrong, since it only acts on a popup that is carrying a token in its own URL.
