### PR TITLE
chore(browser): update browser-use to 0.13.8

### DIFF
--- a/backend/src/tools/library/actions/ai-browser-use.js
+++ b/backend/src/tools/library/actions/ai-browser-use.js
@@ -31,7 +31,7 @@ import { RUNNER_PY, RUNNER_VERSION, RESULT_SENTINEL } from './browserUseRunner.j
  * Bumping this constant is the whole upgrade procedure: the version check below
  * reinstalls when the venv disagrees.
  */
-export const BROWSER_USE_VERSION = '0.13.7';
+export const BROWSER_USE_VERSION = '0.13.8';
 
 /**
  * Packages the runner needs that browser-use does not already pull in.


### PR DESCRIPTION
AGNT pins its Browser Use runtime for reproducible installs. This updates that pin from 0.13.7 to the current published release, 0.13.8, through AGNT's documented one-line upgrade path.

Checks:

- 75 focused Browser Use tests passed
- 5,119 full-suite tests passed; the two unrelated timing flakes passed on focused rerun (42/42)
- `normalize-eol` checked 2,546 attributed files with no rewrites
- `git diff --check` passed
- Fresh Python 3.13 install verified the runner imports, supported chat adapters, domain controls, runner compilation, and structured error output
