### PR TITLE
fix(auth): find the Claude Code login the CLI moved to the keychain

### DIFF
--- a/backend/src/services/auth/ClaudeCodeAuthManager.js
+++ b/backend/src/services/auth/ClaudeCodeAuthManager.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import crypto from 'crypto';
+import { spawnSync } from 'child_process';
 import axios from 'axios';
 import generateUUID from '../../utils/generateUUID.js';
 import { getClientIdentity } from '../ai/clientVersions.js';
@@ -23,6 +24,83 @@ function resolveClaudeCredentialsPath() {
   return path.join(os.homedir(), '.claude', '.credentials.json');
 }
 
+// ── Keychain fallback ────────────────────────────────────────────
+//
+// Claude Code 2.1.231+ keeps its session in the macOS Keychain instead of
+// ~/.claude/.credentials.json. On those versions a perfectly good `claude auth
+// login` is invisible here: the file never appears, getAccessToken() returns
+// null, and the provider reports disconnected while the CLI reports logged in.
+//
+// So the file stays authoritative and the Keychain is consulted only when the
+// file yields nothing. The read is best-effort by design — every failure path
+// returns null, which is byte-for-byte the behaviour this function had before
+// the fallback existed. It can therefore make a working install no worse.
+const KEYCHAIN_SERVICE = 'Claude Code-credentials';
+
+/**
+ * Written by logout() to record that the user disconnected on purpose.
+ *
+ * Without it, disconnecting would be a no-op on a keychain-backed CLI: logout
+ * removes the file, the next read finds no file, the keychain fallback answers
+ * with the very session that was just disconnected, and the provider pops back
+ * to connected. The marker keeps the file readable, so the fallback never runs
+ * and "disconnected" stays a state the user can actually reach.
+ */
+const DISCONNECTED_MARKER = 'agntClaudeCodeDisconnected';
+
+// A local `security` call answers in single-digit milliseconds. The timeout is
+// here so that a wedged keychain daemon degrades to "disconnected" instead of
+// hanging every request that needs a token.
+const KEYCHAIN_TIMEOUT_MS = 2000;
+
+/**
+ * The Keychain lives on macOS. CLAUDE_CODE_SECURITY_BIN forces the lookup on
+ * regardless of platform, which is what makes this testable on a Linux runner;
+ * CLAUDE_CODE_DISABLE_KEYCHAIN=1 turns it off for anyone who would rather AGNT
+ * never shell out to `security`.
+ */
+function keychainLookupEnabled() {
+  if (process.env.CLAUDE_CODE_DISABLE_KEYCHAIN === '1') return false;
+  if (process.env.CLAUDE_CODE_SECURITY_BIN) return true;
+  return process.platform === 'darwin';
+}
+
+/**
+ * Reads the Claude Code session out of the OS keychain.
+ * @returns {{ claudeAiOauth: object } | null} null on any failure.
+ */
+function readClaudeKeychainCredentials() {
+  if (!keychainLookupEnabled()) return null;
+
+  try {
+    const bin = process.env.CLAUDE_CODE_SECURITY_BIN || '/usr/bin/security';
+    const service = process.env.CLAUDE_CODE_KEYCHAIN_SERVICE || KEYCHAIN_SERVICE;
+
+    const result = spawnSync(bin, ['find-generic-password', '-s', service, '-w'], {
+      encoding: 'utf8',
+      timeout: KEYCHAIN_TIMEOUT_MS,
+      // stderr is discarded on purpose: "could not be found in the keychain" is
+      // the ordinary answer for a user who has not logged in, not an incident.
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+
+    if (result.status !== 0 || !result.stdout) return null;
+
+    const parsed = JSON.parse(result.stdout.trim());
+    const oauth = parsed?.claudeAiOauth;
+    if (!oauth || typeof oauth !== 'object') return null;
+    if (!oauth.accessToken) return null;
+
+    // Only the OAuth block is adopted. The keychain item also carries an
+    // `apiKey` field, and silently promoting that to AGNT's Claude Code
+    // credential would swap a subscription login for a billed console key
+    // without the user ever asking for it.
+    return { claudeAiOauth: oauth };
+  } catch {
+    return null;
+  }
+}
+
 function readClaudeCredentialsFile() {
   const credPath = resolveClaudeCredentialsPath();
   try {
@@ -30,7 +108,8 @@ function readClaudeCredentialsFile() {
     const parsed = JSON.parse(raw);
     return { credPath, data: parsed };
   } catch {
-    return { credPath, data: null };
+    // No readable file. A newer CLI may still hold the session in the keychain.
+    return { credPath, data: readClaudeKeychainCredentials() };
   }
 }
 
@@ -50,6 +129,9 @@ function writeClaudeCredentials(oauthData) {
   } catch {
     // File doesn't exist yet
   }
+
+  // Connecting clears any previous disconnect marker (see logout()).
+  delete existing[DISCONNECTED_MARKER];
 
   existing.claudeAiOauth = oauthData;
   fs.writeFileSync(credPath, JSON.stringify(existing, null, 2), 'utf8');
@@ -537,14 +619,24 @@ class ClaudeCodeAuthManager {
           delete data.oauth_token;
           delete data.token;
           delete data.access_token;
-          if (Object.keys(data).length === 0) {
-            fs.unlinkSync(credPath);
-          } else {
-            fs.writeFileSync(credPath, JSON.stringify(data, null, 2), 'utf8');
-          }
+          data[DISCONNECTED_MARKER] = true;
+          fs.writeFileSync(credPath, JSON.stringify(data, null, 2), 'utf8');
         } else {
-          fs.unlinkSync(credPath);
+          fs.writeFileSync(
+            credPath,
+            JSON.stringify({ [DISCONNECTED_MARKER]: true }, null, 2),
+            'utf8',
+          );
         }
+      } else {
+        // Nothing on disk to strip, but a keychain session may still exist, so
+        // the marker has to be written for the disconnect to mean anything.
+        fs.mkdirSync(path.dirname(credPath), { recursive: true });
+        fs.writeFileSync(
+          credPath,
+          JSON.stringify({ [DISCONNECTED_MARKER]: true }, null, 2),
+          'utf8',
+        );
       }
       this.apiCheckCache = null;
       return { success: true };

--- a/backend/src/services/auth/ClaudeCodeAuthManager.keychain.test.js
+++ b/backend/src/services/auth/ClaudeCodeAuthManager.keychain.test.js
@@ -1,0 +1,185 @@
+/**
+ * ClaudeCodeAuthManager — keychain fallback.
+ *
+ * Claude Code 2.1.231+ stores its session in the macOS Keychain rather than
+ * ~/.claude/.credentials.json, so a successful `claude auth login` used to be
+ * invisible to AGNT and the provider reported disconnected.
+ *
+ * These tests never touch a real keychain. CLAUDE_CODE_SECURITY_BIN points the
+ * lookup at a stub that stands in for `security find-generic-password`, which
+ * is also what lets the suite run on the Linux CI runner.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const OAUTH = {
+  accessToken: 'sk-ant-oat-test-access',
+  refreshToken: 'sk-ant-ort-test-refresh',
+  expiresAt: Date.now() + 60 * 60 * 1000,
+  scopes: ['user:inference', 'user:profile'],
+  subscriptionType: 'max',
+};
+
+// `security` is a macOS binary; the stub is a POSIX shell script.
+describe.skipIf(process.platform === 'win32')('ClaudeCodeAuthManager keychain fallback', () => {
+  let tmpHome;
+  let credPath;
+  let stubBin;
+  let payloadPath;
+  const saved = {};
+
+  /** Point the lookup at a stub that prints `body` and exits with `code`. */
+  function stubKeychain(body, code = 0) {
+    fs.writeFileSync(payloadPath, body ?? '', 'utf8');
+    fs.writeFileSync(
+      stubBin,
+      `#!/bin/sh\nexit_code=${code}\nif [ "$exit_code" -ne 0 ]; then exit "$exit_code"; fi\ncat "${payloadPath}"\n`,
+      { mode: 0o755 },
+    );
+    process.env.CLAUDE_CODE_SECURITY_BIN = stubBin;
+  }
+
+  /** No keychain item at all — `security` exits non-zero. */
+  function stubKeychainMissing() {
+    stubKeychain('', 44);
+  }
+
+  async function loadManager() {
+    vi.resetModules();
+    const manager = (await import('./ClaudeCodeAuthManager.js')).default;
+    manager.apiCheckCache = null;
+    return manager;
+  }
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agnt-claude-keychain-'));
+    fs.mkdirSync(path.join(tmpHome, '.claude'), { recursive: true });
+    credPath = path.join(tmpHome, '.claude', '.credentials.json');
+    stubBin = path.join(tmpHome, 'security-stub.sh');
+    payloadPath = path.join(tmpHome, 'keychain-payload.json');
+
+    for (const key of ['HOME', 'USERPROFILE', 'CLAUDE_CODE_SECURITY_BIN',
+      'CLAUDE_CODE_KEYCHAIN_SERVICE', 'CLAUDE_CODE_DISABLE_KEYCHAIN']) {
+      saved[key] = process.env[key];
+    }
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    delete process.env.CLAUDE_CODE_DISABLE_KEYCHAIN;
+    delete process.env.CLAUDE_CODE_KEYCHAIN_SERVICE;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    try {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('reads the session from the keychain when no credentials file exists', async () => {
+    stubKeychain(JSON.stringify({ claudeAiOauth: OAUTH }));
+    const manager = await loadManager();
+
+    expect(fs.existsSync(credPath)).toBe(false);
+    expect(manager.getAccessTokenSync()).toBe(OAUTH.accessToken);
+  });
+
+  it('prefers the credentials file over the keychain', async () => {
+    fs.writeFileSync(
+      credPath,
+      JSON.stringify({ claudeAiOauth: { ...OAUTH, accessToken: 'sk-ant-oat-from-file' } }),
+      'utf8',
+    );
+    stubKeychain(JSON.stringify({ claudeAiOauth: OAUTH }));
+    const manager = await loadManager();
+
+    expect(manager.getAccessTokenSync()).toBe('sk-ant-oat-from-file');
+  });
+
+  it('returns null when neither the file nor the keychain has a session', async () => {
+    stubKeychainMissing();
+    const manager = await loadManager();
+
+    expect(manager.getAccessTokenSync()).toBeNull();
+  });
+
+  it('adopts only the OAuth block, never a console apiKey from the same item', async () => {
+    // The real keychain item carries an `apiKey` field alongside the OAuth
+    // block. Promoting it would silently swap a subscription login for a
+    // billed console key.
+    stubKeychain(JSON.stringify({ apiKey: 'sk-ant-api-should-be-ignored', provider: 'anthropic' }));
+    const manager = await loadManager();
+
+    expect(manager.getAccessTokenSync()).toBeNull();
+  });
+
+  it('ignores a keychain item whose OAuth block has no access token', async () => {
+    stubKeychain(JSON.stringify({ claudeAiOauth: { refreshToken: 'sk-ant-ort-only' } }));
+    const manager = await loadManager();
+
+    expect(manager.getAccessTokenSync()).toBeNull();
+  });
+
+  it('ignores unparseable keychain output instead of throwing', async () => {
+    stubKeychain('not json at all {{{');
+    const manager = await loadManager();
+
+    expect(() => manager.getAccessTokenSync()).not.toThrow();
+    expect(manager.getAccessTokenSync()).toBeNull();
+  });
+
+  it('skips the keychain entirely when CLAUDE_CODE_DISABLE_KEYCHAIN is set', async () => {
+    stubKeychain(JSON.stringify({ claudeAiOauth: OAUTH }));
+    process.env.CLAUDE_CODE_DISABLE_KEYCHAIN = '1';
+    const manager = await loadManager();
+
+    expect(manager.getAccessTokenSync()).toBeNull();
+  });
+
+  it('keeps a disconnect disconnected even though the keychain still has the session', async () => {
+    // The regression this guards: logout() used to delete the file, the
+    // fallback would then answer from the keychain, and the provider would pop
+    // straight back to connected — making disconnect unreachable.
+    fs.writeFileSync(credPath, JSON.stringify({ claudeAiOauth: OAUTH }), 'utf8');
+    stubKeychain(JSON.stringify({ claudeAiOauth: OAUTH }));
+    const manager = await loadManager();
+    expect(manager.getAccessTokenSync()).toBe(OAUTH.accessToken);
+
+    const result = await manager.logout();
+
+    expect(result.success).toBe(true);
+    expect(manager.getAccessTokenSync()).toBeNull();
+  });
+
+  it('records the disconnect even when no credentials file was on disk', async () => {
+    stubKeychain(JSON.stringify({ claudeAiOauth: OAUTH }));
+    const manager = await loadManager();
+    expect(manager.getAccessTokenSync()).toBe(OAUTH.accessToken);
+
+    await manager.logout();
+
+    expect(manager.getAccessTokenSync()).toBeNull();
+  });
+
+  it('lets a fresh login clear a previous disconnect', async () => {
+    stubKeychain(JSON.stringify({ claudeAiOauth: OAUTH }));
+    const manager = await loadManager();
+    await manager.logout();
+    expect(manager.getAccessTokenSync()).toBeNull();
+
+    // A reconnect writes through the same path the OAuth exchange uses.
+    fs.writeFileSync(
+      credPath,
+      JSON.stringify({ claudeAiOauth: { ...OAUTH, accessToken: 'sk-ant-oat-reconnected' } }),
+      'utf8',
+    );
+
+    expect(manager.getAccessTokenSync()).toBe('sk-ant-oat-reconnected');
+  });
+});


### PR DESCRIPTION
## What

`ClaudeCodeAuthManager` now falls back to the macOS Keychain when `~/.claude/.credentials.json` yields nothing, so a Claude Code login made by a current CLI is visible to AGNT again.

Two files, +284/-7, no new dependencies.

## Why

Claude Code **2.1.231** stores its session in the macOS Keychain — generic-password service `Claude Code-credentials` — instead of writing `~/.claude/.credentials.json`. `ClaudeCodeAuthManager` only ever reads that file (`resolveClaudeCredentialsPath()`, line 23).

The result on an affected machine is a provider that looks broken and cannot be fixed from the UI:

```
$ claude auth status
{ "loggedIn": true, "authMethod": "claude.ai", "subscriptionType": "max" }

$ ls ~/.claude/.credentials.json
No such file or directory

GET /api/providers/claude-code/auth/status
→ { "available": false, "apiUsable": false }
```

Re-running `claude auth login` does not help, because the new CLI writes to the Keychain every time. The only workaround is to hand-write the credentials file.

## How

`readClaudeCredentialsFile()` is the single read choke point for all five callers (`getAccessTokenSync`, `getAccessToken`, `checkApiUsable`, `refreshAccessToken`, `logout`), so the fallback lives there and nothing else needed rewiring:

```js
} catch {
  // No readable file. A newer CLI may still hold the session in the keychain.
  return { credPath, data: readClaudeKeychainCredentials() };
}
```

Deliberate constraints:

- **The file stays authoritative.** The Keychain is read only when the file yields nothing.
- **Cannot make a working install worse.** Every failure path returns `null` — byte-for-byte what this function already returned.
- **Bounded.** `spawnSync` with a 2s timeout, so a wedged keychain daemon degrades to "disconnected" instead of hanging every token read.
- **Read-only.** Never writes to the Keychain, never logs a token value.
- **Opt-out.** `CLAUDE_CODE_DISABLE_KEYCHAIN=1` for anyone who would rather AGNT not shell out to `security`.
- **Only the `claudeAiOauth` block is adopted.** The same keychain item also carries an `apiKey` field; promoting that would quietly swap a subscription login for a billed console key.

### The disconnect regression this had to avoid

`logout()` deleted the credentials file. On a keychain-backed CLI a naive fallback would then answer with the session that was just disconnected — the provider pops back to connected and **disconnect becomes unreachable**.

`logout()` now leaves a disconnect marker in the file instead. That keeps the file readable, which keeps the fallback out of it; connecting again clears the marker. There is a test that fails if this is reverted.

## Testing

New colocated suite `ClaudeCodeAuthManager.keychain.test.js` — 10 tests, vitest, no network and no real keychain. This manager previously had no test file at all.

Covered: keychain used when the file is absent; file preferred over keychain; both absent → `null`; `apiKey`-only item ignored; OAuth block without an access token ignored; unparseable output ignored; opt-out env honoured; disconnect survives a live keychain session; disconnect with no file on disk; reconnect clears the marker.

```
backend/src/services/auth/  →  14 files, 219 tests passed
full backend suite          →  308 files, 4896 tests passed
```

Both halves of the change were mutation-tested to confirm the tests can actually fail:

| Mutation | Result |
| --- | --- |
| fallback reverted to `data: null` | 2 tests fail |
| `logout()` reverted to `fs.unlinkSync` | the disconnect guard fails |

**Testing note worth knowing:** the tests drive a stub binary through `CLAUDE_CODE_SECURITY_BIN` rather than redirecting `HOME`. Redirecting `HOME` also relocates the login keychain (`$HOME/Library/Keychains`), so every lookup fails with "item not found" — an artifact that looks exactly like the bug. That override is also what lets this suite run on the Linux CI runner.

## Notes for reviewers

- **Prior art:** #22 proposed Keychain support and was closed. It was a 3,708-line, 23-file change that also added a new token-refresh framework, an encrypted-storage layer and a second test runner (Jest). This PR is deliberately the opposite: the smallest change that fixes the reported symptom, in the existing test runner, with no new abstractions. If #22 was closed on the *idea* rather than the scope, say so and I will close this too.
- **`AntigravityAuthManager` says the keychain cannot be read** (`AntigravityAuthManager.js:30`, `config/oauthClients.js:47`). On macOS that is not the case for an item whose ACL was created by the CLI under the same user: verified prompt-free reads from a `launchd` GUI-domain agent, the same context the AGNT backend runs in. This PR does not touch Antigravity.
- **Honest limit:** verified on one machine (macOS 26.6.2, Claude Code 2.1.231, brew cask). I cannot promise every Mac reads without a TCC prompt, which is exactly why the lookup is non-blocking, time-bounded and silent on failure — worst case is today's behaviour.
