### PR TITLE
fix(worktree): a linked node_modules is a symlink on POSIX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,17 @@
 backend/plugins/tests/fixtures/registry-pre-*.json
 !backend/plugins/tests/fixtures/registry-pre-0.6.0.json
 # Dependencies
-node_modules/
+#
+# The two paths scripts/worktree.mjs links into every worktree carry NO
+# trailing slash, deliberately. A trailing slash matches directories only, and
+# on macOS/Linux those links are symlinks — which git classifies as files, not
+# directories. `node_modules/` therefore missed them completely, so they showed
+# up as untracked and `git add .` inside a worktree would commit a symlink
+# pointing at the primary checkout. On Windows the same links are junctions,
+# which git does report as directories, which is why this only ever bit POSIX.
+node_modules
 .npm-cache
-frontend/node_modules/
+frontend/node_modules
 backend/node_modules/
 
 # Plugin builds (generated during build, not stored in git)

--- a/scripts/worktree.mjs
+++ b/scripts/worktree.mjs
@@ -58,6 +58,12 @@ const SLUG = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 
 const toPosix = (p) => p.split(path.sep).join('/');
 
+// Normalised once, not per call. Both sources are `export const` arrays that
+// nothing reassigns or mutates, so there is no value here to go stale — the
+// usual hazard with hoisting a derived constant to module scope.
+const LINKED_FILES_POSIX = new Set(LINKED_FILES.map(toPosix));
+const LINKED_DIRS_POSIX = LINKED_DIRS.map(toPosix);
+
 /**
  * Is this `git status` path the links we installed, rather than the user's work?
  *
@@ -68,11 +74,18 @@ const toPosix = (p) => p.split(path.sep).join('/');
  * trailing slash (`node_modules`). Matching only the `node_modules/` prefix
  * missed that second form and reported the link as uncommitted work — which
  * made `wt remove` refuse every worktree it had just created.
+ *
+ * Called once per `git status` line. That is a handful of lines in normal use,
+ * because .gitignore keeps git from ever enumerating the links — but this
+ * filter deliberately does not depend on .gitignore being right, and the case
+ * it exists to survive is precisely the one where git walks all ~30k files
+ * under node_modules. Keeping it allocation-free costs nothing and makes the
+ * backstop cheap in the only scenario that reaches it.
  */
 export function isLinkNoise(file) {
   const f = toPosix(file);
-  if (LINKED_FILES.map(toPosix).includes(f)) return true;
-  return LINKED_DIRS.map(toPosix).some((d) => f === d || f.startsWith(`${d}/`));
+  if (LINKED_FILES_POSIX.has(f)) return true;
+  return LINKED_DIRS_POSIX.some((d) => f === d || f.startsWith(`${d}/`));
 }
 
 function git(repoRoot, args, opts = {}) {

--- a/scripts/worktree.mjs
+++ b/scripts/worktree.mjs
@@ -56,6 +56,25 @@ export const LINKED_FILES = [path.join('backend', '.env')];
 
 const SLUG = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 
+const toPosix = (p) => p.split(path.sep).join('/');
+
+/**
+ * Is this `git status` path the links we installed, rather than the user's work?
+ *
+ * Both spellings have to be covered, because git describes the same link
+ * differently per platform. On Windows a junction reads as a directory, so with
+ * `-uall` git names the files INSIDE it (`node_modules/.bin/x`). On macOS and
+ * Linux a symlink reads as a file, so git names the link ITSELF, with no
+ * trailing slash (`node_modules`). Matching only the `node_modules/` prefix
+ * missed that second form and reported the link as uncommitted work — which
+ * made `wt remove` refuse every worktree it had just created.
+ */
+export function isLinkNoise(file) {
+  const f = toPosix(file);
+  if (LINKED_FILES.map(toPosix).includes(f)) return true;
+  return LINKED_DIRS.map(toPosix).some((d) => f === d || f.startsWith(`${d}/`));
+}
+
 function git(repoRoot, args, opts = {}) {
   return execFileSync('git', args, {
     cwd: repoRoot,
@@ -213,18 +232,14 @@ export function removeWorktree(repoRoot, slug, { force = false } = {}) {
 
   if (!force) {
     // Anything under a linked directory, or a linked file, is not the
-    // user's work — it is the primary checkout seen through a link. Git on
-    // Windows reports a junction as an ordinary directory, so it must be
-    // filtered here whether or not .gitignore happens to cover it.
-    const toPosix = (p) => p.split(path.sep).join('/');
-    const linkedDirs = LINKED_DIRS.map((d) => `${toPosix(d)}/`);
-    const linkedFiles = new Set(LINKED_FILES.map(toPosix));
+    // user's work — it is the primary checkout seen through a link. This is
+    // filtered here whether or not .gitignore happens to cover it, because the
+    // two disagree per platform: see isLinkNoise.
     const dirty = git(dir, ['status', '--porcelain', '--untracked-files=all'])
       .split('\n')
       .filter((line) => {
         if (!line) return false;
-        const file = line.slice(3).trim();
-        return !linkedFiles.has(file) && !linkedDirs.some((d) => file.startsWith(d));
+        return !isLinkNoise(line.slice(3).trim());
       })
       .join('\n');
     if (dirty) throw new Error(`${slug} has uncommitted changes; commit them or pass --force:\n${dirty}`);

--- a/scripts/worktree.test.js
+++ b/scripts/worktree.test.js
@@ -11,11 +11,14 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createWorktree,
   findOrphans,
+  isLinkNoise,
+  LINKED_DIRS,
   listWorktrees,
   removeWorktree,
   sweepOrphans,
@@ -37,10 +40,12 @@ beforeEach(() => {
   git(['config', 'user.name', 't']);
   git(['config', 'commit.gpgsign', 'false']);
   fs.writeFileSync(path.join(root, 'README.md'), 'x\n');
-  // Mirrors the real repo: node_modules and .env are ignored. Git on Windows
-  // sees a junction as a directory, so without this `git add .` in a
-  // worktree would commit the primary's node_modules through the link.
-  fs.writeFileSync(path.join(root, '.gitignore'), 'node_modules/\n.env\n');
+  // Mirrors the real repo: node_modules and .env are ignored. The missing
+  // trailing slash is the whole point on POSIX, where the link is a symlink
+  // and a directory-only pattern would sail straight past it — see the
+  // ".gitignore contract" block, which checks the real file rather than this
+  // copy of it.
+  fs.writeFileSync(path.join(root, '.gitignore'), 'node_modules\n.env\n');
   git(['add', '.']);
   git(['commit', '-q', '-m', 'init']);
 
@@ -194,5 +199,67 @@ describe('sweep', () => {
     createWorktree(root, 'live');
     expect(sweepOrphans(root)).toEqual({ orphans: [], removed: [] });
     expect(onDisk()).toEqual(inGit());
+  });
+});
+
+/**
+ * The REAL .gitignore, not the fixture's copy of it.
+ *
+ * A trailing slash makes a pattern directory-only. Every link this script
+ * installs is a symlink on macOS and Linux, which git classifies as a file, so
+ * `node_modules/` did not cover them: they showed up as untracked, and a
+ * `git add .` inside a worktree committed a symlink pointing at the primary
+ * checkout. Asserting against the shipped file is the point — a fixture that
+ * merely claims to mirror the repo cannot catch the repo drifting.
+ */
+describe('.gitignore contract', () => {
+  const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+  it('ignores every linked directory when it is a symlink, not only a real one', () => {
+    const probe = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'agnt-ignore-')));
+    try {
+      execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: probe, stdio: ['ignore', 'pipe', 'ignore'] });
+      fs.copyFileSync(path.join(REPO_ROOT, '.gitignore'), path.join(probe, '.gitignore'));
+
+      const target = path.join(probe, 'real-deps');
+      fs.mkdirSync(target);
+      fs.writeFileSync(path.join(target, 'canary.txt'), 'x');
+      for (const rel of LINKED_DIRS) {
+        const link = path.join(probe, rel);
+        fs.mkdirSync(path.dirname(link), { recursive: true });
+        fs.symlinkSync(target, link, 'junction');
+      }
+
+      const status = execFileSync('git', ['status', '--porcelain', '--untracked-files=all'], { cwd: probe, encoding: 'utf8' });
+      expect(status, 'a symlinked node_modules must not be reported as untracked').not.toMatch(/node_modules/);
+    } finally {
+      fs.rmSync(probe, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('isLinkNoise', () => {
+  it('matches a link named on its own — how POSIX git reports a symlink', () => {
+    for (const rel of LINKED_DIRS) {
+      expect(isLinkNoise(rel), `${rel} on its own`).toBe(true);
+    }
+  });
+
+  it('matches paths inside a link — how Windows git reports a junction', () => {
+    expect(isLinkNoise('node_modules/.bin/vitest')).toBe(true);
+    expect(isLinkNoise('frontend/node_modules/vue/index.js')).toBe(true);
+  });
+
+  it('matches a hard-linked file', () => {
+    expect(isLinkNoise('backend/.env')).toBe(true);
+  });
+
+  it('never swallows the user’s own work', () => {
+    // The last two matter: widening the match to a bare prefix would silently
+    // discard real edits whose names merely begin with a linked path.
+    expect(isLinkNoise('work.txt')).toBe(false);
+    expect(isLinkNoise('backend/.env.example')).toBe(false);
+    expect(isLinkNoise('node_modules.txt')).toBe(false);
+    expect(isLinkNoise('node_modules-notes/readme.md')).toBe(false);
   });
 });


### PR DESCRIPTION
## What this fixes

`scripts/worktree.test.js` has been failing on `main` since 2c7199b1, so **every PR inherits a red Backend (vitest) check**. Main's own run [33596904066](https://github.com/agnt-gg/agnt/actions/runs/33596904066) (@ acc865d1) fails the same two tests:

- `detaches links first, removes the worktree, deletes the merged branch`
- `keeps an unmerged branch rather than -D it on your behalf`

This branch is based on `acc865d1` and touches nothing else.

## Root cause — one bug, two symptoms

`git worktree` links are **junctions on Windows** but **symlinks on macOS/Linux**, and git classifies the two differently: a junction is a *directory*, a symlink is a *file*. Every rule that named these links assumed the Windows spelling.

Demonstrated with a two-case probe against the pre-fix `.gitignore`:

| `node_modules` is… | `git status --porcelain -uall` |
|---|---|
| a real directory | *(ignored)* |
| a symlink | `?? node_modules` |

**1. `.gitignore` said `node_modules/`.** A trailing slash matches directories only, so the link was never ignored. It shows up as untracked in every worktree — and `git add .` inside one **commits a symlink pointing at the primary checkout**, the exact accident the pattern exists to prevent.

**2. `removeWorktree`'s dirty filter tested `file.startsWith('node_modules/')`**, which cannot match the bare `node_modules` that POSIX git reports. So `wt remove` declared uncommitted changes and refused every worktree it had just created.

The second test failure is downstream of the first: because the links aren't ignored, `git add .` commits them; `detachLinks` then deletes those tracked paths, leaving staged deletions, so `git worktree remove` refuses. Each step of that chain was reproduced directly.

## The change

- **`.gitignore`** — dropped the trailing slash on the two paths `worktree.mjs` actually links (`node_modules`, `frontend/node_modules`). Other entries are untouched.
- **`scripts/worktree.mjs`** — extracted the filter into a pure exported `isLinkNoise()` covering both spellings (`f === d || f.startsWith(d + '/')`), so it is testable without a filesystem.
- **`scripts/worktree.test.js`** — 13 → 18 tests.

The new `.gitignore` contract test copies the **real** `.gitignore` into a probe repo and asserts a symlinked `node_modules` is not reported. It deliberately does not assert against the fixture's own copy: a fixture that merely *claims* to mirror the repo cannot catch the repo drifting.

## Verification

- `scripts/worktree.test.js` — **18/18**, and green inside the full run
- Full `npm test` — **5508 passed**. The only failures are `browserFallbackSurface.test.js` (*"Brave does not appear to be installed on this machine"*), which fail identically on an unmodified checkout and pass in CI
- `npm run eol:check` — clean (2621 files, would rewrite 0)

**Mutation-tested**, each mutation killed by a different test:

| Mutation | Killed by |
|---|---|
| restore the trailing slashes | `.gitignore` contract test |
| drop the bare-entry match | POSIX `isLinkNoise` test |
| naive `startsWith(d)` prefix match | *never swallows the user's own work* |

That middle one is why the pure function was extracted: dropping the bare-entry match does **not** break the integration tests once `.gitignore` is fixed, so without a unit test that layer would sit unguarded.

## Note for reviewers on Windows

This is POSIX-only in effect. On Windows the links are junctions, git reports them as directories, and both the old and new patterns match — so behaviour there is unchanged. The `isLinkNoise` tests cover both spellings explicitly so neither platform can regress silently.
