### PR TITLE
fix(auth): pin trust -> shape -> read across message handlers

### DIFF
--- a/frontend/src/__guards__/messageHandlerContract.spec.js
+++ b/frontend/src/__guards__/messageHandlerContract.spec.js
@@ -256,17 +256,87 @@ function walk(dir, found = []) {
 }
 
 /**
- * Every `window.addEventListener('message', ...)` in host code, with the body
- * of the function it registers.
+ * HOW A SENDER REACHES A RECEIVER, AND WHY THAT DECIDES WHAT TO DEMAND.
+ *
+ * Two shapes exist in this codebase and they are not equivalent:
+ *
+ *   window.addEventListener('message', h)   A GLOBAL receiver. Anyone able to
+ *   window.onmessage = h                    reach the window can post to it —
+ *                                           a page that framed us, an
+ *                                           extension, an allow-same-origin
+ *                                           artifact iframe. Receiving a
+ *                                           message implies nothing whatever
+ *                                           about the sender, so the handler
+ *                                           body is the entire trust boundary.
+ *
+ *   someChannel.onmessage = h               A HANDLE receiver. To post, a
+ *                                           sender must already hold the same
+ *                                           object: a BroadcastChannel on our
+ *                                           origin, a socket we opened, a port
+ *                                           we were handed. Possession IS the
+ *                                           boundary, and it was settled when
+ *                                           the object was constructed — there
+ *                                           is no `event.origin` to compare and
+ *                                           no `event.source` to identify.
+ *
+ * So the sender-trust rule applies to global receivers only, and that
+ * exemption is DERIVED from the syntax rather than granted by name. Note the
+ * second line above: `window.onmessage = h` is a global receiver wearing
+ * handle clothing, and is classified global for exactly that reason — it must
+ * not be able to buy the exemption by changing shape.
+ *
+ * Shape discipline applies to both. A malformed payload throws the same way
+ * whichever door it came through.
  *
  * Registrations on a DataChannel or an EventSource are deliberately not
  * matched: `dc.addEventListener('message')` is a negotiated WebRTC peer and
  * `eventSource.addEventListener('message')` is a same-origin SSE stream, so
- * neither is spoofable by a third party and neither has an `event.origin` to
- * check. Only `window` receives postMessage.
+ * neither is third-party spoofable and neither carries an `event.origin`.
  */
-function messageHandlers() {
-  const handlers = [];
+const GLOBAL_TARGETS = new Set(['window', 'globalThis', 'self']);
+
+/** Which kind of receiver an `X.onmessage =` assignment creates. */
+function receiverKindFor(target) {
+  return GLOBAL_TARGETS.has(target) ? 'global' : 'handle';
+}
+
+/**
+ * The body of the function starting at `at`, written inline or by name.
+ *
+ * Returns null when neither shape is recognised, so a call site the extractor
+ * does not understand goes MISSING from the set rather than being counted as
+ * compliant — which the anti-vacuity test below is there to notice.
+ */
+function functionAt(code, at) {
+  const after = code.slice(at);
+
+  // Inline: `function (event) {`, `(event) => {`, `async event => {`
+  const inline = after.match(/^(?:async\s+)?(?:function\s*)?\(?[\w$]*\)?\s*(?:=>)?\s*\{/);
+  if (inline) {
+    const open = at + inline[0].length - 1;
+    const close = matchBrace(code, open);
+    return close > -1 ? { name: '<inline>', body: code.slice(open, close + 1) } : null;
+  }
+
+  // Named: resolve the identifier to its declaration. The character that
+  // follows differs by call shape — `, handler)` for a listener, `= handler;`
+  // for an assignment — so accept any of them.
+  const named = after.match(/^([A-Za-z_$][\w$]*)\s*[),;\n]/);
+  if (!named) return null;
+  const name = named[1];
+
+  const declRe = new RegExp(`(?:const|let|var|function)\\s+${name}\\b[\\s\\S]{0,200}?\\{`, 'g');
+  const decl = declRe.exec(code);
+  if (!decl) return null;
+
+  const open = decl.index + decl[0].length - 1;
+  const close = matchBrace(code, open);
+  return close > -1 ? { name, body: code.slice(open, close + 1) } : null;
+}
+
+/** Every message receiver in host code, tagged with how a sender reaches it. */
+function messageReceivers() {
+  const found = [];
 
   for (const full of walk(FRONTEND_SRC)) {
     const rel = path.relative(FRONTEND_SRC, full).split(path.sep).join('/');
@@ -274,40 +344,28 @@ function messageHandlers() {
     if (rel.endsWith('messageHandlerContract.spec.js')) continue;
 
     const code = blankTemplateContents(stripComments(fs.readFileSync(full, 'utf8')));
-    const re = /window\.addEventListener\(\s*['"]message['"]\s*,\s*/g;
     let m;
 
-    while ((m = re.exec(code))) {
-      const after = code.slice(m.index + m[0].length);
+    const listenerRe = /window\.addEventListener\(\s*['"]message['"]\s*,\s*/g;
+    while ((m = listenerRe.exec(code))) {
+      const fn = functionAt(code, m.index + m[0].length);
+      if (fn) found.push({ rel, kind: 'global', target: 'window', ...fn });
+    }
 
-      // Inline: `function (event) {` or `(event) => {`
-      const inline = after.match(/^(?:async\s+)?(?:function\s*)?\(?[\w$]*\)?\s*(?:=>)?\s*\{/);
-      if (inline) {
-        const open = m.index + m[0].length + inline[0].length - 1;
-        const close = matchBrace(code, open);
-        if (close > -1) handlers.push({ rel, name: '<inline>', body: code.slice(open, close + 1) });
-        continue;
-      }
-
-      // Named: resolve the identifier to its declaration.
-      const named = after.match(/^([A-Za-z_$][\w$]*)\s*\)/);
-      if (!named) continue;
-      const name = named[1];
-
-      const declRe = new RegExp(
-        `(?:const|let|var|function)\\s+${name}\\b[\\s\\S]{0,200}?\\{`,
-        'g',
-      );
-      const decl = declRe.exec(code);
-      if (!decl) continue;
-
-      const open = decl.index + decl[0].length - 1;
-      const close = matchBrace(code, open);
-      if (close > -1) handlers.push({ rel, name, body: code.slice(open, close + 1) });
+    // `x.onmessage = fn`. A comparison (`x.onmessage === fn`) leaves `after`
+    // starting with `=`, which matches neither function shape, so it is
+    // discarded rather than mistaken for a registration.
+    const onmessageRe = /\b([A-Za-z_$][\w$]*)\s*\.\s*onmessage\s*=\s*/g;
+    while ((m = onmessageRe.exec(code))) {
+      const target = m[1];
+      const fn = functionAt(code, m.index + m[0].length);
+      if (!fn) continue;
+      const kind = receiverKindFor(target);
+      found.push({ rel, kind, target, ...fn });
     }
   }
 
-  return handlers;
+  return found;
 }
 
 // ---------------------------------------------------------------------------
@@ -393,15 +451,15 @@ function unguardedReadIndex(body) {
 // ---------------------------------------------------------------------------
 
 describe('every window message handler: trust, then shape, then read', () => {
-  const handlers = messageHandlers();
-  const describeOne = (h) => `${h.rel} (${h.name})`;
+  const receivers = messageReceivers();
+  const describeOne = (r) => `${r.rel} (${r.kind}: ${r.target}.${r.name})`;
 
-  it('discovers the handlers, so a silent zero cannot pass this suite', () => {
+  it('discovers the receivers, so a silent zero cannot pass this suite', () => {
     // Without this, renaming addEventListener or breaking the body extractor
     // would empty the set and every assertion below would vacuously succeed.
-    const files = handlers.map((h) => h.rel);
+    const files = receivers.map((r) => r.rel);
 
-    expect(handlers.length).toBeGreaterThanOrEqual(6);
+    expect(receivers.length).toBeGreaterThanOrEqual(7);
     expect(files).toContain('canvas/widgetSdk.js');
     expect(files).toContain('composables/useProviderConnection.js');
     expect(files).toContain('views/Terminal/CenterPanel/screens/Artifacts/Artifacts.vue');
@@ -414,19 +472,35 @@ describe('every window message handler: trust, then shape, then read', () => {
     );
   });
 
+  it('finds both kinds, so widening discovery cannot quietly collapse back', () => {
+    // The BroadcastChannel receiver was invisible here until `.onmessage =`
+    // was added to discovery: the suite stayed green while an unaudited
+    // receiver sat in the tree. If the handle pattern ever stops matching,
+    // that blind spot returns silently — this is what notices.
+    const kinds = receivers.map((r) => r.kind);
+
+    expect(kinds).toContain('global');
+    expect(kinds).toContain('handle');
+  });
+
   it('extracts a real body for each, not an empty match', () => {
     // A zero-length body would satisfy "no unguarded read" for free.
-    const tiny = handlers.filter((h) => h.body.length < 40).map(describeOne);
+    const tiny = receivers.filter((r) => r.body.length < 40).map(describeOne);
 
     expect(tiny, 'these bodies are too short to be real handlers').toEqual([]);
   });
 
-  it('establishes sender trust before acting, in every handler', () => {
+  it('establishes sender trust before acting, in every global receiver', () => {
     // Either mechanism is accepted. Identity is the stronger of the two:
     // same-origin does not mean "the window I opened", and this app runs
     // authored HTML in allow-same-origin iframes.
-    const untrusted = handlers
-      .filter((h) => originGateIndex(h.body) === -1 && identityGateIndex(h.body) === -1)
+    //
+    // Handle receivers are exempt because there is nothing for them to check:
+    // possession of the object is the boundary. That exemption is derived from
+    // the syntax, not granted by name — see GLOBAL_TARGETS.
+    const untrusted = receivers
+      .filter((r) => r.kind === 'global')
+      .filter((r) => originGateIndex(r.body) === -1 && identityGateIndex(r.body) === -1)
       .map(describeOne);
 
     // Phrased as "approved" on purpose: a hand-rolled origin comparison is a
@@ -438,12 +512,15 @@ describe('every window message handler: trust, then shape, then read', () => {
     ).toEqual([]);
   });
 
-  it('checks the payload is there before dereferencing it', () => {
-    const unguarded = handlers
-      .filter((h) => {
-        const read = unguardedReadIndex(h.body);
+  it('checks the payload is there before dereferencing it, in every receiver', () => {
+    // Both kinds. A malformed payload throws the same way whichever door it
+    // came through, and these handlers are async, so the TypeError surfaces as
+    // an unhandled rejection rather than as anything anyone would notice.
+    const unguarded = receivers
+      .filter((r) => {
+        const read = unguardedReadIndex(r.body);
         if (read === -1) return false; // never dot-dereferences the payload
-        const shape = shapeGuardIndex(h.body);
+        const shape = shapeGuardIndex(r.body);
         return shape === -1 || shape > read;
       })
       .map(describeOne);
@@ -458,12 +535,12 @@ describe('every window message handler: trust, then shape, then read', () => {
     // The literal sequence, applied to the handlers whose trust mechanism IS
     // the origin. Membership is derived from the code above, so converting a
     // handler to origin-gating brings it under this rule automatically.
-    const misordered = handlers
-      .filter((h) => originGateIndex(h.body) > -1)
-      .filter((h) => {
-        const origin = originGateIndex(h.body);
-        const shape = shapeGuardIndex(h.body);
-        const read = unguardedReadIndex(h.body);
+    const misordered = receivers
+      .filter((r) => originGateIndex(r.body) > -1)
+      .filter((r) => {
+        const origin = originGateIndex(r.body);
+        const shape = shapeGuardIndex(r.body);
+        const read = unguardedReadIndex(r.body);
         if (shape === -1) return true; // origin-gated but never shape-checked
         if (origin > shape) return true; // payload trusted before the sender was
         return read > -1 && read < shape;
@@ -476,7 +553,7 @@ describe('every window message handler: trust, then shape, then read', () => {
   it('leaves origin comparison to the shared predicates', () => {
     // The two guards that existed were copy-pasted, and the copy is what let
     // them drift apart until one of them silently stopped working.
-    const handRolled = handlers
+    const handRolled = receivers
       .filter(({ body }) =>
         /event\.origin\s*(?:===|!==|\.includes|\.startsWith|\.indexOf|\.match)/.test(body),
       )
@@ -487,6 +564,57 @@ describe('every window message handler: trust, then shape, then read', () => {
       `these compare event.origin inline instead of using ${ORIGIN_PREDICATES.join(' / ')}`,
     ).toEqual([]);
   });
+
+  /**
+   * For a global receiver the boundary is the check in the handler body. For a
+   * handle receiver it is WHICH OBJECT you were handed — and for a
+   * BroadcastChannel that is decided entirely by its name. Two sides typing the
+   * same string is the same copy-paste failure the shared origin predicates
+   * exist to prevent, except that this one fails silently: a mismatched name is
+   * not an error, it is a channel nobody ever posts to.
+   *
+   * So this is the handle receiver's equivalent of "leave origin comparison to
+   * the shared predicates" — leave the channel name to the shared constant.
+   */
+  it('names a channel from a shared constant, never a bare literal', () => {
+    const literals = [];
+
+    for (const full of walk(FRONTEND_SRC)) {
+      const rel = path.relative(FRONTEND_SRC, full).split(path.sep).join('/');
+      if (rel.endsWith('messageHandlerContract.spec.js')) continue;
+
+      const code = blankTemplateContents(stripComments(fs.readFileSync(full, 'utf8')));
+      if (/new\s+BroadcastChannel\(\s*['"]/.test(code)) literals.push(rel);
+    }
+
+    expect(
+      literals,
+      'a channel name written twice is a channel that silently never connects',
+    ).toEqual([]);
+  });
+});
+
+/**
+ * The global/handle split is what decides whether the sender-trust rule
+ * applies, so it carries real weight. Nothing in the tree currently writes
+ * `window.onmessage =`, which means the guard against a global receiver
+ * disguised as a handle would otherwise never be exercised — these cover it
+ * directly rather than waiting for someone to write that line.
+ */
+describe('receiver classification', () => {
+  it.each(['window', 'globalThis', 'self'])(
+    'treats %s.onmessage as GLOBAL, so it still owes a trust check',
+    (target) => {
+      expect(receiverKindFor(target)).toBe('global');
+    },
+  );
+
+  it.each(['channel', 'ws', 'port', 'worker', 'eventSource'])(
+    'treats %s.onmessage as a handle, where possession is the boundary',
+    (target) => {
+      expect(receiverKindFor(target)).toBe('handle');
+    },
+  );
 });
 
 /**
@@ -503,8 +631,8 @@ describe('the injected widget-side listener', () => {
   });
 
   it('is not counted as a host handler', () => {
-    const inlineHandlers = messageHandlers().filter(
-      (h) => h.rel === 'canvas/widgetSdk.js' && h.name === '<inline>',
+    const inlineHandlers = messageReceivers().filter(
+      (r) => r.rel === 'canvas/widgetSdk.js' && r.name === '<inline>',
     );
 
     expect(inlineHandlers).toEqual([]);

--- a/frontend/src/__guards__/messageHandlerContract.spec.js
+++ b/frontend/src/__guards__/messageHandlerContract.spec.js
@@ -1,0 +1,570 @@
+/**
+ * CONTRACT: every `message` listener establishes trust, then checks the
+ * payload's shape, and only then reads it.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `window.addEventListener('message', ...)` is a GLOBAL receiver. It gets every
+ * message the window is sent, from anyone who can reach it — an attacker page
+ * that framed us, a browser extension, a dev-server client, another widget.
+ * Cross-origin *sending* is permitted by design and cannot be prevented, so
+ * whatever the handler checks first IS the trust boundary.
+ *
+ * Three separate defects in this codebase came from getting that sequence
+ * wrong, and each was found only after shipping:
+ *
+ *   1. NO TRUST CHECK. Connectors.vue redeemed an OAuth authorization code
+ *      with the signed-in user's bearer token, from any sender at all.
+ *
+ *   2. A TRUST CHECK THAT DID NOT WORK. Two handlers shared
+ *      `allowedOrigins.some((origin) => event.origin === origin ||
+ *      event.origin.includes('localhost'))` — whose second term never
+ *      references the callback's own parameter, making it an unconditional
+ *      substring test that admitted `localhost.evil.com` and friends.
+ *
+ *   3. TRUST WITHOUT SHAPE. Handlers that had cleared the origin then read
+ *      `event.data.type` directly, so a trusted-origin sender posting `null`
+ *      threw a TypeError. The handlers are `async`, so that surfaced as an
+ *      unhandled rejection: nothing crashed, nothing was logged where anyone
+ *      looked, and the handler silently did not run.
+ *
+ * Every one of those is an ORDERING or PRESENCE property of a handler body.
+ * None of them is visible in review, none makes a test go red on its own, and
+ * two of the three were shipped for months. That is precisely the shape of
+ * defect a mechanical check earns its keep against.
+ *
+ * WHY THE RULE IS "TRUST", NOT "ORIGIN"
+ * -------------------------------------
+ * Three of the handlers here do not check `event.origin` at all, and are right
+ * not to. They compare the SENDER instead:
+ *
+ *   widgetSdk.js       `widgetWindows.has(event.source)`  — a WeakSet allowlist
+ *   Artifacts.vue      `event.source !== previewFrame.value.contentWindow`
+ *
+ * Identity is strictly stronger than origin: same-origin does not mean "the
+ * window I opened", which is exactly the hole Copilot found in the Google
+ * sign-in handler — artifact and widget iframes are `allow-scripts
+ * allow-same-origin`, so authored HTML runs at our own origin and passes any
+ * origin check. Demanding a redundant origin comparison from those handlers
+ * would be cargo-cult, so the contract accepts either mechanism.
+ *
+ * Which handlers are origin-gated is DERIVED from the code, never listed. Turn
+ * an identity-gated handler into an origin-gated one and the ordering rule
+ * starts applying to it automatically, with nobody having to remember this
+ * file exists.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT CHECK
+ * -------------------------------------
+ * That the trust check is CORRECT. A predicate can be present and still be
+ * wrong — defect 2 above was exactly that. Correctness is pinned by the unit
+ * tests for each predicate; this file pins that one is called, and called
+ * first. The two jobs are complementary and neither substitutes for the other.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FRONTEND_SRC = path.resolve(HERE, '..');
+
+/**
+ * The predicates allowed to answer "may this sender act?". Both parse and
+ * compare origins properly; see their own specs for why each exists.
+ */
+const ORIGIN_PREDICATES = ['isTrustedOAuthMessageOrigin', 'isTrustedAuthMessage'];
+
+/** The predicate allowed to answer "is this payload actionable?". */
+const PAYLOAD_PREDICATE = 'hasOAuthMessagePayload';
+
+/**
+ * Modules that DEFINE the predicates, and their specs. They necessarily
+ * mention `event.origin` and `event.data` without being message handlers.
+ */
+const PREDICATE_MODULES = [
+  'utils/oauthMessageOrigin.js',
+  'utils/oauthMessageOrigin.spec.js',
+  'utils/googleAuthPopup.js',
+  'utils/googleAuthPopup.spec.js',
+];
+
+// ---------------------------------------------------------------------------
+// Source normalisation
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove comments, string- and template-aware.
+ *
+ * A naive `//.*$` sweep truncates any line containing a URL — `'http://x'`
+ * becomes `'http:` — which deletes real code from the text being scanned and
+ * turns every assertion below into a false pass. Self-tested at the bottom.
+ */
+function stripComments(source) {
+  let out = '';
+  let i = 0;
+  const n = source.length;
+
+  while (i < n) {
+    const ch = source[i];
+    const next = source[i + 1];
+
+    if (ch === '/' && next === '/') {
+      while (i < n && source[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      i += 2;
+      while (i < n && !(source[i] === '*' && source[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const quote = ch;
+      out += ch;
+      i++;
+      while (i < n) {
+        if (source[i] === '\\') {
+          out += source[i] + (source[i + 1] ?? '');
+          i += 2;
+          continue;
+        }
+        out += source[i];
+        if (source[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    out += ch;
+    i++;
+  }
+
+  return out;
+}
+
+/**
+ * Blank the CONTENTS of template literals, preserving length so every index
+ * computed afterwards still lines up with the original text.
+ *
+ * This is what excludes the widget-side listener in widgetSdk.js: that code
+ * lives inside a backtick template, is injected into the widget iframe's
+ * srcdoc, and runs over there rather than in this application. Treating it as
+ * a host handler would be wrong — and it is worth noting it satisfies the
+ * contract anyway, opening with `if (event.source !== parent) return;`.
+ *
+ * The exclusion is asserted below rather than assumed, so moving that listener
+ * into real host code brings it back under every rule here.
+ */
+function blankTemplateContents(code) {
+  let out = '';
+  let i = 0;
+  const n = code.length;
+
+  while (i < n) {
+    const ch = code[i];
+    if (ch === '`') {
+      out += ch;
+      i++;
+      while (i < n && code[i] !== '`') {
+        if (code[i] === '\\') {
+          out += '  ';
+          i += 2;
+          continue;
+        }
+        out += code[i] === '\n' ? '\n' : ' ';
+        i++;
+      }
+      if (i < n) {
+        out += '`';
+        i++;
+      }
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      const quote = ch;
+      out += ch;
+      i++;
+      while (i < n) {
+        if (code[i] === '\\') {
+          out += code[i] + (code[i + 1] ?? '');
+          i += 2;
+          continue;
+        }
+        out += code[i];
+        if (code[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+
+  return out;
+}
+
+/** Scan forward from an opening brace to its match, skipping quoted strings. */
+function matchBrace(code, openIndex) {
+  let depth = 0;
+  let i = openIndex;
+  const n = code.length;
+
+  while (i < n) {
+    const ch = code[i];
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const quote = ch;
+      i++;
+      while (i < n) {
+        if (code[i] === '\\') {
+          i += 2;
+          continue;
+        }
+        if (code[i] === quote) break;
+        i++;
+      }
+      i++;
+      continue;
+    }
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return i;
+    }
+    i++;
+  }
+  return -1;
+}
+
+// ---------------------------------------------------------------------------
+// Handler discovery
+// ---------------------------------------------------------------------------
+
+function walk(dir, found = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, found);
+    else if (/\.(js|vue)$/.test(entry.name)) found.push(full);
+  }
+  return found;
+}
+
+/**
+ * Every `window.addEventListener('message', ...)` in host code, with the body
+ * of the function it registers.
+ *
+ * Registrations on a DataChannel or an EventSource are deliberately not
+ * matched: `dc.addEventListener('message')` is a negotiated WebRTC peer and
+ * `eventSource.addEventListener('message')` is a same-origin SSE stream, so
+ * neither is spoofable by a third party and neither has an `event.origin` to
+ * check. Only `window` receives postMessage.
+ */
+function messageHandlers() {
+  const handlers = [];
+
+  for (const full of walk(FRONTEND_SRC)) {
+    const rel = path.relative(FRONTEND_SRC, full).split(path.sep).join('/');
+    if (PREDICATE_MODULES.includes(rel)) continue;
+    if (rel.endsWith('messageHandlerContract.spec.js')) continue;
+
+    const code = blankTemplateContents(stripComments(fs.readFileSync(full, 'utf8')));
+    const re = /window\.addEventListener\(\s*['"]message['"]\s*,\s*/g;
+    let m;
+
+    while ((m = re.exec(code))) {
+      const after = code.slice(m.index + m[0].length);
+
+      // Inline: `function (event) {` or `(event) => {`
+      const inline = after.match(/^(?:async\s+)?(?:function\s*)?\(?[\w$]*\)?\s*(?:=>)?\s*\{/);
+      if (inline) {
+        const open = m.index + m[0].length + inline[0].length - 1;
+        const close = matchBrace(code, open);
+        if (close > -1) handlers.push({ rel, name: '<inline>', body: code.slice(open, close + 1) });
+        continue;
+      }
+
+      // Named: resolve the identifier to its declaration.
+      const named = after.match(/^([A-Za-z_$][\w$]*)\s*\)/);
+      if (!named) continue;
+      const name = named[1];
+
+      const declRe = new RegExp(
+        `(?:const|let|var|function)\\s+${name}\\b[\\s\\S]{0,200}?\\{`,
+        'g',
+      );
+      const decl = declRe.exec(code);
+      if (!decl) continue;
+
+      const open = decl.index + decl[0].length - 1;
+      const close = matchBrace(code, open);
+      if (close > -1) handlers.push({ rel, name, body: code.slice(open, close + 1) });
+    }
+  }
+
+  return handlers;
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+const originGateIndex = (body) => {
+  const hits = ORIGIN_PREDICATES.map((p) => body.indexOf(`${p}(`)).filter((i) => i > -1);
+  return hits.length ? Math.min(...hits) : -1;
+};
+
+/** A comparison against the sending window, which is stronger than an origin. */
+const identityGateIndex = (body) => {
+  const m = body.match(/event\.source\s*(?:!==|===)|\.has\(\s*event\.source\s*\)/);
+  return m ? m.index : -1;
+};
+
+/**
+ * Where this handler first establishes that the payload is safe to read.
+ *
+ * Three spellings count, because all three are sound:
+ *   - the shared predicate, `hasOAuthMessagePayload(event)`
+ *   - optional chaining, `event.data?.`
+ *   - a falsy test on the payload or an alias of it, `if (!data || ...)`
+ */
+function shapeGuardIndex(body) {
+  const candidates = [];
+
+  const shared = body.indexOf(`${PAYLOAD_PREDICATE}(`);
+  if (shared > -1) candidates.push(shared);
+
+  const optional = body.indexOf('event.data?.');
+  if (optional > -1) candidates.push(optional);
+
+  const direct = body.match(/!\s*event\.data\b/);
+  if (direct) candidates.push(direct.index);
+
+  for (const alias of aliasesOfEventData(body)) {
+    const falsy = body.match(new RegExp(`!\\s*${alias}\\b`));
+    if (falsy) candidates.push(falsy.index);
+  }
+
+  return candidates.length ? Math.min(...candidates) : -1;
+}
+
+/** Local names bound to `event.data`, e.g. `const data = event.data;`. */
+function aliasesOfEventData(body) {
+  const names = [];
+  const re = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*event\.data\b/g;
+  let m;
+  while ((m = re.exec(body))) names.push(m[1]);
+  return names;
+}
+
+/**
+ * Where this handler first dereferences a property off the payload WITHOUT
+ * optional chaining — the read that throws when the payload is absent.
+ *
+ * Destructuring (`const { code } = event.data`) is out of scope: it is only
+ * ever reached inside a branch already gated on `?.`, and proving that
+ * mechanically would need real flow analysis. The dot-dereference above is the
+ * exact shape that actually threw in production.
+ */
+function unguardedReadIndex(body) {
+  const candidates = [];
+
+  const directRe = /event\.data\.[A-Za-z_$]/g;
+  let m;
+  while ((m = directRe.exec(body))) candidates.push(m.index);
+
+  for (const alias of aliasesOfEventData(body)) {
+    // Negative lookbehind so `event.data.` is not counted twice via alias `data`.
+    const aliasRe = new RegExp(`(?<![.\\w$])${alias}\\.[A-Za-z_$]`, 'g');
+    let a;
+    while ((a = aliasRe.exec(body))) candidates.push(a.index);
+  }
+
+  return candidates.length ? Math.min(...candidates) : -1;
+}
+
+// ---------------------------------------------------------------------------
+// The contract
+// ---------------------------------------------------------------------------
+
+describe('every window message handler: trust, then shape, then read', () => {
+  const handlers = messageHandlers();
+  const describeOne = (h) => `${h.rel} (${h.name})`;
+
+  it('discovers the handlers, so a silent zero cannot pass this suite', () => {
+    // Without this, renaming addEventListener or breaking the body extractor
+    // would empty the set and every assertion below would vacuously succeed.
+    const files = handlers.map((h) => h.rel);
+
+    expect(handlers.length).toBeGreaterThanOrEqual(6);
+    expect(files).toContain('canvas/widgetSdk.js');
+    expect(files).toContain('composables/useProviderConnection.js');
+    expect(files).toContain('views/Terminal/CenterPanel/screens/Artifacts/Artifacts.vue');
+    expect(files).toContain('views/Terminal/CenterPanel/screens/Connectors/Connectors.vue');
+    expect(files).toContain(
+      'views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue',
+    );
+    expect(files).toContain(
+      'views/Terminal/RightPanel/types/ChatPanel/components/IntegrationHealth.vue',
+    );
+  });
+
+  it('extracts a real body for each, not an empty match', () => {
+    // A zero-length body would satisfy "no unguarded read" for free.
+    const tiny = handlers.filter((h) => h.body.length < 40).map(describeOne);
+
+    expect(tiny, 'these bodies are too short to be real handlers').toEqual([]);
+  });
+
+  it('establishes sender trust before acting, in every handler', () => {
+    // Either mechanism is accepted. Identity is the stronger of the two:
+    // same-origin does not mean "the window I opened", and this app runs
+    // authored HTML in allow-same-origin iframes.
+    const untrusted = handlers
+      .filter((h) => originGateIndex(h.body) === -1 && identityGateIndex(h.body) === -1)
+      .map(describeOne);
+
+    // Phrased as "approved" on purpose: a hand-rolled origin comparison is a
+    // check, and two of these once had one that silently did not work. Being
+    // present is not the bar; delegating to a tested predicate is.
+    expect(
+      untrusted,
+      'these establish trust via neither an approved origin predicate nor a sender-identity check',
+    ).toEqual([]);
+  });
+
+  it('checks the payload is there before dereferencing it', () => {
+    const unguarded = handlers
+      .filter((h) => {
+        const read = unguardedReadIndex(h.body);
+        if (read === -1) return false; // never dot-dereferences the payload
+        const shape = shapeGuardIndex(h.body);
+        return shape === -1 || shape > read;
+      })
+      .map(describeOne);
+
+    expect(
+      unguarded,
+      'these read a property off event.data before establishing it is an object',
+    ).toEqual([]);
+  });
+
+  it('orders origin-gated handlers origin -> payload -> read', () => {
+    // The literal sequence, applied to the handlers whose trust mechanism IS
+    // the origin. Membership is derived from the code above, so converting a
+    // handler to origin-gating brings it under this rule automatically.
+    const misordered = handlers
+      .filter((h) => originGateIndex(h.body) > -1)
+      .filter((h) => {
+        const origin = originGateIndex(h.body);
+        const shape = shapeGuardIndex(h.body);
+        const read = unguardedReadIndex(h.body);
+        if (shape === -1) return true; // origin-gated but never shape-checked
+        if (origin > shape) return true; // payload trusted before the sender was
+        return read > -1 && read < shape;
+      })
+      .map(describeOne);
+
+    expect(misordered, 'these break the origin -> payload -> read sequence').toEqual([]);
+  });
+
+  it('leaves origin comparison to the shared predicates', () => {
+    // The two guards that existed were copy-pasted, and the copy is what let
+    // them drift apart until one of them silently stopped working.
+    const handRolled = handlers
+      .filter(({ body }) =>
+        /event\.origin\s*(?:===|!==|\.includes|\.startsWith|\.indexOf|\.match)/.test(body),
+      )
+      .map(describeOne);
+
+    expect(
+      handRolled,
+      `these compare event.origin inline instead of using ${ORIGIN_PREDICATES.join(' / ')}`,
+    ).toEqual([]);
+  });
+});
+
+/**
+ * The widget-side listener in widgetSdk.js is injected into an iframe's srcdoc
+ * and runs in the widget, not here. It is excluded by blanking template
+ * contents rather than by name, so the exclusion cannot rot — and if anyone
+ * lifts that code into the host, discovery picks it up and every rule applies.
+ */
+describe('the injected widget-side listener', () => {
+  const raw = fs.readFileSync(path.join(FRONTEND_SRC, 'canvas/widgetSdk.js'), 'utf8');
+
+  it('exists in the source as a template literal', () => {
+    expect(raw).toContain("window.addEventListener('message', function(event)");
+  });
+
+  it('is not counted as a host handler', () => {
+    const inlineHandlers = messageHandlers().filter(
+      (h) => h.rel === 'canvas/widgetSdk.js' && h.name === '<inline>',
+    );
+
+    expect(inlineHandlers).toEqual([]);
+  });
+
+  it('satisfies the contract anyway, by checking the sender first', () => {
+    // Not enforced here, but worth pinning: it opens by comparing the sender,
+    // so lifting it into host code would not suddenly fail the suite.
+    const idx = raw.indexOf("window.addEventListener('message', function(event)");
+    expect(raw.slice(idx, idx + 160)).toContain('event.source !== parent');
+  });
+});
+
+/**
+ * Self-tests. A normaliser that eats real code turns every assertion above
+ * into a false pass, which is the failure mode Copilot caught in the sibling
+ * guard on #78.
+ */
+describe('the source normalisers this contract depends on', () => {
+  it('removes a commented-out trust check', () => {
+    expect(stripComments('// isTrustedOAuthMessageOrigin(event.origin)')).not.toContain(
+      'isTrustedOAuthMessageOrigin',
+    );
+  });
+
+  it('keeps a URL that contains a double slash', () => {
+    const line = `const state = 'github:http://localhost:3333';`;
+    expect(stripComments(line)).toBe(line);
+  });
+
+  it('keeps code that follows a URL on the same line', () => {
+    const line = `send('https://api.agnt.gg'); check(event.origin);`;
+    expect(stripComments(line)).toContain('check(event.origin)');
+  });
+
+  it('blanks template contents but preserves every index', () => {
+    const src = 'a(`  hidden(x)  `);b();';
+    const out = blankTemplateContents(src);
+
+    expect(out.length).toBe(src.length);
+    expect(out).not.toContain('hidden');
+    expect(out.indexOf('b()')).toBe(src.indexOf('b()'));
+  });
+
+  it("leaves ordinary quoted strings alone, so 'message' stays findable", () => {
+    const src = `window.addEventListener('message', h)`;
+    expect(blankTemplateContents(src)).toBe(src);
+  });
+
+  it('matches braces across a string containing an unbalanced one', () => {
+    const src = 'f() { const s = "}"; g(); }';
+    const open = src.indexOf('{');
+
+    expect(matchBrace(src, open)).toBe(src.length - 1);
+  });
+
+  it('does not count event.data. twice when an alias is also named data', () => {
+    // `event.data.type` contains the substring `data.`, so a naive alias scan
+    // would report a read at the wrong index.
+    const body = '{ const data = event.data; if (!data) return; x = event.data.type; }';
+    expect(unguardedReadIndex(body)).toBe(body.indexOf('event.data.type'));
+  });
+});

--- a/frontend/src/__guards__/oauthMessageOriginContract.spec.js
+++ b/frontend/src/__guards__/oauthMessageOriginContract.spec.js
@@ -1,0 +1,197 @@
+/**
+ * CONTRACT: code that redeems an OAuth code must first vet the message origin.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `providerAuthService.completeRemoteOAuthCallback({ code, state })` POSTs a
+ * forwarded authorization code to `/auth/callback` **with the signed-in user's
+ * bearer token**. Every caller of it sits inside a `message` listener, so the
+ * origin check in front of it is the entire trust boundary: cross-origin
+ * *sending* is permitted by design and cannot be prevented.
+ *
+ * Three call sites existed and they did three different things. One had no
+ * origin check at all. Two shared a copy-pasted guard whose second term never
+ * referenced its own loop variable:
+ *
+ *   allowedOrigins.some((origin) =>
+ *     event.origin === origin || event.origin.includes('localhost'))
+ *
+ * making it an unconditional substring test that admitted `localhost.evil.com`
+ * and friends. Redeeming an attacker's code grafts the ATTACKER'S Google /
+ * Gmail / Drive account onto the victim's AGNT user, so the victim's later
+ * agent runs operate on someone else's data.
+ *
+ * It was a *class* of bug rather than one mistake because no single module
+ * owned the rule — the same reasoning as apiAuthContract.spec.js in this
+ * directory, and the same remedy: one shared predicate, enforced mechanically
+ * at every call site.
+ *
+ * Neither Connectors.vue nor IntegrationHealth.vue has a unit spec, so without
+ * this guard the check could be deleted from either and nothing would fail.
+ *
+ * The call sites are DISCOVERED from source rather than listed here, so a
+ * fourth handler added tomorrow is covered without anyone remembering to come
+ * back and update this file.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FRONTEND_SRC = path.resolve(HERE, '..');
+
+/** The dangerous operation: redeeming a code against the current user. */
+const REDEEM = 'completeRemoteOAuthCallback';
+/** The one predicate allowed to answer "may this sender do that?". */
+const GUARD = 'isTrustedOAuthMessageOrigin';
+
+/**
+ * Where the function is defined and where it is mocked. Neither redeems
+ * anything on a real user's behalf.
+ */
+const NOT_CALL_SITES = [
+  'services/providerAuthService.js',
+  'services/providerAuthService.spec.js',
+];
+
+/**
+ * Remove comments so that prose discussing these identifiers cannot vouch for
+ * a file that never calls them — and so a commented-out guard reads as absent.
+ *
+ * String- and template-aware on purpose: a naive `//.*$` sweep truncates any
+ * line containing a URL, which would silently delete real code from the text
+ * being scanned and turn this guard into a source of false passes.
+ */
+function stripComments(source) {
+  let out = '';
+  let i = 0;
+  const n = source.length;
+
+  while (i < n) {
+    const ch = source[i];
+    const next = source[i + 1];
+
+    if (ch === '/' && next === '/') {
+      while (i < n && source[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      i += 2;
+      while (i < n && !(source[i] === '*' && source[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const quote = ch;
+      out += ch;
+      i++;
+      while (i < n) {
+        if (source[i] === '\\') {
+          out += source[i] + (source[i + 1] ?? '');
+          i += 2;
+          continue;
+        }
+        out += source[i];
+        if (source[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    out += ch;
+    i++;
+  }
+
+  return out;
+}
+
+function walk(dir, found = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, found);
+    } else if (/\.(js|vue)$/.test(entry.name)) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+function callSites() {
+  return walk(FRONTEND_SRC)
+    .map((full) => ({
+      rel: path.relative(FRONTEND_SRC, full).split(path.sep).join('/'),
+      code: stripComments(fs.readFileSync(full, 'utf8')),
+    }))
+    .filter(({ rel, code }) => !NOT_CALL_SITES.includes(rel) && code.includes(`${REDEEM}(`));
+}
+
+describe('every OAuth code redemption is behind an origin check', () => {
+  it('finds the call sites at all, so a silent zero cannot pass this suite', () => {
+    // Without this, renaming the service method would empty the set and every
+    // assertion below would vacuously succeed.
+    const sites = callSites().map((s) => s.rel);
+
+    expect(sites.length).toBeGreaterThanOrEqual(3);
+    expect(sites).toContain('composables/useProviderConnection.js');
+    expect(sites).toContain('views/Terminal/CenterPanel/screens/Connectors/Connectors.vue');
+    expect(sites).toContain(
+      'views/Terminal/RightPanel/types/ChatPanel/components/IntegrationHealth.vue',
+    );
+  });
+
+  it('vets the sender before redeeming, at every call site', () => {
+    const unguarded = callSites()
+      .filter(({ code }) => !code.includes(`${GUARD}(`))
+      .map(({ rel }) => rel);
+
+    expect(unguarded, `these redeem an OAuth code without calling ${GUARD}`).toEqual([]);
+  });
+
+  it('nobody has reintroduced a hand-rolled origin comparison', () => {
+    // The two guards that existed were copy-pasted, and the copy is what let
+    // them drift apart. One predicate, or the class of bug comes back.
+    const handRolled = callSites()
+      .filter(({ code }) => /event\.origin\s*(===|!==|\.includes|\.startsWith|\.indexOf)/.test(code))
+      .map(({ rel }) => rel);
+
+    expect(handRolled, `these compare event.origin inline instead of using ${GUARD}`).toEqual([]);
+  });
+
+  it('the guard is called before the redemption in each file', () => {
+    // Ordering is the whole point: a check that runs afterwards is decoration.
+    const tooLate = callSites()
+      .filter(({ code }) => code.indexOf(`${GUARD}(`) > code.indexOf(`${REDEEM}(`))
+      .map(({ rel }) => rel);
+
+    expect(tooLate, `these call ${REDEEM} before ${GUARD}`).toEqual([]);
+  });
+});
+
+describe('the comment stripper this guard depends on', () => {
+  // Self-tests, because a stripper that eats real code turns the assertions
+  // above into false passes — the exact failure mode Copilot caught in the
+  // sibling guard on PR #78.
+  it('removes a commented-out guard call', () => {
+    expect(stripComments(`// ${GUARD}(event.origin)`)).not.toContain(GUARD);
+  });
+
+  it('keeps a URL that contains a double slash', () => {
+    const line = `const state = 'github:http://localhost:3333';`;
+    expect(stripComments(line)).toBe(line);
+  });
+
+  it('keeps code that follows a URL on the same line', () => {
+    const line = `send('https://api.agnt.gg'); ${GUARD}(event.origin);`;
+    expect(stripComments(line)).toContain(`${GUARD}(event.origin)`);
+  });
+
+  it('removes a block comment without touching adjacent code', () => {
+    expect(stripComments(`a();/* ${GUARD}( */b();`)).toBe('a();b();');
+  });
+});

--- a/frontend/src/__guards__/oauthMessageOriginContract.spec.js
+++ b/frontend/src/__guards__/oauthMessageOriginContract.spec.js
@@ -45,6 +45,8 @@ const FRONTEND_SRC = path.resolve(HERE, '..');
 const REDEEM = 'completeRemoteOAuthCallback';
 /** The one predicate allowed to answer "may this sender do that?". */
 const GUARD = 'isTrustedOAuthMessageOrigin';
+/** The one predicate allowed to answer "is this message actionable?". */
+const PAYLOAD_GUARD = 'hasOAuthMessagePayload';
 
 /**
  * Where the function is defined and where it is mocked. Neither redeems
@@ -170,6 +172,35 @@ describe('every OAuth code redemption is behind an origin check', () => {
       .map(({ rel }) => rel);
 
     expect(tooLate, `these call ${REDEEM} before ${GUARD}`).toEqual([]);
+  });
+
+  /**
+   * A trusted origin is not a well-formed message. These are global `message`
+   * listeners, so a same-origin sender that knows nothing about OAuth can post
+   * `null` and make `event.data.type` throw. Because the handlers are `async`
+   * that surfaces as an unhandled rejection rather than a visible crash, so
+   * nothing fails loudly when it regresses — which is exactly when a mechanical
+   * check earns its place.
+   */
+  it('checks the payload is object-shaped before branching on it', () => {
+    const unguarded = callSites()
+      .filter(({ code }) => !code.includes(`${PAYLOAD_GUARD}(`))
+      .map(({ rel }) => rel);
+
+    expect(unguarded, `these read event.data without calling ${PAYLOAD_GUARD}`).toEqual([]);
+  });
+
+  it('nobody has reintroduced a hand-rolled payload check', () => {
+    // Three handlers previously disagreed about this: two omitted it entirely
+    // and one repeated `event.data &&` at every branch. One predicate, or they
+    // drift apart again.
+    const handRolled = callSites()
+      .filter(({ code }) => /event\.data\s*&&/.test(code))
+      .map(({ rel }) => rel);
+
+    expect(handRolled, `these test event.data inline instead of using ${PAYLOAD_GUARD}`).toEqual(
+      [],
+    );
   });
 });
 

--- a/frontend/src/composables/useProviderConnection.js
+++ b/frontend/src/composables/useProviderConnection.js
@@ -9,7 +9,10 @@ import { API_CONFIG } from '@/tt.config.js';
 import { PROVIDER_DISPLAY_NAMES, resolveProviderKey } from '@/store/app/aiProvider.js';
 import { encrypt } from '@/views/_utils/encryption.js';
 import providerAuthService from '@/services/providerAuthService.js';
-import { isTrustedOAuthMessageOrigin } from '@/utils/oauthMessageOrigin.js';
+import {
+  isTrustedOAuthMessageOrigin,
+  hasOAuthMessagePayload,
+} from '@/utils/oauthMessageOrigin.js';
 
 export function useProviderConnection(modalRef) {
   const store = useStore();
@@ -482,6 +485,12 @@ export function useProviderConnection(modalRef) {
     // `event.origin.includes('localhost')`, which admitted any registrable
     // domain containing that substring. See utils/oauthMessageOrigin.js.
     if (!isTrustedOAuthMessageOrigin(event.origin)) return;
+
+    // A trusted origin is not a well-formed message. This is a global listener,
+    // so a same-origin extension or dev-server client posting `null` would
+    // otherwise throw on `event.data.type` — as an unhandled rejection, since
+    // this handler is async.
+    if (!hasOAuthMessagePayload(event)) return;
 
     if (event.data.type === 'oauth_success') {
       await refreshHealth();

--- a/frontend/src/composables/useProviderConnection.js
+++ b/frontend/src/composables/useProviderConnection.js
@@ -9,6 +9,7 @@ import { API_CONFIG } from '@/tt.config.js';
 import { PROVIDER_DISPLAY_NAMES, resolveProviderKey } from '@/store/app/aiProvider.js';
 import { encrypt } from '@/views/_utils/encryption.js';
 import providerAuthService from '@/services/providerAuthService.js';
+import { isTrustedOAuthMessageOrigin } from '@/utils/oauthMessageOrigin.js';
 
 export function useProviderConnection(modalRef) {
   const store = useStore();
@@ -476,8 +477,11 @@ export function useProviderConnection(modalRef) {
   // ── OAuth postMessage listener ───────────────────────────
 
   const handleOAuthMessage = async (event) => {
-    const allowedOrigins = [window.location.origin, 'https://api.agnt.gg'];
-    if (!allowedOrigins.some((origin) => event.origin === origin || event.origin.includes('localhost'))) return;
+    // This handler redeems an OAuth code against the signed-in user's account,
+    // so the origin check is the trust boundary. It used to OR in a bare
+    // `event.origin.includes('localhost')`, which admitted any registrable
+    // domain containing that substring. See utils/oauthMessageOrigin.js.
+    if (!isTrustedOAuthMessageOrigin(event.origin)) return;
 
     if (event.data.type === 'oauth_success') {
       await refreshHealth();

--- a/frontend/src/composables/useProviderConnection.spec.js
+++ b/frontend/src/composables/useProviderConnection.spec.js
@@ -92,8 +92,11 @@ describe('useProviderConnection — oauth-callback postMessage handler', () => {
           state: 'twitter:http://localhost:3333',
           provider: 'twitter',
         },
-        // jsdom's window.location.origin is 'http://localhost' which the
-        // handler accepts via its `event.origin.includes('localhost')` rule.
+        // Same-origin, which is an exact match against `window.location.origin`.
+        // This previously carried a comment attributing the pass to the
+        // handler's `event.origin.includes('localhost')` rule; that was never
+        // true — the exact-match term matched first, and the test goes on
+        // passing now that the substring rule is gone.
         origin: window.location.origin,
       }),
     );
@@ -134,6 +137,41 @@ describe('useProviderConnection — oauth-callback postMessage handler', () => {
           provider: 'twitter',
         },
         origin: 'https://evil.example.com',
+      }),
+    );
+    await flushPromises();
+
+    expect(providerAuthService.completeRemoteOAuthCallback).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The test above passed against the vulnerable handler too: it never
+   * exercised the hole. The old guard OR'd in a bare
+   * `event.origin.includes('localhost')`, so it refused `evil.example.com`
+   * while admitting anything whose origin merely CONTAINED that substring —
+   * all of these registrable by an attacker.
+   *
+   * A wrong code redeemed here is grafted onto the signed-in user's account,
+   * so these run through the real listener rather than the predicate alone.
+   */
+  it.each([
+    'https://localhost.evil.com',
+    'https://evil-localhost.io',
+    'http://localhostage.com',
+    'https://notlocalhost.xyz',
+  ])('ignores oauth-callback from %s, which the substring rule admitted', async (origin) => {
+    wrapper = mount(Harness, { global: { plugins: [makeStore()] } });
+    await flushPromises();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          type: 'oauth-callback',
+          code: 'attacker-supplied-code',
+          state: 'twitter:x',
+          provider: 'twitter',
+        },
+        origin,
       }),
     );
     await flushPromises();

--- a/frontend/src/composables/useProviderConnection.spec.js
+++ b/frontend/src/composables/useProviderConnection.spec.js
@@ -154,6 +154,85 @@ describe('useProviderConnection — oauth-callback postMessage handler', () => {
    * A wrong code redeemed here is grafted onto the signed-in user's account,
    * so these run through the real listener rather than the predicate alone.
    */
+  /**
+   * Passing the origin check says the sender is us; it says nothing about what
+   * they sent. This is a global `message` listener, so same-origin senders that
+   * know nothing about OAuth reach it too, and `event.data.type` on a `null`
+   * payload throws.
+   *
+   * The rejection has to be captured explicitly. `handleOAuthMessage` is
+   * `async`, so the throw never reaches `dispatchEvent` — it becomes an
+   * unhandled rejection, and a test written as `expect(() =>
+   * window.dispatchEvent(...)).not.toThrow()` passes whether or not the guard
+   * exists. Verified before writing this: without the capture below, removing
+   * the guard leaves the suite green.
+   */
+  // `undefined` is deliberately absent: the MessageEvent constructor
+  // normalises it to `null` (verified, not assumed), so a case labelled
+  // "undefined" here would silently be a second null case. Genuine `undefined`
+  // is covered against the predicate directly in utils/oauthMessageOrigin.spec.js.
+  it.each([
+    ['null', null],
+    ['a string', 'vite:beforeUpdate'],
+    ['a number', 42],
+  ])(
+    'survives a trusted-origin message whose payload is %s',
+    async (_label, data) => {
+      wrapper = mount(Harness, { global: { plugins: [makeStore()] } });
+      await flushPromises();
+
+      const rejections = [];
+      const capture = (reason) => rejections.push(reason);
+      process.on('unhandledRejection', capture);
+
+      try {
+        window.dispatchEvent(
+          new MessageEvent('message', { data, origin: window.location.origin }),
+        );
+        await flushPromises();
+        // An unhandled rejection is only reported once the microtask queue has
+        // drained and no handler has attached, so yield to the macrotask queue.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      } finally {
+        process.off('unhandledRejection', capture);
+      }
+
+      expect(rejections.map(String)).toEqual([]);
+      expect(providerAuthService.completeRemoteOAuthCallback).not.toHaveBeenCalled();
+    },
+  );
+
+  it('still acts on a well-formed message after a malformed one', async () => {
+    // The guard must skip the bad message, not wedge the listener.
+    providerAuthService.completeRemoteOAuthCallback.mockResolvedValueOnce({
+      success: true,
+      provider: 'twitter',
+    });
+
+    wrapper = mount(Harness, { global: { plugins: [makeStore()] } });
+    await flushPromises();
+
+    window.dispatchEvent(
+      new MessageEvent('message', { data: null, origin: window.location.origin }),
+    );
+    await flushPromises();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          type: 'oauth-callback',
+          code: 'twitter-auth-code-xyz',
+          state: 'twitter:x',
+          provider: 'twitter',
+        },
+        origin: window.location.origin,
+      }),
+    );
+    await flushPromises();
+
+    expect(providerAuthService.completeRemoteOAuthCallback).toHaveBeenCalledTimes(1);
+  });
+
   it.each([
     'https://localhost.evil.com',
     'https://evil-localhost.io',

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -11,6 +11,7 @@ import { registerAllWidgets } from '@/canvas/widgets/index.js';
 import { syncMediaCookieFromStorage } from '@/services/mediaAuth.js';
 import { watchSession, stopLicenseRefresh, idle } from '@/store/auth/sessionBoot.js';
 import { adoptTokenFromUrl } from '@/store/auth/urlSessionToken.js';
+import { forwardGoogleAuthToOpener } from '@/utils/googleAuthPopup.js';
 import { vTooltip } from '@/directives/tooltip.js';
 import { vViewportClamp } from '@/directives/viewportClamp.js';
 import { installAppHeight } from '@/utils/appHeight.js';
@@ -19,6 +20,21 @@ import { installAppHeight } from '@/utils/appHeight.js';
 if (process.env.NODE_ENV === 'development') {
   import('@/utils/testRateLimit');
 }
+
+// FIRST, before any other boot work: if this document is the "Continue with
+// Google" popup coming back with a token, hand that token to the window that
+// opened the popup and close.
+//
+// This has to happen before `adoptTokenFromUrl` below, which strips `?token=`
+// from the address bar — the token is readable exactly once, and whichever of
+// the two runs first is the one that gets it. It also has to happen before
+// `createApp`, because a window that exists only to carry a token back must
+// not mount an application. Without it the popup boots a second copy of AGNT
+// and signs ITSELF in, stranding the user in a 600x700 login window while the
+// window they started from still shows the sign-in screen.
+//
+// See utils/googleAuthPopup.js.
+const isGoogleAuthHandoff = forwardGoogleAuthToOpener();
 
 // Before mount, not after: a restored conversation can render an <img
 // src="/api/local-file/..."> on the very first paint, and that request needs
@@ -133,7 +149,13 @@ app.config.errorHandler = (err, _instance, info) => {
 
 // MOUNT IMMEDIATELY - show the app shell before data loading
 // This eliminates the blank screen while API calls complete
-app.mount('#app');
+//
+// ...unless this window is the Google auth popup, which has already handed its
+// token to the opener and is closing. Mounting a second application in there
+// IS the defect — see utils/googleAuthPopup.js.
+if (!isGoogleAuthHandoff) {
+  app.mount('#app');
+}
 
 // Dev-only: `__auditContrast()` in the console reports any on-screen text that
 // is unreadable against its ACTUAL rendered backdrop. Static analysis cannot
@@ -214,4 +236,17 @@ window.addEventListener('beforeunload', () => {
 });
 
 // Initialize app data in background AFTER mount (non-blocking)
-initializeApp().catch(console.error);
+if (!isGoogleAuthHandoff) {
+  initializeApp().catch(console.error);
+} else {
+  // `window.close()` is a request the browser is allowed to refuse. If it did,
+  // this popup is now sitting on an empty page, so boot it after all: the worst
+  // case becomes the old behaviour — signed in, wrong window — and never a
+  // dead end the user has to work out for themselves.
+  setTimeout(() => {
+    if (!window.closed) {
+      app.mount('#app');
+      initializeApp().catch(console.error);
+    }
+  }, 1000);
+}

--- a/frontend/src/store/auth/urlSessionToken.js
+++ b/frontend/src/store/auth/urlSessionToken.js
@@ -47,8 +47,12 @@
  * session: adopting garbage would store it, fail verification, and take the
  * user's existing localStorage token down with it. Ignoring garbage instead
  * leaves an already-signed-in user exactly as they were.
+ *
+ * Exported because there are two ways a token can arrive from outside — the
+ * address bar and the Google popup's postMessage — and they must apply the
+ * same rule. A second copy of this would be one more place to forget.
  */
-function looksLikeJwt(value) {
+export function looksLikeJwt(value) {
   if (typeof value !== 'string') return false;
   const parts = value.split('.');
   return parts.length === 3 && parts.every((p) => p.length > 0);

--- a/frontend/src/utils/googleAuthPopup.js
+++ b/frontend/src/utils/googleAuthPopup.js
@@ -50,6 +50,61 @@
 export const GOOGLE_AUTH_SUCCESS = 'google-auth-success';
 
 /**
+ * May this `message` event be allowed to complete a sign-in?
+ *
+ * ---------------------------------------------------------------------------
+ * WHY AN ORIGIN CHECK IS NOT ENOUGH
+ * ---------------------------------------------------------------------------
+ * `event.origin` says the sender is same-origin. It does not say the sender is
+ * the popup we just opened, and this application renders authored HTML in
+ * iframes that are same-origin by construction:
+ *
+ *   Artifacts.vue          sandbox="allow-scripts allow-same-origin"
+ *   CustomWidgetRenderer   sandbox="allow-scripts allow-same-origin ..."
+ *                          :srcdoc="renderedSource"
+ *
+ * `allow-scripts` together with `allow-same-origin` means that content runs AT
+ * the app's real origin. Any artifact or widget could therefore call
+ * `parent.postMessage({ type: 'google-auth-success', token }, origin)` and, on
+ * an origin check alone, be believed. The user would be moved into whichever
+ * account that token belongs to and carry on working there — filing their
+ * keys, files and conversations under someone else's login.
+ *
+ * So the sender's identity is checked, not merely its origin.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS IS NOT A STRICT `event.source === popup`
+ * ---------------------------------------------------------------------------
+ * A message is only REFUSED when a different sender is positively identified.
+ * If `event.source` is null — some engines drop it once the sender has been
+ * discarded, and this popup closes itself immediately after posting — the
+ * check abstains rather than rejects.
+ *
+ * That abstention cannot be exploited: a live frame always has a non-null
+ * `source`, so the spoof above is refused either way. What it buys is that a
+ * quirk of one embedder can never lock a user out of signing in, which a
+ * strict identity test would risk for no additional protection. Electron is
+ * already known to report an empty `origin` across this same window boundary.
+ *
+ * @param {MessageEvent} event
+ * @param {Window|null}  popup  the handle returned by `window.open`
+ * @param {Window}       [win]  injectable for tests
+ */
+export function isTrustedAuthMessage(event, popup, win = globalThis.window) {
+  if (!event) return false;
+
+  // An empty origin is tolerated for the same reason as below: Electron's
+  // proxy for a window that is same-origin by construction can report one.
+  const expectedOrigin = win?.location?.origin;
+  if (event.origin && expectedOrigin && event.origin !== expectedOrigin) return false;
+
+  // A sender we can see, that is not the window we opened, is refused.
+  if (popup && event.source && event.source !== popup) return false;
+
+  return true;
+}
+
+/**
  * If this document is a Google-auth popup on its return leg, give the token to
  * the opener and close.
  *

--- a/frontend/src/utils/googleAuthPopup.js
+++ b/frontend/src/utils/googleAuthPopup.js
@@ -50,6 +50,116 @@
 export const GOOGLE_AUTH_SUCCESS = 'google-auth-success';
 
 /**
+ * A same-origin channel the handover falls back to when `window.opener` is not
+ * reachable.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY A SECOND CHANNEL AT ALL
+ * ---------------------------------------------------------------------------
+ * `opener.postMessage` needs the opener relationship to survive the round trip
+ * through Google. Today it does, but only just: `accounts.google.com` already
+ * sends
+ *
+ *   cross-origin-opener-policy-report-only: same-origin
+ *
+ * Report-only means Google is MEASURING the breakage before enforcing it. On
+ * the day that header loses its `-report-only`, navigating the popup to
+ * accounts.google.com swaps its browsing-context group, `window.opener`
+ * becomes permanently null, and a handover built on the opener alone goes
+ * silently inert — the popup would boot a second app again, which is the exact
+ * bug this file exists to fix. The same COOP change is what broke the
+ * `window.closed` polling in Google's own GSI library.
+ *
+ * Electron is the other unknown: the popup is a separate BrowserWindow created
+ * by `setWindowOpenHandler`, and whether the child sees a usable `opener` is
+ * not something a unit test here can settle.
+ *
+ * A BroadcastChannel depends on neither. It is same-origin by construction and
+ * carries no relationship to how the window was created, so it works whether
+ * or not COOP severs the opener, and regardless of how Electron builds the
+ * child window.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY IT IS A FALLBACK AND NOT THE PRIMARY
+ * ---------------------------------------------------------------------------
+ * `postMessage` to a specific opener is TARGETED: exactly one window receives
+ * the token. A broadcast reaches every same-origin context, which here
+ * includes artifact and widget iframes, since those are rendered
+ * `allow-scripts allow-same-origin`.
+ *
+ * That is not a new capability — this application keeps the session token in
+ * `localStorage`, which any same-origin script can already read, so a hostile
+ * artifact does not need the channel to obtain one. But "no worse than
+ * today" is a poor reason to widen a path, so the broadcast only happens when
+ * the targeted route is unavailable. In the common case nothing is broadcast
+ * at all.
+ */
+export const GOOGLE_AUTH_CHANNEL = 'agnt-google-auth';
+
+/**
+ * Set by the opener immediately before `window.open`, read by the popup on its
+ * return leg.
+ *
+ * THE PROBLEM THIS SOLVES: a popup whose opener COOP has severed and an
+ * ordinary redirect into the user's own tab are INDISTINGUISHABLE from inside
+ * the document. Both have `window.opener === null` and both arrive at
+ * `/settings?token=...`. Broadcasting and closing on that signal alone would
+ * mean a popup-blocked user — who is signing in in their real tab — has that
+ * tab closed underneath them.
+ *
+ * So the opener leaves a positive signal instead of the popup guessing.
+ * `localStorage` rather than `sessionStorage`, because a session store is only
+ * cloned into a same-origin `window.open`, and this popup is navigated
+ * cross-origin before it comes back.
+ *
+ * A stale mark is bounded three ways: a short TTL, the opener clearing it when
+ * the flow finishes, and the fact that `window.close()` is a no-op on a window
+ * that script did not open — so the worst case of a misread is the one-second
+ * mount fallback in main.js, not a lost tab.
+ */
+const POPUP_MARK_KEY = 'agnt:google-auth-popup-open';
+const POPUP_MARK_TTL_MS = 5 * 60 * 1000;
+
+/** localStorage, or null where it is unavailable (private mode, some embeds). */
+function defaultStorage() {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Record that this window is about to open a Google auth popup. */
+export function markGoogleAuthPopupOpen(storage = defaultStorage()) {
+  try {
+    storage?.setItem(POPUP_MARK_KEY, String(Date.now()));
+  } catch {
+    /* a storage that refuses writes just means we fall back to opener-only */
+  }
+}
+
+/** Forget it, once the flow has finished one way or the other. */
+export function clearGoogleAuthPopupMark(storage = defaultStorage()) {
+  try {
+    storage?.removeItem(POPUP_MARK_KEY);
+  } catch {
+    /* nothing to do */
+  }
+}
+
+/** Was a popup opened recently enough that this document is plausibly it? */
+function popupMarkIsFresh(storage) {
+  try {
+    const raw = storage?.getItem(POPUP_MARK_KEY);
+    if (!raw) return false;
+    const age = Date.now() - Number(raw);
+    return Number.isFinite(age) && age >= 0 && age < POPUP_MARK_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * May this `message` event be allowed to complete a sign-in?
  *
  * ---------------------------------------------------------------------------
@@ -114,15 +224,14 @@ export function isTrustedAuthMessage(event, popup, win = globalThis.window) {
  *                      load" — including the genuine redirect flow, where
  *                      there is no opener and boot signs in normally.
  */
-export function forwardGoogleAuthToOpener(win = globalThis.window) {
+export function forwardGoogleAuthToOpener(win = globalThis.window, options = {}) {
   if (!win) return false;
 
-  // No opener means this is not a popup. That is the redirect flow — the path
-  // taken when the browser blocks popups — and signing in right here is the
-  // correct behaviour, not the bug. Returning false hands it to
-  // adoptTokenFromUrl untouched.
-  const opener = win.opener;
-  if (!opener || opener === win) return false;
+  const {
+    storage = defaultStorage(),
+    createChannel = defaultCreateChannel,
+    defer = (fn) => setTimeout(fn, 0),
+  } = options;
 
   let token = null;
   try {
@@ -131,28 +240,77 @@ export function forwardGoogleAuthToOpener(win = globalThis.window) {
     return false;
   }
 
-  // A popup with no token: the OAuth leg is still in flight, or an error came
-  // back. Either way there is nothing to forward.
+  // No token: the OAuth leg is still in flight, an error came back, or this is
+  // an ordinary page load. Nothing to forward either way.
   if (!token) return false;
 
-  try {
-    // targetOrigin is OUR origin and never '*'. The opener is same-origin by
-    // construction, and a session token must not be readable by whatever else
-    // that window may have navigated to in the meantime.
-    opener.postMessage({ type: GOOGLE_AUTH_SUCCESS, token }, win.location.origin);
-  } catch {
-    // The opener was closed, or is otherwise unreachable. Report "not handled"
-    // so the caller boots normally and the user is still signed in — in this
-    // window, which is the old behaviour and strictly better than stranding
-    // them in a popup nobody is listening to.
-    return false;
+  // ── Route 1: the opener, when we can still reach it ──────────────────────
+  // Targeted delivery to exactly one window. targetOrigin is OUR origin and
+  // never '*': the opener is same-origin by construction, and a session token
+  // must not be readable by whatever else that window may have navigated to.
+  const opener = win.opener && win.opener !== win ? win.opener : null;
+  if (opener) {
+    let delivered = false;
+    try {
+      opener.postMessage({ type: GOOGLE_AUTH_SUCCESS, token }, win.location.origin);
+      delivered = true;
+    } catch {
+      /* opener closed or unreachable — fall through to the channel */
+    }
+
+    if (delivered) {
+      clearGoogleAuthPopupMark(storage);
+      try {
+        win.close();
+      } catch {
+        /* close() is a request, not a guarantee; main.js handles a refusal */
+      }
+      return true;
+    }
   }
 
+  // ── Route 2: the same-origin channel ─────────────────────────────────────
+  // Only for a window we can POSITIVELY identify as a popup. Without the mark,
+  // a document with no opener is indistinguishable from the redirect flow, and
+  // broadcasting there would mean closing a tab the user opened themselves.
+  if (!popupMarkIsFresh(storage)) return false;
+
+  const channel = createChannel(GOOGLE_AUTH_CHANNEL);
+  if (!channel) return false; // no BroadcastChannel: boot normally, old behaviour
+
   try {
-    win.close();
+    channel.postMessage({ type: GOOGLE_AUTH_SUCCESS, token });
   } catch {
-    /* close() is a request, not a guarantee; main.js handles a refusal */
+    return false;
+  } finally {
+    try {
+      channel.close();
+    } catch {
+      /* already gone */
+    }
   }
+
+  clearGoogleAuthPopupMark(storage);
+
+  // Deferred by one task. `postMessage` queues delivery on the receiving
+  // contexts rather than this one, so closing immediately should be safe —
+  // this costs nothing and removes the question.
+  defer(() => {
+    try {
+      win.close();
+    } catch {
+      /* main.js mounts after a second if the browser refused */
+    }
+  });
 
   return true;
+}
+
+/** A BroadcastChannel, or null where the API is unavailable or blocked. */
+function defaultCreateChannel(name) {
+  try {
+    return typeof BroadcastChannel === 'function' ? new BroadcastChannel(name) : null;
+  } catch {
+    return null;
+  }
 }

--- a/frontend/src/utils/googleAuthPopup.js
+++ b/frontend/src/utils/googleAuthPopup.js
@@ -1,0 +1,103 @@
+/**
+ * FINISH A "CONTINUE WITH GOOGLE" SIGN-IN IN THE WINDOW THAT STARTED IT.
+ *
+ * ---------------------------------------------------------------------------
+ * THE DEFECT THIS CLOSES
+ * ---------------------------------------------------------------------------
+ * `connectGoogle()` in LoginSection.vue opens a 600x700 popup at
+ * `<REMOTE>/users/auth/google?redirectUrl=<origin>/settings`, and then listens
+ * on its own window for a `google-auth-success` message.
+ *
+ * Nothing ever sent that message. It has been dead code since it was written:
+ * a repo-wide search finds the listener and no sender.
+ *
+ * The remote does not hand the token back to the opener. It redirects the
+ * POPUP to `<origin>/settings?token=...`, and that URL is the whole
+ * application. So the popup booted a second copy of AGNT, adopted the token
+ * from its own address bar, verified it and navigated to the chat — inside a
+ * 600x700 window with no chrome. The window the user started from was never
+ * told anything and sat on the sign-in screen.
+ *
+ * The user ends up working in the popup. That is the reported symptom: "AGNT
+ * opens in the sign-in window instead of the main one."
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THE FIX GOES HERE AND NOT IN A COMPONENT
+ * ---------------------------------------------------------------------------
+ * A window that exists only to carry a token back must not mount an app. If
+ * this ran from a mounted component the entire SPA would render in the popup
+ * before it closed — the user would watch a second AGNT flash up and vanish,
+ * and every request that render issued would be real.
+ *
+ * So it runs at module scope in main.js, before `createApp`.
+ *
+ * ---------------------------------------------------------------------------
+ * ORDERING: THIS MUST RUN BEFORE adoptTokenFromUrl()
+ * ---------------------------------------------------------------------------
+ * `store/auth/urlSessionToken.js` reads `?token=` and then STRIPS it from the
+ * address bar via `history.replaceState`, so that a live credential does not
+ * leak into browser history or into the `Referer` header. That is correct, and
+ * it means the token is readable exactly once. Whichever of the two runs first
+ * is the one that gets it.
+ *
+ * If adoption ran first, this function would find an empty query string, the
+ * popup would sign itself in, and the bug would be exactly as it was. The
+ * order is asserted mechanically in googleAuthPopup.spec.js, in the same way
+ * and for the same reason as the rest of the boot sequence.
+ */
+
+/** The message type LoginSection.vue's opener-side listener waits for. */
+export const GOOGLE_AUTH_SUCCESS = 'google-auth-success';
+
+/**
+ * If this document is a Google-auth popup on its return leg, give the token to
+ * the opener and close.
+ *
+ * @param {Window} win  Injectable for tests; defaults to the real window.
+ * @returns {boolean}   true when the handoff happened and the caller must NOT
+ *                      boot the app. false means "this is an ordinary page
+ *                      load" — including the genuine redirect flow, where
+ *                      there is no opener and boot signs in normally.
+ */
+export function forwardGoogleAuthToOpener(win = globalThis.window) {
+  if (!win) return false;
+
+  // No opener means this is not a popup. That is the redirect flow — the path
+  // taken when the browser blocks popups — and signing in right here is the
+  // correct behaviour, not the bug. Returning false hands it to
+  // adoptTokenFromUrl untouched.
+  const opener = win.opener;
+  if (!opener || opener === win) return false;
+
+  let token = null;
+  try {
+    token = new URLSearchParams(win.location.search).get('token');
+  } catch {
+    return false;
+  }
+
+  // A popup with no token: the OAuth leg is still in flight, or an error came
+  // back. Either way there is nothing to forward.
+  if (!token) return false;
+
+  try {
+    // targetOrigin is OUR origin and never '*'. The opener is same-origin by
+    // construction, and a session token must not be readable by whatever else
+    // that window may have navigated to in the meantime.
+    opener.postMessage({ type: GOOGLE_AUTH_SUCCESS, token }, win.location.origin);
+  } catch {
+    // The opener was closed, or is otherwise unreachable. Report "not handled"
+    // so the caller boots normally and the user is still signed in — in this
+    // window, which is the old behaviour and strictly better than stranding
+    // them in a popup nobody is listening to.
+    return false;
+  }
+
+  try {
+    win.close();
+  } catch {
+    /* close() is a request, not a guarantee; main.js handles a refusal */
+  }
+
+  return true;
+}

--- a/frontend/src/utils/googleAuthPopup.spec.js
+++ b/frontend/src/utils/googleAuthPopup.spec.js
@@ -192,6 +192,131 @@ describe('isTrustedAuthMessage', () => {
 });
 
 /**
+ * THE NULL-SOURCE ABSTENTION, AND HOW FAR IT IS ALLOWED TO REACH.
+ *
+ * `isTrustedAuthMessage` refuses a message only when a DIFFERENT sender is
+ * positively identified. When `event.source` is null it abstains rather than
+ * rejects, because this popup calls `postMessage` and then `close()`
+ * immediately: by delivery the sender may already be discarded, and the HTML
+ * spec permits a null `source` for exactly that case. Refusing there would
+ * reject the LEGITIMATE message and lock that user out of signing in — worse
+ * than the attack being defended against, on a path CI cannot exercise.
+ *
+ * That is a deliberate weakening of a security check, so its EDGES are what
+ * need pinning, not its happy path. Two properties have to hold, and only the
+ * first of them is obvious:
+ *
+ *   1. a message that cannot be attributed is still allowed through
+ *   2. the abstention is NARROW - it excuses a sender from the identity check
+ *      and from nothing else
+ *
+ * The second is the one that would actually hurt. An abstention written as an
+ * early `if (!event.source) return true;` reads almost identically, passes
+ * every test in the block above, and hands any CROSS-ORIGIN sender a way to
+ * skip the origin check by the simple trick of not being identifiable. These
+ * tests exist to make that refactor fail loudly.
+ */
+describe('isTrustedAuthMessage: the boundaries of the null-source abstention', () => {
+  const ORIGIN = 'https://tenant.example.com';
+  const win = { location: { origin: ORIGIN } };
+  const popup = { name: 'the popup we opened' };
+
+  describe('a sender that cannot be attributed is allowed through', () => {
+    // Engines disagree on how an unattributable sender is reported, and the
+    // difference is not observable from here, so both spellings must behave
+    // the same. `null` is what the HTML spec calls for; `undefined` is what a
+    // synthetic or proxied event can carry.
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+    ])('abstains on a %s source', (_label, source) => {
+      expect(isTrustedAuthMessage({ origin: ORIGIN, source }, popup, win)).toBe(true);
+    });
+
+    it('abstains for a popup the browser has already closed', () => {
+      // The real sequence this exists for: the popup posts, closes itself, and
+      // the message is delivered afterwards with nothing left to attribute it
+      // to. The handle we still hold reports `closed`.
+      const closedPopup = { name: 'the popup we opened', closed: true };
+
+      expect(isTrustedAuthMessage({ origin: ORIGIN, source: null }, closedPopup, win)).toBe(true);
+    });
+
+    it('abstains when the origin is empty AND the sender is gone', () => {
+      // Both known quirks at once: Electron reports an empty origin across
+      // this window boundary, and the sender has been discarded. Neither is
+      // evidence of an attack, and together they must not add up to one.
+      expect(isTrustedAuthMessage({ origin: '', source: null }, popup, win)).toBe(true);
+    });
+  });
+
+  describe('the abstention excuses the identity check and nothing else', () => {
+    it('still refuses a cross-origin sender that has no identifiable source', () => {
+      // THE LOAD-BEARING TEST. If the null-source case is ever moved ahead of
+      // the origin check, this is the hole it opens: a hostile frame stops
+      // being refused the moment it stops being identifiable, which is not a
+      // property an attacker has to work for.
+      const event = { origin: 'https://evil.example.net', source: null };
+
+      expect(isTrustedAuthMessage(event, popup, win)).toBe(false);
+    });
+
+    it('still refuses a cross-origin sender whose source is undefined', () => {
+      const event = { origin: 'https://evil.example.net', source: undefined };
+
+      expect(isTrustedAuthMessage(event, popup, win)).toBe(false);
+    });
+
+    it('does not extend to a sender that IS identifiable', () => {
+      // Tolerating the unattributable must not soften the case the check was
+      // written for. A frame that can be seen, and is not ours, is refused.
+      const artifactFrame = { name: 'an allow-same-origin srcdoc iframe' };
+
+      expect(isTrustedAuthMessage({ origin: ORIGIN, source: artifactFrame }, popup, win)).toBe(
+        false,
+      );
+    });
+
+    it('refuses a missing event even though its source is also absent', () => {
+      // `undefined.source` is unattributable in the most literal sense. It is
+      // still not a reason to sign anybody in.
+      expect(isTrustedAuthMessage(null, popup, win)).toBe(false);
+    });
+  });
+
+  /**
+   * The whole abstention rests on one claim: a sender that is still alive can
+   * always be seen, so nothing an attacker controls reaches the abstaining
+   * branch. If any live-window shape could arrive with a falsy `source`, the
+   * abstention would be a bypass rather than a concession.
+   *
+   * This asserts the claim across every shape a hostile sender could plausibly
+   * take in this app, rather than trusting the single object literal used
+   * above.
+   */
+  describe('every identifiable sender that is not our popup is refused', () => {
+    it.each([
+      ['an artifact preview iframe', { tag: 'iframe', sandbox: 'allow-scripts allow-same-origin' }],
+      ['a custom widget iframe', { tag: 'iframe', srcdoc: '<script>...</script>' }],
+      ['a second popup the app opened', { name: 'some-other-popup' }],
+      ['the top-level window itself', { self: 'window', top: true }],
+      ['an object impersonating our popup by name', { name: 'the popup we opened' }],
+    ])('refuses %s', (_label, source) => {
+      // The last case matters most: identity here is reference equality, not a
+      // name or any other forgeable property.
+      expect(isTrustedAuthMessage({ origin: ORIGIN, source }, popup, win)).toBe(false);
+    });
+
+    it('accepts only the exact window object we opened', () => {
+      expect(isTrustedAuthMessage({ origin: ORIGIN, source: popup }, popup, win)).toBe(true);
+
+      // A structural clone of it is a different window.
+      expect(isTrustedAuthMessage({ origin: ORIGIN, source: { ...popup } }, popup, win)).toBe(false);
+    });
+  });
+});
+
+/**
  * The handoff and `adoptTokenFromUrl` both read `?token=`, and adoption strips
  * it from the address bar so it cannot leak into history or a Referer header.
  * That makes it single-use. If adoption runs first the popup keeps the token,

--- a/frontend/src/utils/googleAuthPopup.spec.js
+++ b/frontend/src/utils/googleAuthPopup.spec.js
@@ -1,0 +1,160 @@
+/**
+ * A SIGN-IN MUST FINISH IN THE WINDOW THAT STARTED IT.
+ *
+ * The reason this defect survived so long is that nothing about it looks like
+ * a failure. The popup signed the user in perfectly — verified the token,
+ * loaded the workspace, navigated to the chat. It just did all of that in a
+ * 600x700 window with no chrome, while the window the user had been looking at
+ * stayed on the sign-in screen. Every unit that could have caught it was
+ * passing, because every unit did its job.
+ *
+ * So these tests are written against the DECISION, in isolation: given an
+ * opener and a token, hand it over and close; given no opener, do nothing and
+ * let the page boot. Both halves are load-bearing. The false branch is the
+ * redirect flow — the path taken when a browser blocks popups — and a fix that
+ * broke it would lock those users out entirely while looking correct here.
+ *
+ * The ordering against `adoptTokenFromUrl` is asserted mechanically against
+ * main.js source, in the same way and for the same reason as the rest of the
+ * boot sequence: both read the same single-use `?token=`, the loser of that
+ * race silently restores the original bug, and no unit test of either function
+ * can see it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { forwardGoogleAuthToOpener, GOOGLE_AUTH_SUCCESS } from './googleAuthPopup.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const makeWin = ({ search = '', opener = null, origin = 'https://tenant.example.com' } = {}) => ({
+  opener,
+  close: vi.fn(),
+  location: { search, origin },
+});
+
+const makeOpener = () => ({ postMessage: vi.fn() });
+
+describe('forwardGoogleAuthToOpener', () => {
+  let opener;
+
+  beforeEach(() => {
+    opener = makeOpener();
+  });
+
+  it('hands the token to the opener and closes the popup', () => {
+    const win = makeWin({ search: '?token=header.payload.signature', opener });
+
+    const handled = forwardGoogleAuthToOpener(win);
+
+    expect(handled).toBe(true);
+    expect(opener.postMessage).toHaveBeenCalledWith(
+      { type: GOOGLE_AUTH_SUCCESS, token: 'header.payload.signature' },
+      'https://tenant.example.com',
+    );
+    expect(win.close).toHaveBeenCalled();
+  });
+
+  it('never posts a token to a wildcard origin', () => {
+    // '*' would publish a live session token to whatever the opener had
+    // navigated to by then.
+    const win = makeWin({ search: '?token=header.payload.signature', opener });
+
+    forwardGoogleAuthToOpener(win);
+
+    expect(opener.postMessage.mock.calls[0][1]).not.toBe('*');
+  });
+
+  it('leaves the redirect flow alone when there is no opener', () => {
+    // A real page load, which must go on to boot and adopt the token here.
+    // This is the popup-blocked path; breaking it would lock those users out.
+    const win = makeWin({ search: '?token=header.payload.signature', opener: null });
+
+    expect(forwardGoogleAuthToOpener(win)).toBe(false);
+    expect(win.close).not.toHaveBeenCalled();
+  });
+
+  it('does nothing in a popup that is not carrying a token', () => {
+    const win = makeWin({ search: '', opener });
+
+    expect(forwardGoogleAuthToOpener(win)).toBe(false);
+    expect(opener.postMessage).not.toHaveBeenCalled();
+    expect(win.close).not.toHaveBeenCalled();
+  });
+
+  it('ignores a window that is its own opener', () => {
+    const win = makeWin({ search: '?token=header.payload.signature' });
+    win.opener = win;
+
+    expect(forwardGoogleAuthToOpener(win)).toBe(false);
+    expect(win.close).not.toHaveBeenCalled();
+  });
+
+  it('reports "not handled" when the opener is gone, so the app still boots', () => {
+    const dead = {
+      postMessage: vi.fn(() => {
+        throw new Error('opener is closed');
+      }),
+    };
+    const win = makeWin({ search: '?token=header.payload.signature', opener: dead });
+
+    // False here is what puts the user in a working app rather than a blank
+    // popup that nobody is listening to.
+    expect(forwardGoogleAuthToOpener(win)).toBe(false);
+    expect(win.close).not.toHaveBeenCalled();
+  });
+
+  it('still reports handled when the browser refuses to close the window', () => {
+    const win = makeWin({ search: '?token=header.payload.signature', opener });
+    win.close = vi.fn(() => {
+      throw new Error('close blocked');
+    });
+
+    // The token was delivered, so the opener is signing in. main.js carries the
+    // fallback for a window that is still standing afterwards.
+    expect(forwardGoogleAuthToOpener(win)).toBe(true);
+    expect(opener.postMessage).toHaveBeenCalled();
+  });
+
+  it('survives being called with no window at all', () => {
+    expect(forwardGoogleAuthToOpener(undefined)).toBe(false);
+  });
+});
+
+/**
+ * The handoff and `adoptTokenFromUrl` both read `?token=`, and adoption strips
+ * it from the address bar so it cannot leak into history or a Referer header.
+ * That makes it single-use. If adoption runs first the popup keeps the token,
+ * signs itself in, and the reported bug is back — with every unit test in this
+ * file still green.
+ */
+describe('boot order in main.js', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../main.js'), 'utf8');
+
+  // The comments in main.js name these functions while explaining them. Index
+  // arithmetic over raw text would match the prose, not the code.
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+  const at = (needle) => {
+    const i = code.indexOf(needle);
+    expect(i, `expected to find \`${needle}\` in main.js`).toBeGreaterThan(-1);
+    return i;
+  };
+
+  it('forwards the token to the opener before adoption strips it from the URL', () => {
+    expect(at('forwardGoogleAuthToOpener()')).toBeLessThan(at('adoptTokenFromUrl(store)'));
+  });
+
+  it('decides before anything mounts', () => {
+    // A window that exists only to carry a token back must not render an app.
+    expect(at('forwardGoogleAuthToOpener()')).toBeLessThan(at('app.mount('));
+  });
+
+  it('does not mount unconditionally', () => {
+    // The guard is the whole fix. A bare `app.mount('#app');` here would mean
+    // the popup boots a second AGNT again.
+    expect(code).toMatch(/if\s*\(\s*!isGoogleAuthHandoff\s*\)\s*\{\s*app\.mount\(/);
+  });
+});

--- a/frontend/src/utils/googleAuthPopup.spec.js
+++ b/frontend/src/utils/googleAuthPopup.spec.js
@@ -25,7 +25,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { forwardGoogleAuthToOpener, GOOGLE_AUTH_SUCCESS } from './googleAuthPopup.js';
+import {
+  forwardGoogleAuthToOpener,
+  isTrustedAuthMessage,
+  GOOGLE_AUTH_SUCCESS,
+} from './googleAuthPopup.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -120,6 +124,70 @@ describe('forwardGoogleAuthToOpener', () => {
 
   it('survives being called with no window at all', () => {
     expect(forwardGoogleAuthToOpener(undefined)).toBe(false);
+  });
+});
+
+/**
+ * WHO IS ALLOWED TO COMPLETE A SIGN-IN.
+ *
+ * The origin check that shipped first is not sufficient, and the gap is
+ * reachable in this application rather than theoretical: artifact previews and
+ * custom widgets are rendered in `allow-scripts allow-same-origin` iframes
+ * with authored HTML in `srcdoc`, so that content runs at the app's own
+ * origin. On an origin check alone it could post its own token and be
+ * believed, moving the user into someone else's account without any visible
+ * change.
+ */
+describe('isTrustedAuthMessage', () => {
+  const win = { location: { origin: 'https://tenant.example.com' } };
+  const popup = { name: 'the popup we opened' };
+
+  it('accepts the popup we opened', () => {
+    const event = { origin: 'https://tenant.example.com', source: popup };
+
+    expect(isTrustedAuthMessage(event, popup, win)).toBe(true);
+  });
+
+  it('refuses a same-origin artifact iframe posing as the popup', () => {
+    // The Copilot finding, verbatim: right origin, wrong window.
+    const artifactFrame = { name: 'an allow-same-origin srcdoc iframe' };
+    const event = { origin: 'https://tenant.example.com', source: artifactFrame };
+
+    expect(isTrustedAuthMessage(event, popup, win)).toBe(false);
+  });
+
+  it('refuses a cross-origin sender', () => {
+    const event = { origin: 'https://evil.example.net', source: popup };
+
+    expect(isTrustedAuthMessage(event, popup, win)).toBe(false);
+  });
+
+  it('tolerates an empty origin, which Electron reports across this boundary', () => {
+    const event = { origin: '', source: popup };
+
+    expect(isTrustedAuthMessage(event, popup, win)).toBe(true);
+  });
+
+  it('abstains when the sender cannot be identified at all', () => {
+    // The popup closes itself immediately after posting, and an engine that
+    // has already discarded it can report `source: null`. Refusing here would
+    // lock those users out of signing in entirely — a worse failure than the
+    // one being defended against, and this abstention does not reopen it:
+    // a live frame always has a source, so the spoof above is still refused.
+    const event = { origin: 'https://tenant.example.com', source: null };
+
+    expect(isTrustedAuthMessage(event, popup, win)).toBe(true);
+  });
+
+  it('abstains when the popup handle is missing', () => {
+    // Nothing to compare against; the origin check is all that is left.
+    const event = { origin: 'https://tenant.example.com', source: { some: 'window' } };
+
+    expect(isTrustedAuthMessage(event, null, win)).toBe(true);
+  });
+
+  it('refuses a missing event outright', () => {
+    expect(isTrustedAuthMessage(undefined, popup, win)).toBe(false);
   });
 });
 

--- a/frontend/src/utils/googleAuthPopup.spec.js
+++ b/frontend/src/utils/googleAuthPopup.spec.js
@@ -28,7 +28,10 @@ import { fileURLToPath } from 'url';
 import {
   forwardGoogleAuthToOpener,
   isTrustedAuthMessage,
+  markGoogleAuthPopupOpen,
+  clearGoogleAuthPopupMark,
   GOOGLE_AUTH_SUCCESS,
+  GOOGLE_AUTH_CHANNEL,
 } from './googleAuthPopup.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -345,9 +348,258 @@ describe('boot order in main.js', () => {
     expect(at('forwardGoogleAuthToOpener()')).toBeLessThan(at('app.mount('));
   });
 
-  it('does not mount unconditionally', () => {
-    // The guard is the whole fix. A bare `app.mount('#app');` here would mean
-    // the popup boots a second AGNT again.
-    expect(code).toMatch(/if\s*\(\s*!isGoogleAuthHandoff\s*\)\s*\{\s*app\.mount\(/);
+    it('does not mount unconditionally', () => {
+      // The guard is the whole fix. A bare `app.mount('#app');` here would mean
+      // the popup boots a second AGNT again.
+      expect(code).toMatch(/if\s*\(\s*!isGoogleAuthHandoff\s*\)\s*\{\s*app\.mount\(/);
+    });
+  });
+
+/**
+ * THE BROADCAST CHANNEL FALLBACK, AND THE MARK THAT MAKES IT SAFE.
+ *
+ * `opener.postMessage` depends on the opener relationship surviving the round
+ * trip through Google. It does today — a real run in the packaged Electron
+ * app confirmed it, which is why this remains a fallback rather than a
+ * repair. But `accounts.google.com` already sends
+ *
+ *   cross-origin-opener-policy-report-only: same-origin
+ *
+ * Google is measuring breakage before enforcing it. The day that header drops
+ * its "report-only", the popup's browsing-context group is swapped on
+ * navigation, `window.opener` becomes permanently null, and the primary route
+ * goes silently inert. A BroadcastChannel has no such dependency: it is
+ * same-origin by construction and does not care how the window was created.
+ *
+ * The danger of a broadcast is the redirect flow. A popup whose opener COOP
+ * has severed and an ordinary redirect into the user's OWN tab are
+ * INDISTINGUISHABLE from inside the document — both have
+ * `window.opener === null` and both arrive at `/settings?token=...`. Without a
+ * positive signal that a popup was actually opened, broadcasting on the
+ * channel would close a tab underneath a popup-blocked user who is signing in
+ * the normal way. The mark in localStorage makes that signal positive, and
+ * these tests pin BOTH halves: the fallback fires when a fresh mark is
+ * present, and REFUSES — refuses to broadcast AND refuses to close — when it
+ * is not.
+ */
+describe('the BroadcastChannel fallback', () => {
+  const TOKEN = 'header.payload.signature';
+
+  /** A storage whose mark is `ageMs` old (default: brand new). */
+  const makeStorage = ({ ageMs = 0, present = true, throwsOn = null } = {}) => {
+    const store = present ? { 'agnt:google-auth-popup-open': String(Date.now() - ageMs) } : {};
+    return {
+      getItem: vi.fn((k) => {
+        if (throwsOn === 'get') throw new Error('storage denied');
+        return store[k] ?? null;
+      }),
+      setItem: vi.fn((k, v) => {
+        if (throwsOn === 'set') throw new Error('storage denied');
+        store[k] = v;
+      }),
+      removeItem: vi.fn((k) => {
+        if (throwsOn === 'remove') throw new Error('storage denied');
+        delete store[k];
+      }),
+    };
+  };
+
+  const makeChannel = () => ({ postMessage: vi.fn(), close: vi.fn() });
+
+  describe('the popup-in-flight mark', () => {
+    it('writes a timestamp the moment the popup is opened', () => {
+      const storage = makeStorage({ present: false });
+
+      markGoogleAuthPopupOpen(storage);
+
+      expect(storage.setItem).toHaveBeenCalledTimes(1);
+      const [key, value] = storage.setItem.mock.calls[0];
+      expect(key).toBe('agnt:google-auth-popup-open');
+      expect(Number(value)).toBeGreaterThan(0);
+    });
+
+    it('is removed once the flow finishes', () => {
+      const storage = makeStorage({});
+
+      clearGoogleAuthPopupMark(storage);
+
+      expect(storage.removeItem).toHaveBeenCalledWith('agnt:google-auth-popup-open');
+    });
+
+    it('survives a storage that refuses to write', () => {
+      // A storage that won't take writes just means the flow falls back to
+      // the opener-only behaviour; it must not throw at the button click.
+      expect(() => markGoogleAuthPopupOpen(makeStorage({ throwsOn: 'set' }))).not.toThrow();
+      expect(() => clearGoogleAuthPopupMark(makeStorage({ throwsOn: 'remove' }))).not.toThrow();
+    });
+  });
+
+  describe('a popup with no reachable opener', () => {
+    it('broadcasts the token and clears the mark', () => {
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+      const storage = makeStorage({});
+      const channel = makeChannel();
+      const createChannel = vi.fn(() => channel);
+      const deferred = [];
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage,
+        createChannel,
+        defer: (fn) => deferred.push(fn),
+      });
+
+      expect(handled).toBe(true);
+      expect(createChannel).toHaveBeenCalledWith('agnt-google-auth');
+      expect(channel.postMessage).toHaveBeenCalledWith({ type: GOOGLE_AUTH_SUCCESS, token: TOKEN });
+      expect(storage.removeItem).toHaveBeenCalledWith('agnt:google-auth-popup-open');
+    });
+
+    it('closes the popup on a deferred task, so delivery is not raced', () => {
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+      const storage = makeStorage({});
+      const deferred = [];
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage,
+        createChannel: () => makeChannel(),
+        defer: (fn) => deferred.push(fn),
+      });
+
+      expect(handled).toBe(true);
+      expect(win.close).not.toHaveBeenCalled(); // still a task to come
+      expect(deferred.length).toBe(1);
+      deferred[0]();
+      expect(win.close).toHaveBeenCalled();
+    });
+
+    it('never opens a wildcard broadcast — the channel is fixed', () => {
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+      const channel = makeChannel();
+
+      forwardGoogleAuthToOpener(win, {
+        storage: makeStorage({}),
+        createChannel: () => channel,
+      });
+
+      expect(channel.postMessage.mock.calls[0][1]).toBeUndefined(); // no targetOrigin — channels have none
+      // and there is no '*' anywhere on the call
+      expect(JSON.stringify(channel.postMessage.mock.calls[0])).not.toContain('*');
+    });
+  });
+
+  describe('THE LOAD-BEARING CASE: the redirect flow must not be touched', () => {
+    it('refuses to broadcast when no mark exists', () => {
+      // A popup-blocked user signs in in their own tab: no opener, no mark.
+      // Firing the channel here would close that tab underneath them.
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+      const createChannel = vi.fn();
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage: makeStorage({ present: false }),
+        createChannel,
+      });
+
+      expect(handled).toBe(false);
+      expect(createChannel).not.toHaveBeenCalled();
+      expect(win.close).not.toHaveBeenCalled();
+    });
+
+    it('refuses when the mark is stale, past the five-minute TTL', () => {
+      // A mark left behind by an abandoned attempt must not fire a day later.
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+      const createChannel = vi.fn();
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage: makeStorage({ ageMs: 6 * 60 * 1000 }),
+        createChannel,
+      });
+
+      expect(handled).toBe(false);
+      expect(createChannel).not.toHaveBeenCalled();
+      expect(win.close).not.toHaveBeenCalled();
+    });
+
+    it('leaves the mark alone when it is not fresh, rather than clearing it', () => {
+      // Only a real handoff clears the mark. A stray read must not erase it,
+      // so an abandoned-but-recent popup can still come back and be recognised.
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+      const storage = makeStorage({ ageMs: 6 * 60 * 1000 });
+
+      forwardGoogleAuthToOpener(win, { storage, createChannel: () => null });
+
+      expect(storage.removeItem).not.toHaveBeenCalled();
+      expect(win.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('route preference: the targeted path, or not at all', () => {
+    it('broadcasts nothing when the opener route works', () => {
+      const opener = makeOpener();
+      const win = makeWin({ search: `?token=${TOKEN}`, opener });
+      const createChannel = vi.fn();
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage: makeStorage({}),
+        createChannel,
+      });
+
+      expect(handled).toBe(true);
+      expect(opener.postMessage).toHaveBeenCalled();
+      expect(createChannel).not.toHaveBeenCalled();
+      expect(win.close).toHaveBeenCalled(); // route 1 closes synchronously
+    });
+
+    it('falls through to the channel when the opener has died', () => {
+      // The opener exists but is unreachable — e.g. closed mid-flight. The
+      // popup must not stop there; the fresh mark lets the channel take over.
+      const deadOpener = {
+        postMessage: vi.fn(() => {
+          throw new Error('opener gone');
+        }),
+      };
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: deadOpener });
+      const channel = makeChannel();
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage: makeStorage({}),
+        createChannel: () => channel,
+      });
+
+      expect(handled).toBe(true);
+      expect(channel.postMessage).toHaveBeenCalled();
+    });
+  });
+
+  describe('degradation when the channel cannot be used', () => {
+    it('returns false when BroadcastChannel is unavailable, so boot proceeds', () => {
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage: makeStorage({}),
+        createChannel: () => null,
+      });
+
+      expect(handled).toBe(false);
+      expect(win.close).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the channel throws on postMessage', () => {
+      const win = makeWin({ search: `?token=${TOKEN}`, opener: null });
+      const channel = {
+        postMessage: vi.fn(() => {
+          throw new Error('channel dead');
+        }),
+        close: vi.fn(),
+      };
+
+      const handled = forwardGoogleAuthToOpener(win, {
+        storage: makeStorage({}),
+        createChannel: () => channel,
+      });
+
+      expect(handled).toBe(false);
+      expect(channel.close).toHaveBeenCalled(); // still released
+      expect(win.close).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/utils/oauthMessageOrigin.js
+++ b/frontend/src/utils/oauthMessageOrigin.js
@@ -120,3 +120,32 @@ export function isTrustedOAuthMessageOrigin(
 
   return false;
 }
+
+/**
+ * Does this message carry a payload worth branching on?
+ *
+ * A trusted origin is not a well-formed message. These are GLOBAL `message`
+ * listeners: they receive every message the window gets, including ones from
+ * senders that have nothing to do with OAuth and post whatever they like. A
+ * browser extension, a dev-server client, another widget on the page — all of
+ * them are same-origin, all of them therefore pass the origin check, and any
+ * of them may post `null`.
+ *
+ * `event.data.type` on a null payload throws. The handlers are `async`, so the
+ * throw does not surface to the dispatcher: it becomes an unhandled rejection,
+ * which is why it can happen repeatedly without anyone noticing.
+ *
+ * Only object payloads are actionable, since every message these handlers act
+ * on is `{ type, ... }`. A string, a number or an array cannot match any branch
+ * anyway, so rejecting them here changes no behaviour — it just moves the
+ * decision to one documented place instead of relying on every `.type` read
+ * being individually defensive.
+ *
+ * @param {MessageEvent} event
+ * @returns {boolean}
+ */
+export function hasOAuthMessagePayload(event) {
+  const data = event?.data;
+  // `typeof null` is 'object', so the null check is not redundant.
+  return data !== null && typeof data === 'object';
+}

--- a/frontend/src/utils/oauthMessageOrigin.js
+++ b/frontend/src/utils/oauthMessageOrigin.js
@@ -1,0 +1,122 @@
+/**
+ * WHICH ORIGINS MAY COMPLETE AN OAUTH CONNECTION.
+ *
+ * ---------------------------------------------------------------------------
+ * THE DEFECT THIS EXISTS FOR
+ * ---------------------------------------------------------------------------
+ * Three `message` handlers act on an `oauth-callback` payload by POSTing the
+ * forwarded `code` to `${REMOTE_URL}/auth/callback` **with the current user's
+ * bearer token**. Whoever can reach those handlers can therefore have an OAuth
+ * authorization code of their choosing redeemed against the victim's account.
+ *
+ * Two of them guarded that with:
+ *
+ *   allowedOrigins.some((origin) =>
+ *     event.origin === origin || event.origin.includes('localhost'))
+ *
+ * The second term never references the callback's own `origin` parameter, so
+ * it is a constant OR'd into every iteration — in effect an unconditional
+ * substring test on the sender's origin. Every one of these is admitted:
+ *
+ *   https://localhost.evil.com     https://evil-localhost.io
+ *   http://localhostage.com        https://notlocalhost.xyz
+ *
+ * all of them registrable by anyone. The third handler (Connectors.vue) had no
+ * origin check at all, so `https://evil.com` reached it directly.
+ *
+ * The consequence is account grafting, not token theft: the ATTACKER'S Google
+ * / Gmail / Drive account gets linked under the VICTIM'S AGNT user, and the
+ * victim's later "read my email" or "save this to Drive" runs operate on the
+ * attacker's account. Nothing on screen indicates it happened.
+ *
+ * Cross-origin *sending* is permitted by design and cannot be prevented — the
+ * receiver's origin check IS the trust boundary. It has to be exact.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY LOOPBACK IS MATCHED ON HOSTNAME, AND ONLY IN A LOOPBACK APP
+ * ---------------------------------------------------------------------------
+ * Development genuinely needs it: the Vite dev server and the backend sit on
+ * different loopback ports, so an exact-origin allowlist alone would break the
+ * OAuth flow for anyone running from source.
+ *
+ * That need is met by parsing the origin and comparing its HOSTNAME against a
+ * fixed set. `new URL('https://localhost.evil.com').hostname` is
+ * `'localhost.evil.com'`, which is not `'localhost'` — the substring hole
+ * closes without costing developers anything.
+ *
+ * The allowance is further conditioned on the APP ITSELF being served from a
+ * loopback host. A hosted tenant therefore never accepts a loopback sender,
+ * so a developer convenience cannot become a production trust rule.
+ */
+
+import { API_CONFIG } from '@/tt.config.js';
+
+/**
+ * Hosts that mean "this machine". Compared exactly, never by substring.
+ * WHATWG `URL` normalises an IPv6 literal to bracketed form in `hostname`.
+ */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+/**
+ * The literal string an opaque origin serialises to — a sandboxed iframe, a
+ * `data:` document, some `file:` contexts. It identifies nobody, so it can
+ * never be a match, not even against an app that is itself opaque.
+ */
+const OPAQUE_ORIGIN = 'null';
+
+function hostnameOf(origin) {
+  try {
+    return new URL(origin).hostname;
+  } catch {
+    return null;
+  }
+}
+
+function originOf(url) {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+function isLoopbackOrigin(origin) {
+  const hostname = hostnameOf(origin);
+  return hostname !== null && LOOPBACK_HOSTS.has(hostname);
+}
+
+/**
+ * May a `message` from this origin be allowed to complete an OAuth connection?
+ *
+ * @param {string} eventOrigin  the `event.origin` of the received message
+ * @param {Window} [win]        injectable for tests
+ * @param {string} [remoteUrl]  injectable for tests; the AGNT API base URL
+ * @returns {boolean}
+ */
+export function isTrustedOAuthMessageOrigin(
+  eventOrigin,
+  win = globalThis.window,
+  remoteUrl = API_CONFIG?.REMOTE_URL,
+) {
+  // An absent or opaque origin identifies nobody. Unlike the popup handover in
+  // utils/googleAuthPopup.js there is no second signal to fall back on here, so
+  // this refuses rather than abstains.
+  if (typeof eventOrigin !== 'string') return false;
+  if (eventOrigin === '' || eventOrigin === OPAQUE_ORIGIN) return false;
+
+  const appOrigin = win?.location?.origin;
+
+  // The app talking to itself: the in-popup callback page on our own origin.
+  if (appOrigin && eventOrigin === appOrigin) return true;
+
+  // The AGNT API, whose callback page forwards the raw code in the Electron
+  // path. Compared as a parsed origin so a trailing path in the configured
+  // URL cannot cause a miss.
+  const remoteOrigin = originOf(remoteUrl);
+  if (remoteOrigin && eventOrigin === remoteOrigin) return true;
+
+  // Any loopback port, but only while we are ourselves on loopback.
+  if (appOrigin && isLoopbackOrigin(appOrigin) && isLoopbackOrigin(eventOrigin)) return true;
+
+  return false;
+}

--- a/frontend/src/utils/oauthMessageOrigin.spec.js
+++ b/frontend/src/utils/oauthMessageOrigin.spec.js
@@ -24,7 +24,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isTrustedOAuthMessageOrigin } from './oauthMessageOrigin.js';
+import { isTrustedOAuthMessageOrigin, hasOAuthMessagePayload } from './oauthMessageOrigin.js';
 
 const REMOTE = 'https://api.agnt.gg';
 const hostedApp = { location: { origin: 'https://tenant.example.com' } };
@@ -126,6 +126,7 @@ describe('isTrustedOAuthMessageOrigin', () => {
   });
 
   describe('it does not fall over on a broken environment', () => {
+
     it('survives a window with no location', () => {
       expect(isTrustedOAuthMessageOrigin('https://api.agnt.gg', {}, REMOTE)).toBe(true);
       expect(isTrustedOAuthMessageOrigin('https://evil.com', {}, REMOTE)).toBe(false);
@@ -148,5 +149,71 @@ describe('isTrustedOAuthMessageOrigin', () => {
     it('survives a malformed remote URL', () => {
       expect(isTrustedOAuthMessageOrigin('https://api.agnt.gg', hostedApp, 'not a url')).toBe(false);
     });
+  });
+});
+
+/**
+ * A TRUSTED ORIGIN IS NOT A WELL-FORMED MESSAGE.
+ *
+ * These are global `message` listeners. Passing the origin check only means the
+ * sender is us — it says nothing about what they sent, and same-origin senders
+ * that know nothing about OAuth (extensions, dev-server clients, other widgets)
+ * post whatever they like. `event.data.type` on a `null` payload throws.
+ *
+ * The throw is invisible in practice, which is why it survived: the handlers
+ * are `async`, so it never reaches the dispatcher. It becomes an unhandled
+ * rejection instead, and a test written as `expect(...).not.toThrow()` would
+ * pass whether or not the guard exists. The integration test in
+ * useProviderConnection.spec.js captures the rejection explicitly for that
+ * reason.
+ */
+describe('hasOAuthMessagePayload', () => {
+  describe('payloads that can carry a `type`', () => {
+    it.each([
+      ['an OAuth message', { type: 'oauth-callback', code: 'x' }],
+      ['an unrelated object', { hello: 'world' }],
+      ['an empty object', {}],
+      // An array cannot match any branch, but it is object-shaped and reading
+      // `.type` off it is safe, so there is no reason to single it out.
+      ['an array', []],
+    ])('accepts %s', (_label, data) => {
+      expect(hasOAuthMessagePayload({ data })).toBe(true);
+    });
+  });
+
+  describe('payloads that would throw or cannot match', () => {
+    it.each([
+      ['null, the shape Copilot flagged', null],
+      ['undefined', undefined],
+    ])('refuses %s, which would throw on .type', (_label, data) => {
+      expect(hasOAuthMessagePayload({ data })).toBe(false);
+    });
+
+    it.each([
+      ['a string, as some dev-server clients post', 'vite:beforeUpdate'],
+      ['a number', 42],
+      ['a boolean', true],
+    ])('refuses %s, which cannot match any branch', (_label, data) => {
+      // These do not throw — primitives box, so `.type` is merely undefined.
+      // They are refused anyway so that one predicate decides what is
+      // actionable, rather than each `.type` read having to be defensive.
+      expect(hasOAuthMessagePayload({ data })).toBe(false);
+    });
+
+    it('refuses an event with no data property at all', () => {
+      expect(hasOAuthMessagePayload({})).toBe(false);
+    });
+
+    it('refuses a missing event, rather than throwing on it', () => {
+      expect(hasOAuthMessagePayload(undefined)).toBe(false);
+      expect(hasOAuthMessagePayload(null)).toBe(false);
+    });
+  });
+
+  it('does not mistake null for an object', () => {
+    // `typeof null === 'object'`, so a check written as `typeof data ===
+    // 'object'` alone would admit exactly the value that throws.
+    expect(typeof null).toBe('object');
+    expect(hasOAuthMessagePayload({ data: null })).toBe(false);
   });
 });

--- a/frontend/src/utils/oauthMessageOrigin.spec.js
+++ b/frontend/src/utils/oauthMessageOrigin.spec.js
@@ -1,0 +1,152 @@
+/**
+ * WHO MAY REDEEM AN OAUTH CODE AGAINST THE SIGNED-IN USER'S ACCOUNT.
+ *
+ * The handlers behind this predicate POST a forwarded `code` to
+ * `/auth/callback` with the current user's bearer token. Admitting the wrong
+ * sender does not leak the victim's tokens — it grafts the ATTACKER'S account
+ * onto the victim's, so the victim's later "read my email" or "save to Drive"
+ * runs quietly operate on someone else's data.
+ *
+ * The guard this replaces was:
+ *
+ *   allowedOrigins.some((origin) =>
+ *     event.origin === origin || event.origin.includes('localhost'))
+ *
+ * The second term never uses the callback's own `origin` parameter, so it is a
+ * constant OR'd into every iteration — an unconditional substring test. The
+ * repository's existing coverage did not catch it, because the one negative
+ * test used `https://evil.example.com`, which contains no `localhost` and so
+ * was refused by the broken guard too. A negative test only means something
+ * when it exercises the shape that actually slips through.
+ *
+ * These tests are therefore written around the substring hole specifically,
+ * and around the loopback allowance that replaces it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isTrustedOAuthMessageOrigin } from './oauthMessageOrigin.js';
+
+const REMOTE = 'https://api.agnt.gg';
+const hostedApp = { location: { origin: 'https://tenant.example.com' } };
+const localApp = { location: { origin: 'http://localhost:3333' } };
+
+const trusts = (origin, win = hostedApp, remote = REMOTE) =>
+  isTrustedOAuthMessageOrigin(origin, win, remote);
+
+describe('isTrustedOAuthMessageOrigin', () => {
+  describe('the senders that must keep working', () => {
+    it('accepts the app talking to itself', () => {
+      expect(trusts('https://tenant.example.com')).toBe(true);
+    });
+
+    it('accepts the AGNT API, which forwards the code in the Electron path', () => {
+      expect(trusts('https://api.agnt.gg')).toBe(true);
+    });
+
+    it('accepts a remote configured with a path, comparing parsed origins', () => {
+      // user.config.js ships `REMOTE_URL` with an /api suffix in some setups;
+      // a naive string compare against the raw value would never match.
+      expect(trusts('https://api.agnt.gg', hostedApp, 'https://api.agnt.gg/api')).toBe(true);
+    });
+
+    it.each([
+      ['a different loopback port', 'http://localhost:5173'],
+      ['the dotted-quad form', 'http://127.0.0.1:5173'],
+      ['the IPv6 literal', 'http://[::1]:5173'],
+    ])('accepts %s while the app is itself on loopback', (_label, origin) => {
+      // Running from source puts Vite and the backend on different ports, so
+      // an exact-origin allowlist alone would break OAuth for developers.
+      expect(trusts(origin, localApp)).toBe(true);
+    });
+  });
+
+  /**
+   * Every one of these is registrable by anyone, and every one was admitted by
+   * the guard this replaces. They are the reason the check is not a substring.
+   */
+  describe('the origins the substring rule let through', () => {
+    it.each([
+      'https://localhost.evil.com',
+      'https://evil-localhost.io',
+      'http://localhostage.com',
+      'https://notlocalhost.xyz',
+      'http://localhost.attacker.co.uk',
+      'https://xn--localhost-fake.com',
+    ])('refuses %s', (origin) => {
+      expect(trusts(origin)).toBe(false);
+      // ...and refuses it just the same from a developer's own machine, where
+      // the loopback allowance is switched on.
+      expect(trusts(origin, localApp)).toBe(false);
+    });
+  });
+
+  describe('the loopback allowance does not escape development', () => {
+    it('refuses a loopback sender when the app is hosted', () => {
+      // THE LOAD-BEARING TEST. A developer convenience must not become a
+      // production trust rule: a hosted tenant has no reason to believe
+      // anything served from the visitor's own machine.
+      expect(trusts('http://localhost:5173', hostedApp)).toBe(false);
+    });
+
+    it('still accepts the hosted app talking to itself', () => {
+      expect(trusts('https://tenant.example.com', hostedApp)).toBe(true);
+    });
+  });
+
+  describe('near-misses on the allowlisted origins', () => {
+    it.each([
+      ['a suffix of the API host', 'https://api.agnt.gg.evil.com'],
+      ['a prefix of the API host', 'https://evil.com/api.agnt.gg'],
+      ['the API host over plain http', 'http://api.agnt.gg'],
+      ['a subdomain of the API host', 'https://evil.api.agnt.gg'],
+      ['a lookalike of the app host', 'https://tenant.example.com.evil.net'],
+    ])('refuses %s', (_label, origin) => {
+      expect(trusts(origin)).toBe(false);
+    });
+  });
+
+  describe('an origin that identifies nobody is refused, never abstained on', () => {
+    // Unlike the popup handover in utils/googleAuthPopup.js, there is no second
+    // signal here to fall back on, so there is nothing to trade off: an
+    // unattributable sender is simply not trusted.
+    it.each([
+      ['the empty string', ''],
+      ['the opaque origin', 'null'],
+      ['a sandboxed frame reporting undefined', undefined],
+      ['a non-string', 12345],
+      ['an object', {}],
+    ])('refuses %s', (_label, origin) => {
+      expect(trusts(origin)).toBe(false);
+    });
+
+    it('refuses the opaque origin even if the app is itself opaque', () => {
+      // Otherwise a sandboxed artifact iframe would match the app by equality.
+      expect(trusts('null', { location: { origin: 'null' } })).toBe(false);
+    });
+  });
+
+  describe('it does not fall over on a broken environment', () => {
+    it('survives a window with no location', () => {
+      expect(isTrustedOAuthMessageOrigin('https://api.agnt.gg', {}, REMOTE)).toBe(true);
+      expect(isTrustedOAuthMessageOrigin('https://evil.com', {}, REMOTE)).toBe(false);
+    });
+
+    it('falls back to the configured remote when the argument is omitted', () => {
+      // A default parameter fires on `undefined`, so omitting the argument and
+      // passing `undefined` are the same thing: both use API_CONFIG.REMOTE_URL.
+      // `null` is therefore the only way to say "no remote at all", and the
+      // test below relies on that distinction.
+      expect(isTrustedOAuthMessageOrigin('https://api.agnt.gg', hostedApp)).toBe(true);
+      expect(isTrustedOAuthMessageOrigin('https://api.agnt.gg', hostedApp, undefined)).toBe(true);
+    });
+
+    it('survives an unset remote URL', () => {
+      expect(isTrustedOAuthMessageOrigin('https://tenant.example.com', hostedApp, null)).toBe(true);
+      expect(isTrustedOAuthMessageOrigin('https://api.agnt.gg', hostedApp, null)).toBe(false);
+    });
+
+    it('survives a malformed remote URL', () => {
+      expect(isTrustedOAuthMessageOrigin('https://api.agnt.gg', hostedApp, 'not a url')).toBe(false);
+    });
+  });
+});

--- a/frontend/src/views/Terminal/CenterPanel/screens/Connectors/Connectors.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Connectors/Connectors.vue
@@ -836,6 +836,7 @@
 import { ref, computed, nextTick, onMounted, onUnmounted } from 'vue';
 import { useStore } from 'vuex';
 import { useRoute, useRouter } from 'vue-router';
+import { isTrustedOAuthMessageOrigin } from '@/utils/oauthMessageOrigin.js';
 import BaseScreen from '../../BaseScreen.vue';
 import BaseTable from '../../../_components/BaseTable.vue';
 import BaseForm from '../../../_components/BaseForm.vue';
@@ -2124,6 +2125,11 @@ export default {
     }
 
     async function handleOAuthMessage(event) {
+      // This handler redeems an OAuth code against the signed-in user's account
+      // and had no origin check at all, so any page that could reach this
+      // window could have one redeemed. See utils/oauthMessageOrigin.js.
+      if (!isTrustedOAuthMessageOrigin(event.origin)) return;
+
       // Handle legacy oauth-success message
       if (event.data && event.data.type === 'oauth-success') {
         store.dispatch('appAuth/fetchConnectedApps', { forceRefresh: true });

--- a/frontend/src/views/Terminal/CenterPanel/screens/Connectors/Connectors.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Connectors/Connectors.vue
@@ -836,7 +836,10 @@
 import { ref, computed, nextTick, onMounted, onUnmounted } from 'vue';
 import { useStore } from 'vuex';
 import { useRoute, useRouter } from 'vue-router';
-import { isTrustedOAuthMessageOrigin } from '@/utils/oauthMessageOrigin.js';
+import {
+  isTrustedOAuthMessageOrigin,
+  hasOAuthMessagePayload,
+} from '@/utils/oauthMessageOrigin.js';
 import BaseScreen from '../../BaseScreen.vue';
 import BaseTable from '../../../_components/BaseTable.vue';
 import BaseForm from '../../../_components/BaseForm.vue';
@@ -2130,15 +2133,21 @@ export default {
       // window could have one redeemed. See utils/oauthMessageOrigin.js.
       if (!isTrustedOAuthMessageOrigin(event.origin)) return;
 
+      // This handler already tested `event.data` at each branch. That is the
+      // same rule the other two now apply, so it is stated once here rather
+      // than repeated per branch — the duplication is what let the three
+      // handlers drift apart in the first place.
+      if (!hasOAuthMessagePayload(event)) return;
+
       // Handle legacy oauth-success message
-      if (event.data && event.data.type === 'oauth-success') {
+      if (event.data.type === 'oauth-success') {
         store.dispatch('appAuth/fetchConnectedApps', { forceRefresh: true });
         showAlert('Success', 'OAuth connection successful!');
       }
       // Electron path: api.agnt.gg's callback page postMessages the raw `code`
       // back here; the opener has to POST it to /auth/callback to mint tokens.
       // (Browser/dev mode does the exchange in-popup via OAuthCallback.vue.)
-      else if (event.data && event.data.type === 'oauth-callback') {
+      else if (event.data.type === 'oauth-callback') {
         const { code, state, provider } = event.data;
         try {
           const result = await providerAuthService.completeRemoteOAuthCallback({ code, state });

--- a/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue
@@ -149,20 +149,46 @@ export default {
         `width=${width},height=${height},top=${top},left=${left}`,
       );
 
+      // The popup sends this from utils/googleAuthPopup.js, before it boots
+      // anything, and then closes itself.
+      //
+      // Until that existed nothing sent it at all: the remote redirects the
+      // POPUP to `<origin>/settings?token=...`, so the popup loaded a second
+      // copy of AGNT and signed itself in, and this window — the one the user
+      // was actually looking at — sat here waiting for a message that was
+      // never coming.
+      const stopListening = () => {
+        window.removeEventListener('message', handleMessage);
+        clearInterval(closedPoll);
+      };
+
       const handleMessage = async (event) => {
+        // Only our own popup may complete a sign-in. It posts with an explicit
+        // targetOrigin, so a genuine cross-origin sender is never legitimate
+        // here. Electron's opener proxy can report an empty origin for a window
+        // that is same-origin by construction, so that one case is tolerated.
+        if (event.origin && event.origin !== window.location.origin) return;
+
         if (event.data?.type === 'google-auth-success') {
           const { token } = event.data;
 
-          window.removeEventListener('message', handleMessage);
+          stopListening();
 
           if (token) {
             await signIn(token);
           }
         } else if (event.data?.type === 'google-auth-error') {
-          window.removeEventListener('message', handleMessage);
+          stopListening();
           errorMessage.value = event.data.error || 'Login failed';
         }
       };
+
+      // A user who closes the popup without finishing used to leave this
+      // listener installed for the life of the page — one more of them on every
+      // click of the button, each one holding this component's scope alive.
+      const closedPoll = setInterval(() => {
+        if (!popup || popup.closed) stopListening();
+      }, 500);
 
       window.addEventListener('message', handleMessage);
     };

--- a/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue
@@ -107,7 +107,8 @@ import { useRouter } from 'vue-router';
 import SvgIcon from '@/views/_components/common/SvgIcon.vue';
 import TermsPrivacyModal from '@/components/TermsPrivacyModal.vue';
 import { API_CONFIG } from '@/tt.config.js';
-import { consumeAdoptedToken } from '@/store/auth/urlSessionToken.js';
+import { consumeAdoptedToken, looksLikeJwt } from '@/store/auth/urlSessionToken.js';
+import { isTrustedAuthMessage } from '@/utils/googleAuthPopup.js';
 
 export default {
   name: 'AuthSection',
@@ -163,20 +164,27 @@ export default {
       };
 
       const handleMessage = async (event) => {
-        // Only our own popup may complete a sign-in. It posts with an explicit
-        // targetOrigin, so a genuine cross-origin sender is never legitimate
-        // here. Electron's opener proxy can report an empty origin for a window
-        // that is same-origin by construction, so that one case is tolerated.
-        if (event.origin && event.origin !== window.location.origin) return;
+        // Only the popup we just opened may complete a sign-in. An origin check
+        // alone is not enough here: artifact and widget iframes are
+        // `allow-scripts allow-same-origin`, so authored HTML runs at this
+        // origin and could otherwise post a token of its own choosing. See
+        // utils/googleAuthPopup.js.
+        if (!isTrustedAuthMessage(event, popup)) return;
 
         if (event.data?.type === 'google-auth-success') {
           const { token } = event.data;
 
           stopListening();
 
-          if (token) {
-            await signIn(token);
+          // The same structural rule the address-bar handover applies. A token
+          // that cannot be one must not reach SET_TOKEN, where it would evict
+          // a session that is currently working.
+          if (!looksLikeJwt(token)) {
+            errorMessage.value = 'Login failed';
+            return;
           }
+
+          await signIn(token);
         } else if (event.data?.type === 'google-auth-error') {
           stopListening();
           errorMessage.value = event.data.error || 'Login failed';

--- a/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/LoginSection/LoginSection.vue
@@ -108,7 +108,13 @@ import SvgIcon from '@/views/_components/common/SvgIcon.vue';
 import TermsPrivacyModal from '@/components/TermsPrivacyModal.vue';
 import { API_CONFIG } from '@/tt.config.js';
 import { consumeAdoptedToken, looksLikeJwt } from '@/store/auth/urlSessionToken.js';
-import { isTrustedAuthMessage } from '@/utils/googleAuthPopup.js';
+import {
+  isTrustedAuthMessage,
+  markGoogleAuthPopupOpen,
+  clearGoogleAuthPopupMark,
+  GOOGLE_AUTH_CHANNEL,
+  GOOGLE_AUTH_SUCCESS,
+} from '@/utils/googleAuthPopup.js';
 
 export default {
   name: 'AuthSection',
@@ -144,6 +150,12 @@ export default {
       const left = window.screen.width / 2 - width / 2;
       const top = window.screen.height / 2 - height / 2;
 
+      // Before opening, not after: the popup may come back with its opener
+      // severed by COOP, and this mark is the only thing that then lets it tell
+      // itself apart from an ordinary redirect into the user's own tab. See
+      // utils/googleAuthPopup.js.
+      markGoogleAuthPopupOpen();
+
       const popup = window.open(
         `${API_CONFIG.REMOTE_URL}/users/auth/google?redirectUrl=${encodeURIComponent(redirectUrl)}`,
         'google-login-popup',
@@ -161,6 +173,41 @@ export default {
       const stopListening = () => {
         window.removeEventListener('message', handleMessage);
         clearInterval(closedPoll);
+        try {
+          channel?.close();
+        } catch {
+          /* already closed */
+        }
+        clearGoogleAuthPopupMark();
+      };
+
+      // The popup reaches us by whichever route survives — the opener if COOP
+      // has not severed it, the same-origin channel otherwise. Both land here,
+      // and `settled` is what stops a token that arrives twice from signing in
+      // twice, or from racing a teardown already in progress.
+      let settled = false;
+
+      const completeSignIn = async (token) => {
+        if (settled) return;
+        settled = true;
+        stopListening();
+
+        // The same structural rule the address-bar handover applies. A token
+        // that cannot be one must not reach SET_TOKEN, where it would evict
+        // a session that is currently working.
+        if (!looksLikeJwt(token)) {
+          errorMessage.value = 'Login failed';
+          return;
+        }
+
+        await signIn(token);
+      };
+
+      const failSignIn = (message) => {
+        if (settled) return;
+        settled = true;
+        stopListening();
+        errorMessage.value = message || 'Login failed';
       };
 
       const handleMessage = async (event) => {
@@ -171,25 +218,35 @@ export default {
         // utils/googleAuthPopup.js.
         if (!isTrustedAuthMessage(event, popup)) return;
 
-        if (event.data?.type === 'google-auth-success') {
-          const { token } = event.data;
-
-          stopListening();
-
-          // The same structural rule the address-bar handover applies. A token
-          // that cannot be one must not reach SET_TOKEN, where it would evict
-          // a session that is currently working.
-          if (!looksLikeJwt(token)) {
-            errorMessage.value = 'Login failed';
-            return;
-          }
-
-          await signIn(token);
+        if (event.data?.type === GOOGLE_AUTH_SUCCESS) {
+          await completeSignIn(event.data.token);
         } else if (event.data?.type === 'google-auth-error') {
-          stopListening();
-          errorMessage.value = event.data.error || 'Login failed';
+          failSignIn(event.data.error);
         }
       };
+
+      // The fallback route. A BroadcastChannel carries no sender identity, so
+      // unlike the message listener above there is nothing here to check it
+      // against — it is same-origin by construction, and that is the whole
+      // boundary. Worth being plain about the trade-off: a hostile same-origin
+      // script could broadcast a token of its own. It could also simply write
+      // one to localStorage, which is where this app keeps the session, so the
+      // channel grants it nothing it did not already have. The shape check in
+      // completeSignIn still applies.
+      let channel = null;
+      try {
+        channel =
+          typeof BroadcastChannel === 'function' ? new BroadcastChannel(GOOGLE_AUTH_CHANNEL) : null;
+      } catch {
+        channel = null; // unavailable in this environment; the opener route stands alone
+      }
+      if (channel) {
+        channel.onmessage = async (event) => {
+          if (event.data?.type === GOOGLE_AUTH_SUCCESS) {
+            await completeSignIn(event.data.token);
+          }
+        };
+      }
 
       // A user who closes the popup without finishing used to leave this
       // listener installed for the life of the page — one more of them on every

--- a/frontend/src/views/Terminal/RightPanel/types/ChatPanel/components/IntegrationHealth.vue
+++ b/frontend/src/views/Terminal/RightPanel/types/ChatPanel/components/IntegrationHealth.vue
@@ -54,6 +54,7 @@ import Tooltip from '@/views/Terminal/_components/Tooltip.vue';
 import { API_CONFIG } from '@/tt.config.js';
 import { PROVIDER_DISPLAY_NAMES } from '@/store/app/aiProvider.js';
 import { encrypt } from '@/views/_utils/encryption.js';
+import { isTrustedOAuthMessageOrigin } from '@/utils/oauthMessageOrigin.js';
 import providerAuthService from '@/services/providerAuthService.js';
 
 export default {
@@ -864,9 +865,11 @@ export default {
 
     // Handle OAuth completion messages from popup
     const handleOAuthMessage = async (event) => {
-      // Verify origin for security (allow same origin and api.agnt.gg for postMessage)
-      const allowedOrigins = [window.location.origin, 'https://api.agnt.gg'];
-      if (!allowedOrigins.some((origin) => event.origin === origin || event.origin.includes('localhost'))) return;
+      // This handler redeems an OAuth code against the signed-in user's account,
+      // so the origin check is the trust boundary. It used to OR in a bare
+      // `event.origin.includes('localhost')`, which admitted any registrable
+      // domain containing that substring. See utils/oauthMessageOrigin.js.
+      if (!isTrustedOAuthMessageOrigin(event.origin)) return;
 
       if (event.data.type === 'oauth_success') {
         // Refresh health immediately

--- a/frontend/src/views/Terminal/RightPanel/types/ChatPanel/components/IntegrationHealth.vue
+++ b/frontend/src/views/Terminal/RightPanel/types/ChatPanel/components/IntegrationHealth.vue
@@ -54,7 +54,10 @@ import Tooltip from '@/views/Terminal/_components/Tooltip.vue';
 import { API_CONFIG } from '@/tt.config.js';
 import { PROVIDER_DISPLAY_NAMES } from '@/store/app/aiProvider.js';
 import { encrypt } from '@/views/_utils/encryption.js';
-import { isTrustedOAuthMessageOrigin } from '@/utils/oauthMessageOrigin.js';
+import {
+  isTrustedOAuthMessageOrigin,
+  hasOAuthMessagePayload,
+} from '@/utils/oauthMessageOrigin.js';
 import providerAuthService from '@/services/providerAuthService.js';
 
 export default {
@@ -870,6 +873,12 @@ export default {
       // `event.origin.includes('localhost')`, which admitted any registrable
       // domain containing that substring. See utils/oauthMessageOrigin.js.
       if (!isTrustedOAuthMessageOrigin(event.origin)) return;
+
+      // A trusted origin is not a well-formed message. This is a global
+      // listener, so a same-origin extension or dev-server client posting
+      // `null` would otherwise throw on `event.data.type` — as an unhandled
+      // rejection, since this handler is async.
+      if (!hasOAuthMessagePayload(event)) return;
 
       if (event.data.type === 'oauth_success') {
         // Refresh health immediately


### PR DESCRIPTION
> **Draft: stacked on #78 and #79.** The contract asserts that every message receiver calls an approved trust predicate, and two of those predicates are introduced by those PRs — neither is on `main` yet, so this can only run green on top of both. The diff below therefore includes their commits. Once they land, a rebase drops them and this reduces to **one new file, 698 lines**. Please merge those two first.

Three defects in this codebase came from getting one sequence wrong inside a `message` receiver, and each was found only after shipping:

1. **No trust check at all.** `Connectors.vue` redeemed an OAuth authorization code — with the signed-in user's bearer token — from any sender whatsoever.
2. **A trust check that did not work.** Two handlers shared `allowedOrigins.some((origin) => event.origin === origin || event.origin.includes('localhost'))`, whose second term never references the callback's own parameter. That makes it an unconditional substring test, admitting `localhost.evil.com` and anything like it.
3. **Trust without shape.** Handlers that had cleared the origin then read `event.data.type` directly, so a trusted-origin sender posting `null` threw a `TypeError`. The handlers are `async`, so it surfaced as an unhandled rejection: nothing crashed, nothing was logged anywhere anyone looks, and the handler silently did not run.

Every one of those is an **ordering or presence property of a handler body**. None is visible in review, none turns a test red on its own, and two shipped for months. That is the shape of defect a mechanical check earns its keep against.

## Two kinds of receiver, and why the difference decides the rule

Discovery matches both shapes a receiver can take, and they are not treated alike:

| | | Trust rule |
| --- | --- | --- |
| **GLOBAL** | `window.addEventListener('message', h)`<br>`window.onmessage = h` | Anyone who can reach the window can post, so the handler body is the entire boundary → **must check** |
| **HANDLE** | `someChannel.onmessage = h` | A sender must already hold the object; possession is the boundary, settled at construction → **exempt** |

A handle receiver has no `event.origin` to compare and no `event.source` to identify, so demanding a check would be demanding one it cannot perform. The exemption is **derived from the syntax, never granted by name** — and note the second line above: `window.onmessage = h` is classified *global* precisely so a receiver cannot buy the exemption by changing shape.

Shape discipline applies to both. A malformed payload throws the same way whichever door it came through.

**This gap was real, not hypothetical.** #78 gained a BroadcastChannel fallback partway through review, and with it a `channel.onmessage =` receiver. The contract discovered only `addEventListener`, so that receiver sat in the tree unaudited while this suite stayed green — the precise drift this file exists to prevent, happening underneath it.

## The rule is trust → shape → read, not origin → shape → read

Two of the six global receivers never look at `event.origin`, and are right not to. They compare the **sender** instead:

```js
widgetSdk.js    widgetWindows.has(event.source)                    // a WeakSet allowlist
Artifacts.vue   event.source !== previewFrame.value.contentWindow  // reference identity
```

Identity is strictly stronger than origin. Same-origin does not mean *"the window I opened"* — which is precisely the hole Copilot found in the Google sign-in handler, since this app renders authored HTML in `allow-scripts allow-same-origin` iframes. Demanding a redundant origin comparison there would be cargo-cult, so **either mechanism satisfies the contract**.

Which receivers are origin-gated is **derived from the code, never listed**. Convert an identity-gated one to origin-gating and the ordering rule starts applying to it automatically, with nobody having to remember this file exists.

## A handle receiver is not left unguarded either

Its boundary is *which object it was handed*, and for a `BroadcastChannel` that is decided entirely by the name. Two sides typing the same string is the same copy-paste failure the shared origin predicates exist to prevent — except this one **fails silently**: a mismatched name is not an error, it is a channel nobody ever posts to.

So it gets the handle equivalent of *"leave origin comparison to the shared predicates"* — leave the channel name to the shared constant. Any `new BroadcastChannel('literal')` fails the suite.

## What it deliberately does not check

That a trust check is **correct**. A predicate can be present and still be wrong — defect 2 above was exactly that. Correctness is pinned by each predicate's own unit tests; this pins that one is *called*, and called *first*. The two jobs are complementary and neither substitutes for the other.

## Scope

**Seven receivers** are covered: six global and one handle. Two other `addEventListener('message')` registrations are deliberately not matched — `dc.addEventListener` in `useRealtimeVoice.js` is a negotiated WebRTC peer, and `eventSource.addEventListener` in `appAuth.js` is a same-origin SSE stream. Neither is third-party spoofable and neither carries an `event.origin`.

The widget-side listener at `widgetSdk.js:161` is excluded because it lives inside a template literal, is injected into a widget iframe's `srcdoc`, and runs over there rather than in this application. That exclusion works by **blanking template-literal contents, not by naming the file**, so it cannot rot — lift that code into the host and it comes back under every rule. It would pass anyway: it opens with `if (event.source !== parent) return;`. Three tests pin this.

## Validation

Rather than assert the contract works, I ran it against the real states of the tree:

| Tree state | Result |
| --- | --- |
| `main` today (neither PR) | 3 rules fail, naming **all four** unguarded handlers — and distinguishing which had *no approved check* from which *compared the origin by hand* |
| #78 only | names exactly the **three OAuth** handlers |
| #79 only | names exactly the **sign-in** handler |
| both (this branch) | **26 tests green** |

That is an independent rediscovery of the same defect distribution the manual audit found.

Mutation tested, each hitting only what it should:

| Mutation | Fails |
| --- | --- |
| comment stripper → identity | 2 — its self-test *and* the anti-vacuity discovery test |
| template blanker → identity | 2 — the widget exclusion *and* the index-preservation self-test |
| `.onmessage` discovery matches nothing | 2 — receivers drop 7 → 6, and the both-kinds test names the gap |
| channel misclassified as global | 3 — **including the trust rule firing on it**, proving the exemption is load-bearing rather than decorative |
| channel name inlined as a literal | 1 — the shared-constant rule, alone |

The first two mutations target the contract's **own machinery**: a normaliser that eats real code would turn every assertion into a false pass.

There is also an explicit anti-vacuity test — discovery must find ≥ 7 receivers, of both kinds, and name the expected files. Renaming `addEventListener` or breaking the body extractor therefore cannot empty the set and let everything pass silently.

Nothing in the tree currently writes `window.onmessage =`, so the global/handle classification would otherwise never be exercised by real code. It is covered directly, in the same spirit as the normaliser self-tests, rather than waiting for someone to write that line.

Full frontend suite on this branch: **4153 tests green**.
