### PR TITLE
fix(auth): vet the sender before redeeming an OAuth code

### DIFF
--- a/frontend/src/__guards__/oauthMessageOriginContract.spec.js
+++ b/frontend/src/__guards__/oauthMessageOriginContract.spec.js
@@ -1,0 +1,197 @@
+/**
+ * CONTRACT: code that redeems an OAuth code must first vet the message origin.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `providerAuthService.completeRemoteOAuthCallback({ code, state })` POSTs a
+ * forwarded authorization code to `/auth/callback` **with the signed-in user's
+ * bearer token**. Every caller of it sits inside a `message` listener, so the
+ * origin check in front of it is the entire trust boundary: cross-origin
+ * *sending* is permitted by design and cannot be prevented.
+ *
+ * Three call sites existed and they did three different things. One had no
+ * origin check at all. Two shared a copy-pasted guard whose second term never
+ * referenced its own loop variable:
+ *
+ *   allowedOrigins.some((origin) =>
+ *     event.origin === origin || event.origin.includes('localhost'))
+ *
+ * making it an unconditional substring test that admitted `localhost.evil.com`
+ * and friends. Redeeming an attacker's code grafts the ATTACKER'S Google /
+ * Gmail / Drive account onto the victim's AGNT user, so the victim's later
+ * agent runs operate on someone else's data.
+ *
+ * It was a *class* of bug rather than one mistake because no single module
+ * owned the rule — the same reasoning as apiAuthContract.spec.js in this
+ * directory, and the same remedy: one shared predicate, enforced mechanically
+ * at every call site.
+ *
+ * Neither Connectors.vue nor IntegrationHealth.vue has a unit spec, so without
+ * this guard the check could be deleted from either and nothing would fail.
+ *
+ * The call sites are DISCOVERED from source rather than listed here, so a
+ * fourth handler added tomorrow is covered without anyone remembering to come
+ * back and update this file.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FRONTEND_SRC = path.resolve(HERE, '..');
+
+/** The dangerous operation: redeeming a code against the current user. */
+const REDEEM = 'completeRemoteOAuthCallback';
+/** The one predicate allowed to answer "may this sender do that?". */
+const GUARD = 'isTrustedOAuthMessageOrigin';
+
+/**
+ * Where the function is defined and where it is mocked. Neither redeems
+ * anything on a real user's behalf.
+ */
+const NOT_CALL_SITES = [
+  'services/providerAuthService.js',
+  'services/providerAuthService.spec.js',
+];
+
+/**
+ * Remove comments so that prose discussing these identifiers cannot vouch for
+ * a file that never calls them — and so a commented-out guard reads as absent.
+ *
+ * String- and template-aware on purpose: a naive `//.*$` sweep truncates any
+ * line containing a URL, which would silently delete real code from the text
+ * being scanned and turn this guard into a source of false passes.
+ */
+function stripComments(source) {
+  let out = '';
+  let i = 0;
+  const n = source.length;
+
+  while (i < n) {
+    const ch = source[i];
+    const next = source[i + 1];
+
+    if (ch === '/' && next === '/') {
+      while (i < n && source[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      i += 2;
+      while (i < n && !(source[i] === '*' && source[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const quote = ch;
+      out += ch;
+      i++;
+      while (i < n) {
+        if (source[i] === '\\') {
+          out += source[i] + (source[i + 1] ?? '');
+          i += 2;
+          continue;
+        }
+        out += source[i];
+        if (source[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    out += ch;
+    i++;
+  }
+
+  return out;
+}
+
+function walk(dir, found = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, found);
+    } else if (/\.(js|vue)$/.test(entry.name)) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+function callSites() {
+  return walk(FRONTEND_SRC)
+    .map((full) => ({
+      rel: path.relative(FRONTEND_SRC, full).split(path.sep).join('/'),
+      code: stripComments(fs.readFileSync(full, 'utf8')),
+    }))
+    .filter(({ rel, code }) => !NOT_CALL_SITES.includes(rel) && code.includes(`${REDEEM}(`));
+}
+
+describe('every OAuth code redemption is behind an origin check', () => {
+  it('finds the call sites at all, so a silent zero cannot pass this suite', () => {
+    // Without this, renaming the service method would empty the set and every
+    // assertion below would vacuously succeed.
+    const sites = callSites().map((s) => s.rel);
+
+    expect(sites.length).toBeGreaterThanOrEqual(3);
+    expect(sites).toContain('composables/useProviderConnection.js');
+    expect(sites).toContain('views/Terminal/CenterPanel/screens/Connectors/Connectors.vue');
+    expect(sites).toContain(
+      'views/Terminal/RightPanel/types/ChatPanel/components/IntegrationHealth.vue',
+    );
+  });
+
+  it('vets the sender before redeeming, at every call site', () => {
+    const unguarded = callSites()
+      .filter(({ code }) => !code.includes(`${GUARD}(`))
+      .map(({ rel }) => rel);
+
+    expect(unguarded, `these redeem an OAuth code without calling ${GUARD}`).toEqual([]);
+  });
+
+  it('nobody has reintroduced a hand-rolled origin comparison', () => {
+    // The two guards that existed were copy-pasted, and the copy is what let
+    // them drift apart. One predicate, or the class of bug comes back.
+    const handRolled = callSites()
+      .filter(({ code }) => /event\.origin\s*(===|!==|\.includes|\.startsWith|\.indexOf)/.test(code))
+      .map(({ rel }) => rel);
+
+    expect(handRolled, `these compare event.origin inline instead of using ${GUARD}`).toEqual([]);
+  });
+
+  it('the guard is called before the redemption in each file', () => {
+    // Ordering is the whole point: a check that runs afterwards is decoration.
+    const tooLate = callSites()
+      .filter(({ code }) => code.indexOf(`${GUARD}(`) > code.indexOf(`${REDEEM}(`))
+      .map(({ rel }) => rel);
+
+    expect(tooLate, `these call ${REDEEM} before ${GUARD}`).toEqual([]);
+  });
+});
+
+describe('the comment stripper this guard depends on', () => {
+  // Self-tests, because a stripper that eats real code turns the assertions
+  // above into false passes — the exact failure mode Copilot caught in the
+  // sibling guard on PR #78.
+  it('removes a commented-out guard call', () => {
+    expect(stripComments(`// ${GUARD}(event.origin)`)).not.toContain(GUARD);
+  });
+
+  it('keeps a URL that contains a double slash', () => {
+    const line = `const state = 'github:http://localhost:3333';`;
+    expect(stripComments(line)).toBe(line);
+  });
+
+  it('keeps code that follows a URL on the same line', () => {
+    const line = `send('https://api.agnt.gg'); ${GUARD}(event.origin);`;
+    expect(stripComments(line)).toContain(`${GUARD}(event.origin)`);
+  });
+
+  it('removes a block comment without touching adjacent code', () => {
+    expect(stripComments(`a();/* ${GUARD}( */b();`)).toBe('a();b();');
+  });
+});

--- a/frontend/src/__guards__/oauthMessageOriginContract.spec.js
+++ b/frontend/src/__guards__/oauthMessageOriginContract.spec.js
@@ -45,6 +45,8 @@ const FRONTEND_SRC = path.resolve(HERE, '..');
 const REDEEM = 'completeRemoteOAuthCallback';
 /** The one predicate allowed to answer "may this sender do that?". */
 const GUARD = 'isTrustedOAuthMessageOrigin';
+/** The one predicate allowed to answer "is this message actionable?". */
+const PAYLOAD_GUARD = 'hasOAuthMessagePayload';
 
 /**
  * Where the function is defined and where it is mocked. Neither redeems
@@ -170,6 +172,35 @@ describe('every OAuth code redemption is behind an origin check', () => {
       .map(({ rel }) => rel);
 
     expect(tooLate, `these call ${REDEEM} before ${GUARD}`).toEqual([]);
+  });
+
+  /**
+   * A trusted origin is not a well-formed message. These are global `message`
+   * listeners, so a same-origin sender that knows nothing about OAuth can post
+   * `null` and make `event.data.type` throw. Because the handlers are `async`
+   * that surfaces as an unhandled rejection rather than a visible crash, so
+   * nothing fails loudly when it regresses — which is exactly when a mechanical
+   * check earns its place.
+   */
+  it('checks the payload is object-shaped before branching on it', () => {
+    const unguarded = callSites()
+      .filter(({ code }) => !code.includes(`${PAYLOAD_GUARD}(`))
+      .map(({ rel }) => rel);
+
+    expect(unguarded, `these read event.data without calling ${PAYLOAD_GUARD}`).toEqual([]);
+  });
+
+  it('nobody has reintroduced a hand-rolled payload check', () => {
+    // Three handlers previously disagreed about this: two omitted it entirely
+    // and one repeated `event.data &&` at every branch. One predicate, or they
+    // drift apart again.
+    const handRolled = callSites()
+      .filter(({ code }) => /event\.data\s*&&/.test(code))
+      .map(({ rel }) => rel);
+
+    expect(handRolled, `these test event.data inline instead of using ${PAYLOAD_GUARD}`).toEqual(
+      [],
+    );
   });
 });
 

--- a/frontend/src/composables/useProviderConnection.js
+++ b/frontend/src/composables/useProviderConnection.js
@@ -9,7 +9,10 @@ import { API_CONFIG } from '@/tt.config.js';
 import { PROVIDER_DISPLAY_NAMES, resolveProviderKey } from '@/store/app/aiProvider.js';
 import { encrypt } from '@/views/_utils/encryption.js';
 import providerAuthService from '@/services/providerAuthService.js';
-import { isTrustedOAuthMessageOrigin } from '@/utils/oauthMessageOrigin.js';
+import {
+  isTrustedOAuthMessageOrigin,
+  hasOAuthMessagePayload,
+} from '@/utils/oauthMessageOrigin.js';
 
 export function useProviderConnection(modalRef) {
   const store = useStore();
@@ -482,6 +485,12 @@ export function useProviderConnection(modalRef) {
     // `event.origin.includes('localhost')`, which admitted any registrable
     // domain containing that substring. See utils/oauthMessageOrigin.js.
     if (!isTrustedOAuthMessageOrigin(event.origin)) return;
+
+    // A trusted origin is not a well-formed message. This is a global listener,
+    // so a same-origin extension or dev-server client posting `null` would
+    // otherwise throw on `event.data.type` — as an unhandled rejection, since
+    // this handler is async.
+    if (!hasOAuthMessagePayload(event)) return;
 
     if (event.data.type === 'oauth_success') {
       await refreshHealth();

--- a/frontend/src/composables/useProviderConnection.js
+++ b/frontend/src/composables/useProviderConnection.js
@@ -9,6 +9,7 @@ import { API_CONFIG } from '@/tt.config.js';
 import { PROVIDER_DISPLAY_NAMES, resolveProviderKey } from '@/store/app/aiProvider.js';
 import { encrypt } from '@/views/_utils/encryption.js';
 import providerAuthService from '@/services/providerAuthService.js';
+import { isTrustedOAuthMessageOrigin } from '@/utils/oauthMessageOrigin.js';
 
 export function useProviderConnection(modalRef) {
   const store = useStore();
@@ -476,8 +477,11 @@ export function useProviderConnection(modalRef) {
   // ── OAuth postMessage listener ───────────────────────────
 
   const handleOAuthMessage = async (event) => {
-    const allowedOrigins = [window.location.origin, 'https://api.agnt.gg'];
-    if (!allowedOrigins.some((origin) => event.origin === origin || event.origin.includes('localhost'))) return;
+    // This handler redeems an OAuth code against the signed-in user's account,
+    // so the origin check is the trust boundary. It used to OR in a bare
+    // `event.origin.includes('localhost')`, which admitted any registrable
+    // domain containing that substring. See utils/oauthMessageOrigin.js.
+    if (!isTrustedOAuthMessageOrigin(event.origin)) return;
 
     if (event.data.type === 'oauth_success') {
       await refreshHealth();

--- a/frontend/src/composables/useProviderConnection.spec.js
+++ b/frontend/src/composables/useProviderConnection.spec.js
@@ -92,8 +92,11 @@ describe('useProviderConnection — oauth-callback postMessage handler', () => {
           state: 'twitter:http://localhost:3333',
           provider: 'twitter',
         },
-        // jsdom's window.location.origin is 'http://localhost' which the
-        // handler accepts via its `event.origin.includes('localhost')` rule.
+        // Same-origin, which is an exact match against `window.location.origin`.
+        // This previously carried a comment attributing the pass to the
+        // handler's `event.origin.includes('localhost')` rule; that was never
+        // true — the exact-match term matched first, and the test goes on
+        // passing now that the substring rule is gone.
         origin: window.location.origin,
       }),
     );
@@ -134,6 +137,41 @@ describe('useProviderConnection — oauth-callback postMessage handler', () => {
           provider: 'twitter',
         },
         origin: 'https://evil.example.com',
+      }),
+    );
+    await flushPromises();
+
+    expect(providerAuthService.completeRemoteOAuthCallback).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The test above passed against the vulnerable handler too: it never
+   * exercised the hole. The old guard OR'd in a bare
+   * `event.origin.includes('localhost')`, so it refused `evil.example.com`
+   * while admitting anything whose origin merely CONTAINED that substring —
+   * all of these registrable by an attacker.
+   *
+   * A wrong code redeemed here is grafted onto the signed-in user's account,
+   * so these run through the real listener rather than the predicate alone.
+   */
+  it.each([
+    'https://localhost.evil.com',
+    'https://evil-localhost.io',
+    'http://localhostage.com',
+    'https://notlocalhost.xyz',
+  ])('ignores oauth-callback from %s, which the substring rule admitted', async (origin) => {
+    wrapper = mount(Harness, { global: { plugins: [makeStore()] } });
+    await flushPromises();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          type: 'oauth-callback',
+          code: 'attacker-supplied-code',
+          state: 'twitter:x',
+          provider: 'twitter',
+        },
+        origin,
       }),
     );
     await flushPromises();

--- a/frontend/src/composables/useProviderConnection.spec.js
+++ b/frontend/src/composables/useProviderConnection.spec.js
@@ -154,6 +154,85 @@ describe('useProviderConnection — oauth-callback postMessage handler', () => {
    * A wrong code redeemed here is grafted onto the signed-in user's account,
    * so these run through the real listener rather than the predicate alone.
    */
+  /**
+   * Passing the origin check says the sender is us; it says nothing about what
+   * they sent. This is a global `message` listener, so same-origin senders that
+   * know nothing about OAuth reach it too, and `event.data.type` on a `null`
+   * payload throws.
+   *
+   * The rejection has to be captured explicitly. `handleOAuthMessage` is
+   * `async`, so the throw never reaches `dispatchEvent` — it becomes an
+   * unhandled rejection, and a test written as `expect(() =>
+   * window.dispatchEvent(...)).not.toThrow()` passes whether or not the guard
+   * exists. Verified before writing this: without the capture below, removing
+   * the guard leaves the suite green.
+   */
+  // `undefined` is deliberately absent: the MessageEvent constructor
+  // normalises it to `null` (verified, not assumed), so a case labelled
+  // "undefined" here would silently be a second null case. Genuine `undefined`
+  // is covered against the predicate directly in utils/oauthMessageOrigin.spec.js.
+  it.each([
+    ['null', null],
+    ['a string', 'vite:beforeUpdate'],
+    ['a number', 42],
+  ])(
+    'survives a trusted-origin message whose payload is %s',
+    async (_label, data) => {
+      wrapper = mount(Harness, { global: { plugins: [makeStore()] } });
+      await flushPromises();
+
+      const rejections = [];
+      const capture = (reason) => rejections.push(reason);
+      process.on('unhandledRejection', capture);
+
+      try {
+        window.dispatchEvent(
+          new MessageEvent('message', { data, origin: window.location.origin }),
+        );
+        await flushPromises();
+        // An unhandled rejection is only reported once the microtask queue has
+        // drained and no handler has attached, so yield to the macrotask queue.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      } finally {
+        process.off('unhandledRejection', capture);
+      }
+
+      expect(rejections.map(String)).toEqual([]);
+      expect(providerAuthService.completeRemoteOAuthCallback).not.toHaveBeenCalled();
+    },
+  );
+
+  it('still acts on a well-formed message after a malformed one', async () => {
+    // The guard must skip the bad message, not wedge the listener.
+    providerAuthService.completeRemoteOAuthCallback.mockResolvedValueOnce({
+      success: true,
+      provider: 'twitter',
+    });
+
+    wrapper = mount(Harness, { global: { plugins: [makeStore()] } });
+    await flushPromises();
+
+    window.dispatchEvent(
+      new MessageEvent('message', { data: null, origin: window.location.origin }),
+    );
+    await flushPromises();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          type: 'oauth-callback',
+          code: 'twitter-auth-code-xyz',
+          state: 'twitter:x',
+          provider: 'twitter',
+        },
+        origin: window.location.origin,
+      }),
+    );
+    await flushPromises();
+
+    expect(providerAuthService.completeRemoteOAuthCallback).toHaveBeenCalledTimes(1);
+  });
+
   it.each([
     'https://localhost.evil.com',
     'https://evil-localhost.io',

--- a/frontend/src/utils/oauthMessageOrigin.js
+++ b/frontend/src/utils/oauthMessageOrigin.js
@@ -120,3 +120,32 @@ export function isTrustedOAuthMessageOrigin(
 
   return false;
 }
+
+/**
+ * Does this message carry a payload worth branching on?
+ *
+ * A trusted origin is not a well-formed message. These are GLOBAL `message`
+ * listeners: they receive every message the window gets, including ones from
+ * senders that have nothing to do with OAuth and post whatever they like. A
+ * browser extension, a dev-server client, another widget on the page — all of
+ * them are same-origin, all of them therefore pass the origin check, and any
+ * of them may post `null`.
+ *
+ * `event.data.type` on a null payload throws. The handlers are `async`, so the
+ * throw does not surface to the dispatcher: it becomes an unhandled rejection,
+ * which is why it can happen repeatedly without anyone noticing.
+ *
+ * Only object payloads are actionable, since every message these handlers act
+ * on is `{ type, ... }`. A string, a number or an array cannot match any branch
+ * anyway, so rejecting them here changes no behaviour — it just moves the
+ * decision to one documented place instead of relying on every `.type` read
+ * being individually defensive.
+ *
+ * @param {MessageEvent} event
+ * @returns {boolean}
+ */
+export function hasOAuthMessagePayload(event) {
+  const data = event?.data;
+  // `typeof null` is 'object', so the null check is not redundant.
+  return data !== null && typeof data === 'object';
+}

--- a/frontend/src/utils/oauthMessageOrigin.js
+++ b/frontend/src/utils/oauthMessageOrigin.js
@@ -1,0 +1,122 @@
+/**
+ * WHICH ORIGINS MAY COMPLETE AN OAUTH CONNECTION.
+ *
+ * ---------------------------------------------------------------------------
+ * THE DEFECT THIS EXISTS FOR
+ * ---------------------------------------------------------------------------
+ * Three `message` handlers act on an `oauth-callback` payload by POSTing the
+ * forwarded `code` to `${REMOTE_URL}/auth/callback` **with the current user's
+ * bearer token**. Whoever can reach those handlers can therefore have an OAuth
+ * authorization code of their choosing redeemed against the victim's account.
+ *
+ * Two of them guarded that with:
+ *
+ *   allowedOrigins.some((origin) =>
+ *     event.origin === origin || event.origin.includes('localhost'))
+ *
+ * The second term never references the callback's own `origin` parameter, so
+ * it is a constant OR'd into every iteration — in effect an unconditional
+ * substring test on the sender's origin. Every one of these is admitted:
+ *
+ *   https://localhost.evil.com     https://evil-localhost.io
+ *   http://localhostage.com        https://notlocalhost.xyz
+ *
+ * all of them registrable by anyone. The third handler (Connectors.vue) had no
+ * origin check at all, so `https://evil.com` reached it directly.
+ *
+ * The consequence is account grafting, not token theft: the ATTACKER'S Google
+ * / Gmail / Drive account gets linked under the VICTIM'S AGNT user, and the
+ * victim's later "read my email" or "save this to Drive" runs operate on the
+ * attacker's account. Nothing on screen indicates it happened.
+ *
+ * Cross-origin *sending* is permitted by design and cannot be prevented — the
+ * receiver's origin check IS the trust boundary. It has to be exact.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY LOOPBACK IS MATCHED ON HOSTNAME, AND ONLY IN A LOOPBACK APP
+ * ---------------------------------------------------------------------------
+ * Development genuinely needs it: the Vite dev server and the backend sit on
+ * different loopback ports, so an exact-origin allowlist alone would break the
+ * OAuth flow for anyone running from source.
+ *
+ * That need is met by parsing the origin and comparing its HOSTNAME against a
+ * fixed set. `new URL('https://localhost.evil.com').hostname` is
+ * `'localhost.evil.com'`, which is not `'localhost'` — the substring hole
+ * closes without costing developers anything.
+ *
+ * The allowance is further conditioned on the APP ITSELF being served from a
+ * loopback host. A hosted tenant therefore never accepts a loopback sender,
+ * so a developer convenience cannot become a production trust rule.
+ */
+
+import { API_CONFIG } from '@/tt.config.js';
+
+/**
+ * Hosts that mean "this machine". Compared exactly, never by substring.
+ * WHATWG `URL` normalises an IPv6 literal to bracketed form in `hostname`.
+ */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+/**
+ * The literal string an opaque origin serialises to — a sandboxed iframe, a
+ * `data:` document, some `file:` contexts. It identifies nobody, so it can
+ * never be a match, not even against an app that is itself opaque.
+ */
+const OPAQUE_ORIGIN = 'null';
+
+function hostnameOf(origin) {
+  try {
+    return new URL(origin).hostname;
+  } catch {
+    return null;
+  }
+}
+
+function originOf(url) {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+function isLoopbackOrigin(origin) {
+  const hostname = hostnameOf(origin);
+  return hostname !== null && LOOPBACK_HOSTS.has(hostname);
+}
+
+/**
+ * May a `message` from this origin be allowed to complete an OAuth connection?
+ *
+ * @param {string} eventOrigin  the `event.origin` of the received message
+ * @param {Window} [win]        injectable for tests
+ * @param {string} [remoteUrl]  injectable for tests; the AGNT API base URL
+ * @returns {boolean}
+ */
+export function isTrustedOAuthMessageOrigin(
+  eventOrigin,
+  win = globalThis.window,
+  remoteUrl = API_CONFIG?.REMOTE_URL,
+) {
+  // An absent or opaque origin identifies nobody. Unlike the popup handover in
+  // utils/googleAuthPopup.js there is no second signal to fall back on here, so
+  // this refuses rather than abstains.
+  if (typeof eventOrigin !== 'string') return false;
+  if (eventOrigin === '' || eventOrigin === OPAQUE_ORIGIN) return false;
+
+  const appOrigin = win?.location?.origin;
+
+  // The app talking to itself: the in-popup callback page on our own origin.
+  if (appOrigin && eventOrigin === appOrigin) return true;
+
+  // The AGNT API, whose callback page forwards the raw code in the Electron
+  // path. Compared as a parsed origin so a trailing path in the configured
+  // URL cannot cause a miss.
+  const remoteOrigin = originOf(remoteUrl);
+  if (remoteOrigin && eventOrigin === remoteOrigin) return true;
+
+  // Any loopback port, but only while we are ourselves on loopback.
+  if (appOrigin && isLoopbackOrigin(appOrigin) && isLoopbackOrigin(eventOrigin)) return true;
+
+  return false;
+}

--- a/frontend/src/utils/oauthMessageOrigin.spec.js
+++ b/frontend/src/utils/oauthMessageOrigin.spec.js
@@ -24,7 +24,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isTrustedOAuthMessageOrigin } from './oauthMessageOrigin.js';
+import { isTrustedOAuthMessageOrigin, hasOAuthMessagePayload } from './oauthMessageOrigin.js';
 
 const REMOTE = 'https://api.agnt.gg';
 const hostedApp = { location: { origin: 'https://tenant.example.com' } };
@@ -126,6 +126,7 @@ describe('isTrustedOAuthMessageOrigin', () => {
   });
 
   describe('it does not fall over on a broken environment', () => {
+
     it('survives a window with no location', () => {
       expect(isTrustedOAuthMessageOrigin('https://api.agnt.gg', {}, REMOTE)).toBe(true);
       expect(isTrustedOAuthMessageOrigin('https://evil.com', {}, REMOTE)).toBe(false);
@@ -148,5 +149,71 @@ describe('isTrustedOAuthMessageOrigin', () => {
     it('survives a malformed remote URL', () => {
       expect(isTrustedOAuthMessageOrigin('https://api.agnt.gg', hostedApp, 'not a url')).toBe(false);
     });
+  });
+});
+
+/**
+ * A TRUSTED ORIGIN IS NOT A WELL-FORMED MESSAGE.
+ *
+ * These are global `message` listeners. Passing the origin check only means the
+ * sender is us — it says nothing about what they sent, and same-origin senders
+ * that know nothing about OAuth (extensions, dev-server clients, other widgets)
+ * post whatever they like. `event.data.type` on a `null` payload throws.
+ *
+ * The throw is invisible in practice, which is why it survived: the handlers
+ * are `async`, so it never reaches the dispatcher. It becomes an unhandled
+ * rejection instead, and a test written as `expect(...).not.toThrow()` would
+ * pass whether or not the guard exists. The integration test in
+ * useProviderConnection.spec.js captures the rejection explicitly for that
+ * reason.
+ */
+describe('hasOAuthMessagePayload', () => {
+  describe('payloads that can carry a `type`', () => {
+    it.each([
+      ['an OAuth message', { type: 'oauth-callback', code: 'x' }],
+      ['an unrelated object', { hello: 'world' }],
+      ['an empty object', {}],
+      // An array cannot match any branch, but it is object-shaped and reading
+      // `.type` off it is safe, so there is no reason to single it out.
+      ['an array', []],
+    ])('accepts %s', (_label, data) => {
+      expect(hasOAuthMessagePayload({ data })).toBe(true);
+    });
+  });
+
+  describe('payloads that would throw or cannot match', () => {
+    it.each([
+      ['null, the shape Copilot flagged', null],
+      ['undefined', undefined],
+    ])('refuses %s, which would throw on .type', (_label, data) => {
+      expect(hasOAuthMessagePayload({ data })).toBe(false);
+    });
+
+    it.each([
+      ['a string, as some dev-server clients post', 'vite:beforeUpdate'],
+      ['a number', 42],
+      ['a boolean', true],
+    ])('refuses %s, which cannot match any branch', (_label, data) => {
+      // These do not throw — primitives box, so `.type` is merely undefined.
+      // They are refused anyway so that one predicate decides what is
+      // actionable, rather than each `.type` read having to be defensive.
+      expect(hasOAuthMessagePayload({ data })).toBe(false);
+    });
+
+    it('refuses an event with no data property at all', () => {
+      expect(hasOAuthMessagePayload({})).toBe(false);
+    });
+
+    it('refuses a missing event, rather than throwing on it', () => {
+      expect(hasOAuthMessagePayload(undefined)).toBe(false);
+      expect(hasOAuthMessagePayload(null)).toBe(false);
+    });
+  });
+
+  it('does not mistake null for an object', () => {
+    // `typeof null === 'object'`, so a check written as `typeof data ===
+    // 'object'` alone would admit exactly the value that throws.
+    expect(typeof null).toBe('object');
+    expect(hasOAuthMessagePayload({ data: null })).toBe(false);
   });
 });

--- a/frontend/src/utils/oauthMessageOrigin.spec.js
+++ b/frontend/src/utils/oauthMessageOrigin.spec.js
@@ -1,0 +1,152 @@
+/**
+ * WHO MAY REDEEM AN OAUTH CODE AGAINST THE SIGNED-IN USER'S ACCOUNT.
+ *
+ * The handlers behind this predicate POST a forwarded `code` to
+ * `/auth/callback` with the current user's bearer token. Admitting the wrong
+ * sender does not leak the victim's tokens — it grafts the ATTACKER'S account
+ * onto the victim's, so the victim's later "read my email" or "save to Drive"
+ * runs quietly operate on someone else's data.
+ *
+ * The guard this replaces was:
+ *
+ *   allowedOrigins.some((origin) =>
+ *     event.origin === origin || event.origin.includes('localhost'))
+ *
+ * The second term never uses the callback's own `origin` parameter, so it is a
+ * constant OR'd into every iteration — an unconditional substring test. The
+ * repository's existing coverage did not catch it, because the one negative
+ * test used `https://evil.example.com`, which contains no `localhost` and so
+ * was refused by the broken guard too. A negative test only means something
+ * when it exercises the shape that actually slips through.
+ *
+ * These tests are therefore written around the substring hole specifically,
+ * and around the loopback allowance that replaces it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isTrustedOAuthMessageOrigin } from './oauthMessageOrigin.js';
+
+const REMOTE = 'https://api.agnt.gg';
+const hostedApp = { location: { origin: 'https://tenant.example.com' } };
+const localApp = { location: { origin: 'http://localhost:3333' } };
+
+const trusts = (origin, win = hostedApp, remote = REMOTE) =>
+  isTrustedOAuthMessageOrigin(origin, win, remote);
+
+describe('isTrustedOAuthMessageOrigin', () => {
+  describe('the senders that must keep working', () => {
+    it('accepts the app talking to itself', () => {
+      expect(trusts('https://tenant.example.com')).toBe(true);
+    });
+
+    it('accepts the AGNT API, which forwards the code in the Electron path', () => {
+      expect(trusts('https://api.agnt.gg')).toBe(true);
+    });
+
+    it('accepts a remote configured with a path, comparing parsed origins', () => {
+      // user.config.js ships `REMOTE_URL` with an /api suffix in some setups;
+      // a naive string compare against the raw value would never match.
+      expect(trusts('https://api.agnt.gg', hostedApp, 'https://api.agnt.gg/api')).toBe(true);
+    });
+
+    it.each([
+      ['a different loopback port', 'http://localhost:5173'],
+      ['the dotted-quad form', 'http://127.0.0.1:5173'],
+      ['the IPv6 literal', 'http://[::1]:5173'],
+    ])('accepts %s while the app is itself on loopback', (_label, origin) => {
+      // Running from source puts Vite and the backend on different ports, so
+      // an exact-origin allowlist alone would break OAuth for developers.
+      expect(trusts(origin, localApp)).toBe(true);
+    });
+  });
+
+  /**
+   * Every one of these is registrable by anyone, and every one was admitted by
+   * the guard this replaces. They are the reason the check is not a substring.
+   */
+  describe('the origins the substring rule let through', () => {
+    it.each([
+      'https://localhost.evil.com',
+      'https://evil-localhost.io',
+      'http://localhostage.com',
+      'https://notlocalhost.xyz',
+      'http://localhost.attacker.co.uk',
+      'https://xn--localhost-fake.com',
+    ])('refuses %s', (origin) => {
+      expect(trusts(origin)).toBe(false);
+      // ...and refuses it just the same from a developer's own machine, where
+      // the loopback allowance is switched on.
+      expect(trusts(origin, localApp)).toBe(false);
+    });
+  });
+
+  describe('the loopback allowance does not escape development', () => {
+    it('refuses a loopback sender when the app is hosted', () => {
+      // THE LOAD-BEARING TEST. A developer convenience must not become a
+      // production trust rule: a hosted tenant has no reason to believe
+      // anything served from the visitor's own machine.
+      expect(trusts('http://localhost:5173', hostedApp)).toBe(false);
+    });
+
+    it('still accepts the hosted app talking to itself', () => {
+      expect(trusts('https://tenant.example.com', hostedApp)).toBe(true);
+    });
+  });
+
+  describe('near-misses on the allowlisted origins', () => {
+    it.each([
+      ['a suffix of the API host', 'https://api.agnt.gg.evil.com'],
+      ['a prefix of the API host', 'https://evil.com/api.agnt.gg'],
+      ['the API host over plain http', 'http://api.agnt.gg'],
+      ['a subdomain of the API host', 'https://evil.api.agnt.gg'],
+      ['a lookalike of the app host', 'https://tenant.example.com.evil.net'],
+    ])('refuses %s', (_label, origin) => {
+      expect(trusts(origin)).toBe(false);
+    });
+  });
+
+  describe('an origin that identifies nobody is refused, never abstained on', () => {
+    // Unlike the popup handover in utils/googleAuthPopup.js, there is no second
+    // signal here to fall back on, so there is nothing to trade off: an
+    // unattributable sender is simply not trusted.
+    it.each([
+      ['the empty string', ''],
+      ['the opaque origin', 'null'],
+      ['a sandboxed frame reporting undefined', undefined],
+      ['a non-string', 12345],
+      ['an object', {}],
+    ])('refuses %s', (_label, origin) => {
+      expect(trusts(origin)).toBe(false);
+    });
+
+    it('refuses the opaque origin even if the app is itself opaque', () => {
+      // Otherwise a sandboxed artifact iframe would match the app by equality.
+      expect(trusts('null', { location: { origin: 'null' } })).toBe(false);
+    });
+  });
+
+  describe('it does not fall over on a broken environment', () => {
+    it('survives a window with no location', () => {
+      expect(isTrustedOAuthMessageOrigin('https://api.agnt.gg', {}, REMOTE)).toBe(true);
+      expect(isTrustedOAuthMessageOrigin('https://evil.com', {}, REMOTE)).toBe(false);
+    });
+
+    it('falls back to the configured remote when the argument is omitted', () => {
+      // A default parameter fires on `undefined`, so omitting the argument and
+      // passing `undefined` are the same thing: both use API_CONFIG.REMOTE_URL.
+      // `null` is therefore the only way to say "no remote at all", and the
+      // test below relies on that distinction.
+      expect(isTrustedOAuthMessageOrigin('https://api.agnt.gg', hostedApp)).toBe(true);
+      expect(isTrustedOAuthMessageOrigin('https://api.agnt.gg', hostedApp, undefined)).toBe(true);
+    });
+
+    it('survives an unset remote URL', () => {
+      expect(isTrustedOAuthMessageOrigin('https://tenant.example.com', hostedApp, null)).toBe(true);
+      expect(isTrustedOAuthMessageOrigin('https://api.agnt.gg', hostedApp, null)).toBe(false);
+    });
+
+    it('survives a malformed remote URL', () => {
+      expect(isTrustedOAuthMessageOrigin('https://api.agnt.gg', hostedApp, 'not a url')).toBe(false);
+    });
+  });
+});

--- a/frontend/src/views/Terminal/CenterPanel/screens/Connectors/Connectors.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Connectors/Connectors.vue
@@ -836,6 +836,7 @@
 import { ref, computed, nextTick, onMounted, onUnmounted } from 'vue';
 import { useStore } from 'vuex';
 import { useRoute, useRouter } from 'vue-router';
+import { isTrustedOAuthMessageOrigin } from '@/utils/oauthMessageOrigin.js';
 import BaseScreen from '../../BaseScreen.vue';
 import BaseTable from '../../../_components/BaseTable.vue';
 import BaseForm from '../../../_components/BaseForm.vue';
@@ -2124,6 +2125,11 @@ export default {
     }
 
     async function handleOAuthMessage(event) {
+      // This handler redeems an OAuth code against the signed-in user's account
+      // and had no origin check at all, so any page that could reach this
+      // window could have one redeemed. See utils/oauthMessageOrigin.js.
+      if (!isTrustedOAuthMessageOrigin(event.origin)) return;
+
       // Handle legacy oauth-success message
       if (event.data && event.data.type === 'oauth-success') {
         store.dispatch('appAuth/fetchConnectedApps', { forceRefresh: true });

--- a/frontend/src/views/Terminal/CenterPanel/screens/Connectors/Connectors.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Connectors/Connectors.vue
@@ -836,7 +836,10 @@
 import { ref, computed, nextTick, onMounted, onUnmounted } from 'vue';
 import { useStore } from 'vuex';
 import { useRoute, useRouter } from 'vue-router';
-import { isTrustedOAuthMessageOrigin } from '@/utils/oauthMessageOrigin.js';
+import {
+  isTrustedOAuthMessageOrigin,
+  hasOAuthMessagePayload,
+} from '@/utils/oauthMessageOrigin.js';
 import BaseScreen from '../../BaseScreen.vue';
 import BaseTable from '../../../_components/BaseTable.vue';
 import BaseForm from '../../../_components/BaseForm.vue';
@@ -2130,15 +2133,21 @@ export default {
       // window could have one redeemed. See utils/oauthMessageOrigin.js.
       if (!isTrustedOAuthMessageOrigin(event.origin)) return;
 
+      // This handler already tested `event.data` at each branch. That is the
+      // same rule the other two now apply, so it is stated once here rather
+      // than repeated per branch — the duplication is what let the three
+      // handlers drift apart in the first place.
+      if (!hasOAuthMessagePayload(event)) return;
+
       // Handle legacy oauth-success message
-      if (event.data && event.data.type === 'oauth-success') {
+      if (event.data.type === 'oauth-success') {
         store.dispatch('appAuth/fetchConnectedApps', { forceRefresh: true });
         showAlert('Success', 'OAuth connection successful!');
       }
       // Electron path: api.agnt.gg's callback page postMessages the raw `code`
       // back here; the opener has to POST it to /auth/callback to mint tokens.
       // (Browser/dev mode does the exchange in-popup via OAuthCallback.vue.)
-      else if (event.data && event.data.type === 'oauth-callback') {
+      else if (event.data.type === 'oauth-callback') {
         const { code, state, provider } = event.data;
         try {
           const result = await providerAuthService.completeRemoteOAuthCallback({ code, state });

--- a/frontend/src/views/Terminal/RightPanel/types/ChatPanel/components/IntegrationHealth.vue
+++ b/frontend/src/views/Terminal/RightPanel/types/ChatPanel/components/IntegrationHealth.vue
@@ -54,6 +54,7 @@ import Tooltip from '@/views/Terminal/_components/Tooltip.vue';
 import { API_CONFIG } from '@/tt.config.js';
 import { PROVIDER_DISPLAY_NAMES } from '@/store/app/aiProvider.js';
 import { encrypt } from '@/views/_utils/encryption.js';
+import { isTrustedOAuthMessageOrigin } from '@/utils/oauthMessageOrigin.js';
 import providerAuthService from '@/services/providerAuthService.js';
 
 export default {
@@ -864,9 +865,11 @@ export default {
 
     // Handle OAuth completion messages from popup
     const handleOAuthMessage = async (event) => {
-      // Verify origin for security (allow same origin and api.agnt.gg for postMessage)
-      const allowedOrigins = [window.location.origin, 'https://api.agnt.gg'];
-      if (!allowedOrigins.some((origin) => event.origin === origin || event.origin.includes('localhost'))) return;
+      // This handler redeems an OAuth code against the signed-in user's account,
+      // so the origin check is the trust boundary. It used to OR in a bare
+      // `event.origin.includes('localhost')`, which admitted any registrable
+      // domain containing that substring. See utils/oauthMessageOrigin.js.
+      if (!isTrustedOAuthMessageOrigin(event.origin)) return;
 
       if (event.data.type === 'oauth_success') {
         // Refresh health immediately

--- a/frontend/src/views/Terminal/RightPanel/types/ChatPanel/components/IntegrationHealth.vue
+++ b/frontend/src/views/Terminal/RightPanel/types/ChatPanel/components/IntegrationHealth.vue
@@ -54,7 +54,10 @@ import Tooltip from '@/views/Terminal/_components/Tooltip.vue';
 import { API_CONFIG } from '@/tt.config.js';
 import { PROVIDER_DISPLAY_NAMES } from '@/store/app/aiProvider.js';
 import { encrypt } from '@/views/_utils/encryption.js';
-import { isTrustedOAuthMessageOrigin } from '@/utils/oauthMessageOrigin.js';
+import {
+  isTrustedOAuthMessageOrigin,
+  hasOAuthMessagePayload,
+} from '@/utils/oauthMessageOrigin.js';
 import providerAuthService from '@/services/providerAuthService.js';
 
 export default {
@@ -870,6 +873,12 @@ export default {
       // `event.origin.includes('localhost')`, which admitted any registrable
       // domain containing that substring. See utils/oauthMessageOrigin.js.
       if (!isTrustedOAuthMessageOrigin(event.origin)) return;
+
+      // A trusted origin is not a well-formed message. This is a global
+      // listener, so a same-origin extension or dev-server client posting
+      // `null` would otherwise throw on `event.data.type` — as an unhandled
+      // rejection, since this handler is async.
+      if (!hasOAuthMessagePayload(event)) return;
 
       if (event.data.type === 'oauth_success') {
         // Refresh health immediately


### PR DESCRIPTION
Three `message` handlers redeem an OAuth authorization code against the signed-in user's account. One had no origin check; the other two shared a guard that does not work.

> **Disclosure note.** Private vulnerability reporting is disabled on this repository and there is no `SECURITY.md`, so there was no non-public channel to use. Maintainers may want to enable it — Settings → Code security → Private vulnerability reporting — for anything found later.

## The bug

`providerAuthService.completeRemoteOAuthCallback({ code, state })` POSTs a forwarded code to `${REMOTE_URL}/auth/callback` **with the current user's bearer token**. Its three callers all sit inside `message` listeners, so the origin check in front of them is the entire trust boundary — cross-origin *sending* is permitted by design and cannot be prevented.

**`Connectors.vue`** had no origin check at all.

**`useProviderConnection.js`** and **`IntegrationHealth.vue`** shared this:

```js
const allowedOrigins = [window.location.origin, 'https://api.agnt.gg'];
if (!allowedOrigins.some((origin) =>
      event.origin === origin || event.origin.includes('localhost'))) return;
```

The `.some()` callback never references its own `origin` parameter in the second term, so `event.origin.includes('localhost')` is a constant OR'd into every iteration — an unconditional substring test. Running the predicate verbatim:

| `event.origin` | intended | actual |
| --- | --- | --- |
| `https://api.agnt.gg` | allow | admits |
| `http://localhost:3333` | allow | admits |
| `https://evil.com` | deny | refuses |
| `https://localhost.evil.com` | deny | **admits** |
| `https://evil-localhost.io` | deny | **admits** |
| `http://localhostage.com` | deny | **admits** |
| `https://notlocalhost.xyz` | deny | **admits** |

All four are registrable by anyone.

## Impact

An attacker who gets a `message` into an authenticated AGNT window has an authorization code **of their choosing** redeemed against the victim's account.

To be precise about severity: this does **not** steal the victim's existing tokens. It grafts the *attacker's* Google / Gmail / Drive account onto the *victim's* AGNT user. The victim's later "read my email" or "save this to Drive" agent runs then operate on the attacker's account — reading what the attacker plants there, writing the victim's data into it. Nothing on screen indicates it happened.

Reachability: neither the desktop build nor the hosted deployment sends `X-Frame-Options` or a CSP `frame-ancestors`, and there is no `helmet`/`frameguard` in the backend, so an attacker page can frame AGNT and post into it. A custom provider with an attacker-controlled `authUrl` also yields a `window.opener` handle.

Introduced in e4e82d2d (2026-02-27).

## The fix

One predicate, `isTrustedOAuthMessageOrigin`, used by all three handlers. Exact allowlist: this app's own origin, plus the configured remote compared as a **parsed** origin so a path suffix in `REMOTE_URL` cannot cause a miss.

Loopback stays supported — running from source puts Vite and the backend on different ports — but it is matched on the parsed **hostname** against a fixed set:

```js
new URL('https://localhost.evil.com').hostname // 'localhost.evil.com', not 'localhost'
```

and it is further conditioned on **the app itself** being served from loopback, so a hosted tenant never trusts a sender on the visitor's machine. A development convenience cannot become a production trust rule.

An absent or opaque (`"null"`) origin is refused rather than abstained on. Unlike the popup handover in `utils/googleAuthPopup.js` (#78) there is no second signal to fall back on here, so there is no trade-off to make.

## On the existing tests

They passed against the vulnerable code, and it is worth saying why:

- the one negative test used `https://evil.example.com`, which contains no `localhost` — the single shape the broken guard *did* refuse;
- a comment claimed the positive test relied on the `includes('localhost')` rule. It never did: the exact-match term matched first. That test passes unchanged here, and the comment is corrected.

## Testing

`frontend/src/utils/oauthMessageOrigin.spec.js` (32) covers the substring hole, near-misses on the allowlisted hosts (`api.agnt.gg.evil.com`, `evil.api.agnt.gg`, plain-http), opaque origins, and the loopback-in-production case. Four table-driven cases in `useProviderConnection.spec.js` drive the **real listener** with the origins that used to slip through.

Neither `Connectors.vue` nor `IntegrationHealth.vue` has a unit spec, so deleting a check from either would otherwise break nothing. `__guards__/oauthMessageOriginContract.spec.js` follows the `apiAuthContract.spec.js` precedent: it **discovers** the call sites from source rather than listing them, requires the predicate to precede the redemption in each, and fails on any hand-rolled `event.origin` comparison. Run against the unfixed tree it names all three files. Its comment stripper is string-aware and self-tested — a `//.*$` sweep would truncate any line containing a URL and cause false passes.

Mutation tested, each hitting only what it should:

| Mutation | Fails |
| --- | --- |
| reinstate `includes('localhost')` | 13 — every substring case, in the predicate *and* through the real listener |
| drop the "app is on loopback" condition | 1 — the production-loopback test, alone |
| delete the check from `Connectors.vue` | 1 — the guard contract, naming the file |

Full frontend suite: **229 files / 4064 tests** green.

## Suggested follow-up

`X-Frame-Options: DENY` or CSP `frame-ancestors 'none'` would remove the framing route as defence in depth. Out of scope here — it is a deployment-wide change and this PR is deliberately confined to the trust boundary itself.
