### PR TITLE
fix(providers): a display-name fallback tier must still fire

### DIFF
--- a/backend/src/services/orchestrator/ProviderFallback.capabilityGate.test.mjs
+++ b/backend/src/services/orchestrator/ProviderFallback.capabilityGate.test.mjs
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+
+/**
+ * `resolveProviderKey` gates its result on PROVIDER_CAPABILITIES membership
+ * rather than returning whatever `getProviderConfig` resolved.
+ *
+ * Today that gate is invisible: PROVIDER_CONFIGS and PROVIDER_CAPABILITIES hold
+ * exactly the same 20 keys, so anything the config table resolves is already in
+ * the capability table. Deleting the gate changes no observable behaviour and
+ * every other test still passes — which is precisely why it needs a test of its
+ * own rather than a claim in a comment.
+ *
+ * The gate exists for the day those two tables diverge. A provider present in
+ * the config table but absent from the capability table would otherwise be
+ * admitted to the chain and then die in the executor: a tier that is silently
+ * DEAD instead of silently DROPPED, which is worse, because the chain reports a
+ * depth it cannot actually deliver.
+ *
+ * This file mocks the config table to force that divergence. It lives apart
+ * from the main suite because the mock is module-wide.
+ */
+
+vi.mock('../ai/providerConfigs.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getProviderConfig: (key) => {
+      // A provider the CONFIG table knows about but the CAPABILITY table does
+      // not — the exact divergence the gate is there to catch.
+      if (String(key).toLowerCase() === 'ghost-provider') return { key: 'ghost-provider', name: 'Ghost' };
+      return actual.getProviderConfig(key);
+    },
+  };
+});
+
+const PF = (await import('./ProviderFallback.js')).default;
+const ProviderRegistry = await import('../ai/ProviderRegistry.js');
+
+describe('resolveProviderKey — capability gate', () => {
+  it('the premise holds: the mocked provider is in the config table only', async () => {
+    const { getProviderConfig } = await import('../ai/providerConfigs.js');
+    expect(getProviderConfig('ghost-provider')).toMatchObject({ key: 'ghost-provider' });
+    expect(Object.keys(ProviderRegistry.PROVIDER_CAPABILITIES)).not.toContain('ghost-provider');
+  });
+
+  it('refuses a provider the capability registry does not know', () => {
+    expect(PF.resolveProviderKey('ghost-provider')).toBeNull();
+    expect(PF.isKnownProvider('ghost-provider')).toBe(false);
+  });
+
+  it('drops such a tier from the chain rather than shipping a dead one', () => {
+    const chain = PF.buildProviderChain({
+      provider: 'anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: 'ghost-provider', model: 'x' }],
+    });
+
+    expect(chain).toHaveLength(1);
+  });
+
+  it('still resolves real providers through the same path', () => {
+    expect(PF.resolveProviderKey('Cursor')).toBe('cursor-cli');
+  });
+});
+
+describe('config and capability tables — divergence tripwire', () => {
+  it('currently hold identical key sets', async () => {
+    // Not a requirement, an observation — but if it ever stops being true the
+    // gate above changes from dead code to load-bearing, and whoever caused the
+    // divergence should find out from a test rather than from a dead tier.
+    const { getAllProviderKeys } = await vi.importActual('../ai/providerConfigs.js');
+    expect([...getAllProviderKeys()].sort()).toEqual(
+      [...Object.keys(ProviderRegistry.PROVIDER_CAPABILITIES)].sort()
+    );
+  });
+});

--- a/backend/src/services/orchestrator/ProviderFallback.displayNames.test.mjs
+++ b/backend/src/services/orchestrator/ProviderFallback.displayNames.test.mjs
@@ -1,0 +1,374 @@
+import { describe, it, expect } from 'vitest';
+import PF from './ProviderFallback.js';
+import * as ProviderRegistry from '../ai/ProviderRegistry.js';
+
+/**
+ * A fallback tier stored under a provider's DISPLAY NAME must still be built
+ * into the chain.
+ *
+ * The UI writes a tier as `{ provider: <displayName> }` (FallbackProviders.vue),
+ * but `isKnownProvider` matched raw PROVIDER_CAPABILITIES KEYS. For 18 of the 20
+ * built-ins the display name lowercases to exactly the key, so nothing looked
+ * wrong. For two it did not, and those tiers were silently dropped from every
+ * chain ever built:
+ *
+ *     "Cursor" -> cursor-cli        "Z.AI" -> zai
+ *
+ * Same failure signature as the custom-provider bug before it: the tier saves,
+ * renders as configured, and never fires.
+ *
+ * These tests run against the REAL registry rather than a stub, so they fail if
+ * the mapping breaks for any reason — including someone renaming a display name
+ * or dropping a provider from the capability table.
+ */
+
+const CUSTOM_ID = '052c419d-1beb-42c9-81b8-f287685af155';
+
+/** Every provider whose display name is NOT simply its key. */
+const DISPLAY_NAME_MISMATCHES = [
+  ['Cursor', 'cursor-cli'],
+  ['Z.AI', 'zai'],
+];
+
+describe('resolveProviderKey', () => {
+  it.each(DISPLAY_NAME_MISMATCHES)('resolves display name %s to its registry key %s', (display, key) => {
+    expect(PF.resolveProviderKey(display)).toBe(key);
+  });
+
+  it('passes a canonical key straight through', () => {
+    expect(PF.resolveProviderKey('cursor-cli')).toBe('cursor-cli');
+    expect(PF.resolveProviderKey('anthropic')).toBe('anthropic');
+  });
+
+  it('is case-insensitive and tolerates surrounding whitespace', () => {
+    expect(PF.resolveProviderKey('  CURSOR  ')).toBe('cursor-cli');
+    expect(PF.resolveProviderKey('z.ai')).toBe('zai');
+  });
+
+  it('returns null for a provider the capability registry does not know', () => {
+    // Admitting these would swap a silently-DROPPED tier for a silently-DEAD
+    // one, which is worse: the chain would claim a depth it cannot deliver.
+    expect(PF.resolveProviderKey('totally-fake-xyz')).toBeNull();
+    // 'ollama' exists in the provider TEMPLATES table but has no capability
+    // entry, so it is not a usable tier.
+    expect(PF.resolveProviderKey('ollama')).toBeNull();
+    // 'Local' is offered by the frontend but has no capability entry either.
+    // Documented here so a future capability addition trips this test rather
+    // than passing unnoticed.
+    expect(PF.resolveProviderKey('Local')).toBeNull();
+  });
+
+  it('returns null for a custom-provider UUID (it has no registry key)', () => {
+    expect(PF.resolveProviderKey(CUSTOM_ID)).toBeNull();
+  });
+
+  it('returns null for empty and non-string input instead of throwing', () => {
+    expect(PF.resolveProviderKey('')).toBeNull();
+    expect(PF.resolveProviderKey('   ')).toBeNull();
+    expect(PF.resolveProviderKey(null)).toBeNull();
+    expect(PF.resolveProviderKey(undefined)).toBeNull();
+    expect(PF.resolveProviderKey(42)).toBeNull();
+    expect(PF.resolveProviderKey({})).toBeNull();
+  });
+});
+
+describe('isKnownProvider — display names', () => {
+  it.each(DISPLAY_NAME_MISMATCHES)('accepts %s', (display) => {
+    expect(PF.isKnownProvider(display)).toBe(true);
+  });
+
+  it('still rejects genuinely unknown providers', () => {
+    expect(PF.isKnownProvider('totally-fake-xyz')).toBe(false);
+    expect(PF.isKnownProvider('')).toBe(false);
+  });
+
+  it('still accepts a custom provider id when the ids are supplied', () => {
+    expect(PF.isKnownProvider(CUSTOM_ID, [CUSTOM_ID])).toBe(true);
+    expect(PF.isKnownProvider(CUSTOM_ID)).toBe(false);
+  });
+});
+
+describe('buildProviderChain — display-name tiers', () => {
+  it('keeps a Cursor tier instead of silently dropping it', () => {
+    const chain = PF.buildProviderChain({
+      provider: 'claude-code',
+      model: 'claude-opus-5',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: 'Cursor', model: 'cursor-grok-4.6-medium-fast' }],
+    });
+
+    expect(chain).toHaveLength(2);
+    expect(chain[1]).toMatchObject({ tier: 1, primary: false });
+  });
+
+  it('normalizes the tier to its canonical key so the executor can look it up', () => {
+    // The executor does getTextModels(String(tier.provider).toLowerCase()) to
+    // resolve a default model, and createLlmClient(key) to build the client.
+    // Leaving "Cursor" here would produce a tier that survives the chain and
+    // then fails to resolve anything.
+    const chain = PF.buildProviderChain({
+      provider: 'claude-code',
+      model: 'claude-opus-5',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: 'Cursor', model: null }],
+    });
+
+    expect(chain[1].provider).toBe('cursor-cli');
+    expect(ProviderRegistry.getTextModels(chain[1].provider.toLowerCase()).length).toBeGreaterThan(0);
+  });
+
+  it('PRESERVES a user-configured model rather than snapping it to the static list', () => {
+    // The regression this guards against is a fix that overreaches: resolving
+    // the key for the MODEL lookup too would make resolveTierModel "recognise"
+    // cursor-cli and replace a live, user-chosen model with the first hardcoded
+    // one — silently rewriting the user's configuration.
+    const configured = 'cursor-grok-4.6-medium-fast';
+    const staticList = ProviderRegistry.getTextModels('cursor-cli') || [];
+
+    const chain = PF.buildProviderChain({
+      provider: 'claude-code',
+      model: 'claude-opus-5',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: 'Cursor', model: configured }],
+    });
+
+    expect(chain[1].model).toBe(configured);
+    // Guard the guard: if the model ever joins the static list this test still
+    // passes, but it would stop proving anything, so assert the premise.
+    expect(staticList).not.toContain(configured);
+  });
+
+  it('keeps a Z.AI tier and normalizes it too', () => {
+    const chain = PF.buildProviderChain({
+      provider: 'anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: 'Z.AI', model: 'glm-4.7' }],
+    });
+
+    expect(chain[1]).toMatchObject({ provider: 'zai', model: 'glm-4.7', tier: 1 });
+  });
+
+  it('leaves the PRIMARY tier exactly as the caller passed it', () => {
+    // The orchestrator already resolved and lowercased the primary and uses
+    // that same string for the tier-0 client; rewriting it here would be an
+    // unrelated behaviour change.
+    const chain = PF.buildProviderChain({
+      provider: 'Cursor',
+      model: 'some-model',
+      fallbackEnabled: true,
+      fallbackProviders: [],
+    });
+
+    expect(chain[0].provider).toBe('Cursor');
+    expect(chain[0]).toMatchObject({ tier: 0, primary: true });
+  });
+});
+
+describe('buildProviderChain — identity is canonical, not textual', () => {
+  // Both directions matter, and only the asymmetric pairs actually discriminate:
+  // for primary "cursor" vs tier "Cursor" a naive lowercase compare gets the
+  // right answer by accident, so a test using only that pair would pass against
+  // a textual comparison and prove nothing.
+  it.each([
+    ['cursor', 'Cursor'], // both lowercase to the same string — the easy case
+    ['cursor-cli', 'Cursor'], // canonical primary vs display-name tier
+    ['cursor', 'cursor-cli'], // display-name primary vs canonical tier
+    ['Cursor', 'cursor-cli'],
+  ])('does not fail %s over to %s — they are the same provider', (primary, tierProvider) => {
+    const chain = PF.buildProviderChain({
+      provider: primary,
+      model: 'cursor-grok-4.5-high',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: tierProvider, model: 'composer-2.5' }],
+    });
+
+    expect(chain).toHaveLength(1);
+    expect(chain[0].primary).toBe(true);
+  });
+
+  it('deduplicates two spellings of the same provider+model', () => {
+    const chain = PF.buildProviderChain({
+      provider: 'anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [
+        { provider: 'Cursor', model: 'composer-2.5' },
+        { provider: 'cursor-cli', model: 'composer-2.5' },
+      ],
+    });
+
+    expect(chain).toHaveLength(2);
+    expect(chain[1].provider).toBe('cursor-cli');
+  });
+
+  it('still allows the same provider at a DIFFERENT model', () => {
+    const chain = PF.buildProviderChain({
+      provider: 'anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [
+        { provider: 'Cursor', model: 'composer-2.5' },
+        { provider: 'cursor-cli', model: 'auto' },
+      ],
+    });
+
+    expect(chain).toHaveLength(3);
+    expect(chain.slice(1).map((t) => t.model)).toEqual(['composer-2.5', 'auto']);
+  });
+});
+
+describe('buildProviderChain — nothing else regressed', () => {
+  it('still drops a genuinely unknown provider', () => {
+    const chain = PF.buildProviderChain({
+      provider: 'anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: 'totally-fake-xyz', model: 'x' }],
+    });
+    expect(chain).toHaveLength(1);
+  });
+
+  it('still passes a custom-provider UUID through untouched', () => {
+    const chain = PF.buildProviderChain({
+      provider: 'anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: CUSTOM_ID, model: 'deepseek-v4-flash-0731' }],
+      customProviderIds: [CUSTOM_ID],
+    });
+
+    expect(chain).toHaveLength(2);
+    // NOT lowercased, NOT rewritten — the UUID is the provider identity.
+    expect(chain[1].provider).toBe(CUSTOM_ID);
+  });
+
+  it('still drops a custom tier that has no model', () => {
+    const chain = PF.buildProviderChain({
+      provider: 'anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: CUSTOM_ID, model: null }],
+      customProviderIds: [CUSTOM_ID],
+    });
+    expect(chain).toHaveLength(1);
+  });
+
+  it('still drops custom tiers when the ids are not supplied', () => {
+    const chain = PF.buildProviderChain({
+      provider: 'anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: CUSTOM_ID, model: 'x' }],
+    });
+    expect(chain).toHaveLength(1);
+  });
+
+  it('still honours fallbackEnabled=false and the MAX_FALLBACKS cap', () => {
+    expect(
+      PF.buildProviderChain({
+        provider: 'anthropic',
+        model: 'm',
+        fallbackEnabled: false,
+        fallbackProviders: [{ provider: 'Cursor', model: 'auto' }],
+      })
+    ).toHaveLength(1);
+
+    const many = Array.from({ length: 8 }, (_, i) => ({ provider: 'Cursor', model: `m${i}` }));
+    const capped = PF.buildProviderChain({
+      provider: 'anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: many,
+    });
+    expect(capped.length - 1).toBe(PF.MAX_FALLBACKS);
+  });
+});
+
+describe('buildProviderChain — a real four-tier configuration', () => {
+  it('builds all three configured tiers, Cursor included', () => {
+    // Shape taken verbatim from a users.fallback_providers row in the field:
+    // a CLI primary, two CLI fallbacks, and a custom provider last.
+    const chain = PF.buildProviderChain({
+      provider: 'claude-code',
+      model: 'claude-opus-5',
+      fallbackEnabled: true,
+      fallbackProviders: [
+        { provider: 'Cursor', model: 'cursor-grok-4.6-medium-fast' },
+        { provider: 'Grok-Build', model: 'grok-4.6' },
+        { provider: CUSTOM_ID, model: 'deepseek-v4-flash-0731' },
+      ],
+      customProviderIds: [CUSTOM_ID],
+    });
+
+    // The contract this fix owns is WHICH providers survive, and in what order.
+    expect(chain.map((t) => t.provider)).toEqual([
+      'claude-code',
+      'cursor-cli',
+      'grok-build',
+      CUSTOM_ID,
+    ]);
+
+    // Models that the fix is responsible for, asserted exactly.
+    expect(chain[1].model).toBe('cursor-grok-4.6-medium-fast');
+    expect(chain[3].model).toBe('deepseek-v4-flash-0731');
+
+    // grok-build's model is NOT pinned to a literal. Its display name already
+    // equals its registry key, so it reaches resolveTierModel's pre-existing
+    // snap-to-first-static-model branch, and the static list moves: it held
+    // ['grok-4.5','grok-4.6'] when this test was written and holds ['grok-4.5']
+    // now, which would rot a hardcoded string on the next catalogue edit.
+    const grokStatic = ProviderRegistry.getTextModels('grok-build') || [];
+    expect(chain[2].model).toBe(
+      grokStatic.includes('grok-4.6') ? 'grok-4.6' : grokStatic[0]
+    );
+  });
+
+  it('trusts a configured model only where the static list cannot vouch for it', () => {
+    // An asymmetry worth stating out loud, because it looks arbitrary until you
+    // see which way each branch fails.
+    //
+    // "Cursor" does not lowercase to its registry key, so getTextModels returns
+    // [] for it and resolveTierModel takes its trust-the-caller branch: the
+    // user's model survives verbatim. "Grok-Build" DOES lowercase to its key,
+    // finds a non-empty static list, and snaps an unrecognised model to the
+    // first entry.
+    //
+    // That snapping is pre-existing behaviour on the primary path and is left
+    // exactly as it was — this fix deliberately does not widen its blast radius
+    // by feeding the canonical key into the model lookup as well. Doing so
+    // would silently rewrite a live, UI-chosen Cursor model to a stale
+    // hardcoded one.
+    const cursorStatic = ProviderRegistry.getTextModels('Cursor') || [];
+    expect(cursorStatic).toEqual([]);
+
+    const chain = PF.buildProviderChain({
+      provider: 'anthropic',
+      model: 'm',
+      fallbackEnabled: true,
+      fallbackProviders: [{ provider: 'Cursor', model: 'a-model-no-static-list-knows' }],
+    });
+
+    expect(chain[1]).toMatchObject({
+      provider: 'cursor-cli',
+      model: 'a-model-no-static-list-knows',
+    });
+  });
+
+  it('every built-in tier it produces is resolvable by the executor', () => {
+    const chain = PF.buildProviderChain({
+      provider: 'claude-code',
+      model: 'claude-opus-5',
+      fallbackEnabled: true,
+      fallbackProviders: [
+        { provider: 'Cursor', model: 'cursor-grok-4.6-medium-fast' },
+        { provider: 'Grok-Build', model: 'grok-4.6' },
+      ],
+    });
+
+    for (const tier of chain) {
+      const key = String(tier.provider).toLowerCase();
+      expect(Object.keys(ProviderRegistry.PROVIDER_CAPABILITIES)).toContain(key);
+    }
+  });
+});

--- a/backend/src/services/orchestrator/ProviderFallback.js
+++ b/backend/src/services/orchestrator/ProviderFallback.js
@@ -28,11 +28,12 @@
  *     that side-effect has historically caused provider drift — see project
  *     memory). runWithFallback therefore never calls updateUserSettings.
  *
- * No external dependencies beyond ProviderRegistry so this stays trivially
- * unit-testable.
+ * Depends only on the provider registry + its config table so this stays
+ * trivially unit-testable.
  */
 
 import * as ProviderRegistry from '../ai/ProviderRegistry.js';
+import { getProviderConfig } from '../ai/providerConfigs.js';
 
 /** Hard ceiling on fallback tiers (excludes the primary). */
 export const MAX_FALLBACKS = 3;
@@ -101,8 +102,51 @@ export function isKnownProvider(provider, customProviderIds) {
       if (typeof id === 'string' && id.trim().toLowerCase() === lower) return true;
     }
   }
-  const caps = ProviderRegistry.PROVIDER_CAPABILITIES || {};
-  return Object.keys(caps).some((k) => k.toLowerCase() === lower);
+  return resolveProviderKey(provider) !== null;
+}
+
+/**
+ * Resolve any accepted spelling of a built-in provider to its canonical
+ * registry key, or null if the registry does not know it.
+ *
+ * The UI stores a fallback tier's provider as its DISPLAY NAME
+ * (FallbackProviders.vue: `{ provider: <displayName> }`), while every backend
+ * lookup is keyed by the registry KEY. For 18 of the 20 built-ins the display
+ * name lowercases to exactly the key, so the mismatch is invisible. For the
+ * other two it was fatal and silent:
+ *
+ *   "Cursor" -> cursor-cli        "Z.AI" -> zai
+ *
+ * Those tiers saved fine, rendered in the UI as configured, and were dropped
+ * from every chain that was ever built.
+ *
+ * `getProviderConfig` already resolves both spellings — it falls back to a
+ * strip-non-alphanumerics match against the config's `name` — which is why the
+ * EXECUTOR has always accepted display names (`createLlmAdapter` calls it).
+ * Only the chain builder was stricter than the thing it feeds.
+ *
+ * The result is gated on PROVIDER_CAPABILITIES membership rather than returned
+ * raw. Admitting a provider the capability registry does not know would trade a
+ * tier that is silently dropped for one that is silently DEAD — strictly worse,
+ * because the chain would then claim a depth it cannot deliver.
+ */
+export function resolveProviderKey(provider) {
+  if (!provider || typeof provider !== 'string') return null;
+  const lower = provider.trim().toLowerCase();
+  if (!lower) return null;
+
+  const capKeys = Object.keys(ProviderRegistry.PROVIDER_CAPABILITIES || {});
+  const direct = capKeys.find((k) => k.toLowerCase() === lower);
+  if (direct) return direct;
+
+  let config;
+  try {
+    config = getProviderConfig(provider);
+  } catch {
+    return null;
+  }
+  if (!config || !config.key) return null;
+  return capKeys.find((k) => k.toLowerCase() === String(config.key).toLowerCase()) || null;
 }
 
 /**
@@ -173,6 +217,10 @@ export function resolveTierModel(provider, model) {
  *   - Fallbacks are included only when `fallbackEnabled` is true.
  *   - Unknown providers are dropped; duplicates (same provider+model as an
  *     earlier tier) are dropped; capped at MAX_FALLBACKS.
+ *   - A built-in tier is normalized to its canonical registry key, so the
+ *     display name the UI stored ("Cursor") reaches the executor as the key it
+ *     looks up ("cursor-cli"). Custom providers are already keyed by UUID and
+ *     pass through untouched.
  *
  * @param {object} args
  * @param {string} args.provider         primary provider (already resolved)
@@ -186,8 +234,16 @@ export function resolveTierModel(provider, model) {
  */
 export function buildProviderChain({ provider, model, fallbackEnabled, fallbackProviders, customProviderIds }) {
   const primaryProviderLc = String(provider || '').toLowerCase();
+  // Compare tiers by canonical identity, not by whatever string each one
+  // happens to be spelled with. The primary arrives lowercased from the
+  // orchestrator ("cursor"), a tier arrives as a display name ("Cursor"), and
+  // both mean cursor-cli — so a raw string compare would fail to notice they
+  // are the same provider and cheerfully build a chain that fails Cursor over
+  // to Cursor. Falls back to the raw lowercase for a custom-provider UUID,
+  // which has no registry key.
+  const primaryCanonical = (resolveProviderKey(provider) || primaryProviderLc).toLowerCase();
   const chain = [{ provider, model: model || null, tier: 0, primary: true }];
-  const seen = new Set([`${primaryProviderLc}::${model || ''}`]);
+  const seen = new Set([`${primaryCanonical}::${model || ''}`]);
 
   if (!fallbackEnabled) return chain;
 
@@ -201,13 +257,34 @@ export function buildProviderChain({ provider, model, fallbackEnabled, fallbackP
   let tier = 1;
   for (const cand of candidates) {
     if (chain.length - 1 >= MAX_FALLBACKS) break;
-    if (!isKnownProvider(cand.provider, customIdSet)) continue;
+
+    const candLc = String(cand.provider || '').trim().toLowerCase();
+    const isCustom = customIdSet.has(candLc);
+    // A custom provider IS its UUID; a built-in is its registry key. Null means
+    // the registry has never heard of it — drop the tier.
+    const canonical = isCustom ? cand.provider : resolveProviderKey(cand.provider);
+    if (!canonical) continue;
 
     // Never fail over to the SAME provider we just exhausted — a different
     // model on the same down provider will almost certainly fail too.
-    if (cand.provider.toLowerCase() === primaryProviderLc) continue;
+    if (canonical.toLowerCase() === primaryCanonical) continue;
 
-    const isCustom = customIdSet.has(cand.provider.toLowerCase());
+    // Deliberately passed the ORIGINAL spelling, not `canonical`.
+    //
+    // resolveTierModel snaps an unrecognised model to the provider's first
+    // STATIC model, and for a CLI provider that static list is a stale floor
+    // rather than an authority — the UI offers models fetched live from the CLI
+    // that the hardcoded list has never heard of. Handing it the canonical key
+    // would make it "recognise" cursor-cli and silently rewrite a live,
+    // user-chosen model (cursor-grok-4.6-medium-fast) to a hardcoded one
+    // (cursor-grok-4.5-high) — turning a fix for a dropped tier into a config
+    // rewrite nobody asked for. The original spelling keeps the
+    // trust-the-caller branch, which is the right answer for a provider whose
+    // real model list is resolved at runtime.
+    //
+    // A tier with NO model configured still gets a default: the executor
+    // resolves one from the canonical key pushed below
+    // (OrchestratorService: getTextModels(String(tier.provider).toLowerCase())).
     const usableModel = resolveTierModel(cand.provider, cand.model);
 
     // A custom provider has no static model list to draw a default from, so an
@@ -215,11 +292,11 @@ export function buildProviderChain({ provider, model, fallbackEnabled, fallbackP
     // request at runtime. Drop the tier instead of shipping a dead one.
     if (isCustom && !usableModel) continue;
 
-    const key = `${cand.provider.toLowerCase()}::${usableModel || ''}`;
+    const key = `${canonical.toLowerCase()}::${usableModel || ''}`;
     if (seen.has(key)) continue;
     seen.add(key);
 
-    chain.push({ provider: cand.provider, model: usableModel, tier, primary: false });
+    chain.push({ provider: canonical, model: usableModel, tier, primary: false });
     tier += 1;
   }
 
@@ -408,6 +485,7 @@ export default {
   MAX_FALLBACKS,
   parseFallbackList,
   isKnownProvider,
+  resolveProviderKey,
   createCustomProviderIdResolver,
   resolveTierModel,
   buildProviderChain,


### PR DESCRIPTION
## What problem does this solve?

A fallback tier set to **Cursor** or **Z.AI** is silently dropped from every provider chain that is ever built. It saves, it renders in the fallback editor as configured, and it never fires.

The fallback editors store a tier as the provider's *display name* (`FallbackProviders.vue`: `{ provider: <displayName> }`), but `isKnownProvider` validated against raw `PROVIDER_CAPABILITIES` *keys*. Eighteen of the twenty built-ins lowercase to exactly their key, so the mismatch is invisible. Two do not:

| Stored by the UI | Registry key | Result |
|---|---|---|
| `Cursor` | `cursor-cli` | dropped |
| `Z.AI` | `zai` | dropped |
| `Claude-Code`, `Grok-Build`, +15 others | match | fine |

Anyone who picks Cursor or Z.AI as a fallback has a failover tier that quietly does not exist. Nothing logs it — `buildProviderChain` does `if (!isKnownProvider(...)) continue;`.

This is the same bug class as `7525e2b9` ("Z-AI display name was lowercased to `z-ai` instead of resolved to `zai`"), which fixed it for model fetching on the frontend. This is the backend chain-builder instance of it.

A concrete four-tier chain, before and after:

```
CONFIGURED                                  BEFORE                 AFTER
Claude-Code / claude-opus-5                 claude-code   (t0)     claude-code   (t0)
Cursor      / cursor-grok-4.6-medium-fast   -- dropped --          cursor-cli    (t1)
Grok-Build  / grok-4.6                      grok-build    (t1)     grok-build    (t2)
<uuid>      / deepseek-v4-flash-0731        <uuid>        (t2)     <uuid>        (t3)
```

## How does it solve it?

`isKnownProvider` now defers to `getProviderConfig`, which already resolves display names via its `name`-based fuzzy match — and is what `createLlmAdapter` has used all along. The chain builder was simply stricter than the code it feeds.

Three details worth a reviewer's attention:

**The resolved key is gated on `PROVIDER_CAPABILITIES` membership** rather than returned raw. Admitting a provider the capability registry does not know would trade a tier that is silently *dropped* for one that is silently *dead* — a chain claiming depth it cannot deliver, which is worse. Today `getAllProviderKeys()` and `Object.keys(PROVIDER_CAPABILITIES)` are identical, so this gate is currently unobservable; `ProviderFallback.capabilityGate.test.mjs` mocks a divergence to prove it works, and carries a tripwire test asserting the two sets stay identical so the day they drift, a test says so.

**The chain stores the canonical key**, so the executor's `getTextModels(String(tier.provider).toLowerCase())` and `createLlmClient(tier.provider)` both resolve. Tier identity is compared canonically too, so a chain no longer fails `cursor` over to `Cursor` believing they are different providers.

**The model lookup deliberately keeps the original spelling.** This is the part I would most like checked. `resolveTierModel` snaps an unrecognised model to the provider's first *static* model. For a CLI provider that list is a stale floor, not an authority — the UI offers models fetched live from the CLI that the hardcoded list has never heard of. Passing the canonical key there would make it "recognise" `cursor-cli` and silently rewrite a live, user-chosen `cursor-grok-4.6-medium-fast` to a hardcoded `cursor-grok-4.5-high`, turning a fix for a dropped tier into a config rewrite nobody asked for. A tier with no model still gets a default, because the executor resolves one from the canonical key.

### Deliberately not done

That last point exposes an asymmetry I chose to leave alone: `Cursor` gets the trust-the-caller branch (its display name has no static list), while `Grok-Build` — whose display name *does* equal its key — hits the snapping branch and has its configured model rewritten. I hit this for real while rebasing: upstream shrank `grok-build`'s static list from `['grok-4.5','grok-4.6']` to `['grok-4.5']`, and a tier configured for `grok-4.6` now silently becomes `grok-4.5`. A control run on pristine `main` confirms that is pre-existing behaviour on the primary path, unrelated to this change, so widening its blast radius did not belong in this PR. `ProviderFallback.displayNames.test.mjs` documents the asymmetry explicitly rather than leaving it to be rediscovered. Happy to follow up separately if you want it addressed.

`Local` also still cannot be a fallback tier — the frontend offers it but it has no `PROVIDER_CAPABILITIES` entry at all. That is a missing capability entry rather than a name mismatch, so it is a different change; a test pins the current `null` so adding one trips.

Custom providers keep their UUID identity and pass through untouched.

## How did you verify it?

34 new tests across two files. Rather than only asserting they pass, I mutation-tested them — six mutations of the new code, each of which turns the suite red:

| # | Mutation | Tests failed |
|---|---|---|
| A | restore the original raw-key match | 2 |
| B | push the raw stored spelling instead of the canonical key | 6 |
| C | normalize the model lookup too (the overreach above) | 4 |
| D | compare tier identity textually instead of canonically | 3 |
| E | drop the capability gate | 2 |
| F | dedupe on the raw spelling | 1 |

Two of my tests initially survived their mutants and were worthless: D passed because the pair I chose (`cursor` vs `Cursor`) is one a naive comparison gets right by accident — it now runs `it.each` over four asymmetric spellings; and E passed because the gate is unobservable while the two key tables coincide — hence the mocked-divergence file. Both were rewritten until they bite.

```
$ npx vitest run backend/src/services/orchestrator/ProviderFallback
 Test Files  4 passed (4)
      Tests  97 passed (97)
```

**Full suites, and an honest note on them.** Both suites have failures on current `main` that this branch does not cause. I verified that by stashing these three files and re-running — identical counts:

```
BACKEND   npx vitest run
  with this change:  2 failed | 351 passed (353 files) — 4 failed | 5536 passed
  pristine main:     same 4 failures
  -> scripts/worktree.test.js (2), browserFallbackSurface.test.js (2)
     Neither imports ProviderFallback.

FRONTEND  npx vitest run --root frontend
  with this change:  9 failed | 238 passed (247 files) — 7 failed | 4265 passed
  pristine main:     9 failed | 238 passed (247 files) — 7 failed | 4265 passed
  -> byte-identical; this branch touches no frontend file.
```

Branched from `origin/main` at `acc865d1`, not from a stale local base. `node scripts/normalize-eol.mjs --check` reports 0 rewrites.

## Checklist

- [x] This does not modify auth, sessions, or credential handling
      (see [Restricted areas](../CONTRIBUTING.md#restricted-areas))
- [x] This is not a fix for a security vulnerability
      (those go to [private reporting](https://github.com/agnt-gg/agnt/security/advisories/new))
- [x] `npm test` passes — *no new failures; 4 pre-existing, control-verified above*
- [x] `npm --prefix frontend test` passes — *no new failures; 7 pre-existing, counts identical to pristine `main`*
- [x] New behaviour has tests, and I watched them fail before the fix
      (mutation table above — stronger than red-then-green, and it caught two of my own tests being worthless)
- [x] Docs updated if the surface changed — no user-facing surface change
- [x] Commit subjects are 72 characters or fewer (60)
