### PR TITLE
fix(providers): keep a custom provider findable when it has no models

### DIFF
--- a/frontend/src/components/common/ProviderModelSearch.customProviders.spec.js
+++ b/frontend/src/components/common/ProviderModelSearch.customProviders.spec.js
@@ -296,6 +296,34 @@ describe('ProviderModelSearch — model sweep reaches custom providers', () => {
     });
   });
 
+  it('sweeps ONLY the custom providers, not every model-less built-in', async () => {
+    // The watcher exists for a defect specific to custom providers, so its
+    // sweep has to be scoped to them. Left unnarrowed it re-fetches every
+    // built-in with no cached models — which is most of them, since an
+    // unconnected provider never has any. Measured on this shape before the
+    // fix: 20 requests dispatched to obtain the 2 that were wanted.
+    const builtIns = ['OpenAI', 'Anthropic', 'Gemini', 'Groq', 'DeepSeek', 'Cerebras'];
+    const { store, dispatched } = makeStore({
+      providers: builtIns,
+      customProviders: [],
+      allModels: { OpenAI: ['gpt-x'] }, // only one built-in is connected
+    });
+
+    mount(ProviderModelSearch, { global: { plugins: [store] } });
+    await flushPromises();
+    dispatched.length = 0;
+
+    store.commit('aiProvider/SET_CUSTOM_PROVIDERS', CUSTOMS);
+    await flushPromises();
+
+    const fetched = dispatched
+      .filter((d) => d.type === 'aiProvider/fetchProviderModels')
+      .map((d) => d.payload.provider);
+
+    expect(fetched.sort()).toEqual([OLLAMA, SPARK].sort());
+    expect(fetched.some((p) => builtIns.includes(p))).toBe(false);
+  });
+
   it('does not re-sweep a provider whose models are already cached', async () => {
     const { store, dispatched } = makeStore({
       customProviders: [],

--- a/frontend/src/components/common/ProviderModelSearch.customProviders.spec.js
+++ b/frontend/src/components/common/ProviderModelSearch.customProviders.spec.js
@@ -1,0 +1,358 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import ProviderModelSearch from './ProviderModelSearch.vue';
+
+/**
+ * Custom providers must stay findable in the provider search when they have
+ * no cached models.
+ *
+ * The search index was built by flattening providers into ONE ROW PER MODEL:
+ *
+ *   for (const model of models) entries.push({ provider, providerLabel, model })
+ *
+ * A custom provider whose endpoint is unreachable has no model list, so it
+ * contributed zero rows and vanished from search entirely — exactly when the
+ * user needs to find it, because the picker is the only place a custom
+ * provider can be edited or deleted.
+ *
+ * A second, independent defect kept even HEALTHY custom providers out of the
+ * index: the mount-time model sweep reads customProviders, but this component
+ * is a child of the provider picker and Vue mounts children before parents, so
+ * the parent's fetchCustomProviders had not resolved yet. The list was empty,
+ * every custom provider was skipped, and nothing ever re-ran the sweep.
+ *
+ * These tests mount the component and assert on rendered rows and on the
+ * actions actually dispatched, so they fail if the behaviour breaks for any
+ * reason — not merely if a particular line goes missing.
+ */
+
+const SPARK = '052c419d-1beb-42c9-81b8-f287685af155';
+const OLLAMA = '85b1bffe-2734-4c2c-97fe-e81beac0cf03';
+
+function makeStore({
+  providers = ['Anthropic', 'OpenAI'],
+  customProviders = [],
+  allModels = {},
+  // Models each provider's endpoint returns when fetchProviderModels is called.
+  fetchResult = {},
+} = {}) {
+  const store = createStore({
+    modules: {
+      aiProvider: {
+        namespaced: true,
+        state: () => ({ providers, customProviders, allModels }),
+        mutations: {
+          SET_CUSTOM_PROVIDERS(state, list) {
+            state.customProviders = list;
+          },
+          SET_PROVIDER_MODELS(state, { provider, models }) {
+            state.allModels = { ...state.allModels, [provider]: models };
+          },
+        },
+        actions: {
+          fetchProviderModels: (_ctx, { provider } = {}) =>
+            Promise.resolve(fetchResult[provider] || []),
+          setProvider: () => Promise.resolve(),
+          setModel: () => Promise.resolve(),
+        },
+      },
+    },
+  });
+
+  const dispatched = [];
+  const realDispatch = store.dispatch.bind(store);
+  store.dispatch = (type, payload) => {
+    dispatched.push({ type, payload });
+    return realDispatch(type, payload);
+  };
+
+  return { store, dispatched };
+}
+
+async function mountSearch(opts = {}, props = {}) {
+  const { store, dispatched } = makeStore(opts);
+  const wrapper = mount(ProviderModelSearch, {
+    props,
+    global: { plugins: [store] },
+  });
+  await flushPromises();
+  dispatched.length = 0; // drop the mount-time sweep
+  return { wrapper, store, dispatched };
+}
+
+/** Type a query and open the dropdown the way a real user would. */
+async function search(wrapper, text) {
+  const input = wrapper.find('input.search-input');
+  await input.setValue(text);
+  await input.trigger('focus');
+  await flushPromises();
+  return wrapper.findAll('.search-result').map((n) => n.text());
+}
+
+const CUSTOMS = [
+  { id: SPARK, provider_name: 'spark-deepseek' },
+  { id: OLLAMA, provider_name: 'ollama-local' },
+];
+
+describe('ProviderModelSearch — custom providers with no cached models', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lists a custom provider that has no cached models', async () => {
+    const { wrapper } = await mountSearch({
+      customProviders: CUSTOMS,
+      allModels: {}, // nothing cached for anyone
+    });
+
+    const rows = await search(wrapper, 'ollama');
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toContain('ollama-local (Custom)');
+  });
+
+  it('labels the model-less row rather than rendering an empty gap', async () => {
+    const { wrapper } = await mountSearch({
+      customProviders: CUSTOMS,
+      allModels: {},
+    });
+
+    await search(wrapper, 'ollama');
+
+    const row = wrapper.find('.search-result');
+    expect(row.find('.result-model-none').exists()).toBe(true);
+    expect(row.text()).toContain('no models loaded');
+  });
+
+  it('lists real model rows and NO extra provider-only row once models are cached', async () => {
+    const { wrapper } = await mountSearch({
+      customProviders: CUSTOMS,
+      allModels: { [SPARK]: ['deepseek-v4-flash-0731', 'deepseek-v4-thinking'] },
+    });
+
+    const rows = await search(wrapper, 'spark');
+
+    expect(rows).toHaveLength(2);
+    expect(rows.join(' ')).toContain('deepseek-v4-flash-0731');
+    expect(rows.join(' ')).toContain('deepseek-v4-thinking');
+    // The provider-only fallback must not double-list a working provider.
+    expect(wrapper.find('.result-model-none').exists()).toBe(false);
+  });
+
+  it('does NOT invent provider-only rows for built-in providers', async () => {
+    // A built-in with no models means "not connected". Listing every
+    // unconnected built-in would bury the providers that actually work.
+    const { wrapper } = await mountSearch({
+      providers: ['Anthropic', 'OpenAI'],
+      customProviders: [],
+      allModels: {},
+    });
+
+    const rows = await search(wrapper, 'anthropic');
+
+    expect(rows).toHaveLength(0);
+    expect(wrapper.find('.search-empty').exists()).toBe(true);
+  });
+});
+
+describe('ProviderModelSearch — selecting a provider-only row', () => {
+  it('resolves a model on the fly and pins the pair when the endpoint answers', async () => {
+    const { wrapper, dispatched } = await mountSearch({
+      customProviders: CUSTOMS,
+      allModels: {},
+      fetchResult: { [SPARK]: ['deepseek-v4-flash-0731'] },
+    });
+
+    await search(wrapper, 'spark');
+    await wrapper.find('.search-result').trigger('mousedown');
+    await flushPromises();
+
+    expect(dispatched).toContainEqual({
+      type: 'aiProvider/fetchProviderModels',
+      payload: { provider: SPARK },
+    });
+    expect(dispatched).toContainEqual({ type: 'aiProvider/setProvider', payload: SPARK });
+    expect(dispatched).toContainEqual({
+      type: 'aiProvider/setModel',
+      payload: 'deepseek-v4-flash-0731',
+    });
+  });
+
+  it('selects an unreachable provider WITHOUT dispatching a null model', async () => {
+    // Selecting is how the user reaches the provider's Edit/Delete buttons, so
+    // it must still work. But setModel(null) would clear the selection that
+    // setProvider just made.
+    const { wrapper, dispatched } = await mountSearch({
+      customProviders: CUSTOMS,
+      allModels: {},
+      fetchResult: {}, // endpoint down — resolves to nothing
+    });
+
+    await search(wrapper, 'ollama');
+    await wrapper.find('.search-result').trigger('mousedown');
+    await flushPromises();
+
+    expect(dispatched).toContainEqual({ type: 'aiProvider/setProvider', payload: OLLAMA });
+    expect(dispatched.some((d) => d.type === 'aiProvider/setModel')).toBe(false);
+  });
+
+  it('survives a rejected model fetch instead of leaving the pick half-applied', async () => {
+    const { store } = makeStore({ customProviders: CUSTOMS, allModels: {} });
+    // Replace the action with a rejecting one.
+    store.hotUpdate({
+      modules: {
+        aiProvider: {
+          namespaced: true,
+          actions: {
+            fetchProviderModels: () => Promise.reject(new Error('ECONNREFUSED')),
+            setProvider: () => Promise.resolve(),
+            setModel: () => Promise.resolve(),
+          },
+        },
+      },
+    });
+    const dispatched = [];
+    const realDispatch = store.dispatch.bind(store);
+    store.dispatch = (type, payload) => {
+      dispatched.push({ type, payload });
+      return realDispatch(type, payload);
+    };
+
+    const wrapper = mount(ProviderModelSearch, { global: { plugins: [store] } });
+    await flushPromises();
+    dispatched.length = 0;
+
+    await search(wrapper, 'ollama');
+    await wrapper.find('.search-result').trigger('mousedown');
+    await flushPromises();
+
+    expect(dispatched).toContainEqual({ type: 'aiProvider/setProvider', payload: OLLAMA });
+    expect(dispatched.some((d) => d.type === 'aiProvider/setModel')).toBe(false);
+  });
+});
+
+describe('ProviderModelSearch — per-conversation overrides (applyGlobally: false)', () => {
+  it('emits the resolved pair when a model is available', async () => {
+    const { wrapper } = await mountSearch(
+      {
+        customProviders: CUSTOMS,
+        allModels: {},
+        fetchResult: { [SPARK]: ['deepseek-v4-flash-0731'] },
+      },
+      { applyGlobally: false },
+    );
+
+    await search(wrapper, 'spark');
+    await wrapper.find('.search-result').trigger('mousedown');
+    await flushPromises();
+
+    const emitted = wrapper.emitted('selected');
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0][0]).toMatchObject({ provider: SPARK, model: 'deepseek-v4-flash-0731' });
+  });
+
+  it('does NOT emit a null-model pin for an unreachable provider', async () => {
+    // ChatProviderSelector pipes result.model straight into setConversationAi.
+    // A provider pinned with a null model cannot route.
+    const { wrapper, dispatched } = await mountSearch(
+      { customProviders: CUSTOMS, allModels: {}, fetchResult: {} },
+      { applyGlobally: false },
+    );
+
+    await search(wrapper, 'ollama');
+    await wrapper.find('.search-result').trigger('mousedown');
+    await flushPromises();
+
+    expect(wrapper.emitted('selected')).toBeUndefined();
+    // And it must not have written the global selection as a consolation prize.
+    expect(dispatched.some((d) => d.type === 'aiProvider/setProvider')).toBe(false);
+  });
+});
+
+describe('ProviderModelSearch — model sweep reaches custom providers', () => {
+  it('re-runs the sweep when custom providers arrive after mount', async () => {
+    // The parent dispatches fetchCustomProviders, and Vue mounts children
+    // before parents — so on mount this list is empty. Without a watcher the
+    // sweep never covers a custom provider at all.
+    const { store, dispatched } = makeStore({ customProviders: [], allModels: {} });
+
+    mount(ProviderModelSearch, { global: { plugins: [store] } });
+    await flushPromises();
+
+    expect(dispatched.some((d) => d.payload?.provider === SPARK)).toBe(false);
+    dispatched.length = 0;
+
+    store.commit('aiProvider/SET_CUSTOM_PROVIDERS', CUSTOMS);
+    await flushPromises();
+
+    expect(dispatched).toContainEqual({
+      type: 'aiProvider/fetchProviderModels',
+      payload: { provider: SPARK },
+    });
+    expect(dispatched).toContainEqual({
+      type: 'aiProvider/fetchProviderModels',
+      payload: { provider: OLLAMA },
+    });
+  });
+
+  it('does not re-sweep a provider whose models are already cached', async () => {
+    const { store, dispatched } = makeStore({
+      customProviders: [],
+      allModels: { [SPARK]: ['deepseek-v4-flash-0731'] },
+    });
+
+    mount(ProviderModelSearch, { global: { plugins: [store] } });
+    await flushPromises();
+    dispatched.length = 0;
+
+    store.commit('aiProvider/SET_CUSTOM_PROVIDERS', CUSTOMS);
+    await flushPromises();
+
+    expect(dispatched.some((d) => d.payload?.provider === SPARK)).toBe(false);
+    expect(dispatched).toContainEqual({
+      type: 'aiProvider/fetchProviderModels',
+      payload: { provider: OLLAMA },
+    });
+  });
+});
+
+describe('ProviderModelSearch — result ordering', () => {
+  it('keeps provider-name-only matches in list order', async () => {
+    // Characterization, not a comparator guard. Every row here scores Infinity,
+    // so the comparator returns NaN — which looks alarming but is well-defined:
+    // ECMA-262 SortCompare says "If v is NaN, return +0", i.e. a tie, and V8's
+    // sort is stable. Verified by mutation: swapping the comparator for a
+    // NaN-collapsing variant changes nothing, at 3 elements or at 30. What this
+    // test does pin down is that ties surface in provider list order rather
+    // than being shuffled by some future scoring change.
+    const many = Array.from({ length: 30 }, (_, i) => ({
+      id: `p${String(i).padStart(2, '0')}`,
+      provider_name: `spark-${String(i).padStart(2, '0')}`,
+    }));
+    const allModels = Object.fromEntries(many.map((p) => [p.id, [`model-${p.id}`]]));
+
+    const { wrapper } = await mountSearch({ providers: [], customProviders: many, allModels });
+
+    const rows = await search(wrapper, 'spark');
+
+    expect(rows).toHaveLength(30);
+    const order = rows.map((r) => r.match(/spark-(\d+)/)[1]);
+    expect(order).toEqual(many.map((_, i) => String(i).padStart(2, '0')));
+  });
+
+  it('still ranks a model-name match above a provider-name-only match', async () => {
+    const { wrapper } = await mountSearch({
+      providers: [],
+      customProviders: [
+        { id: 'a', provider_name: 'zeta' },
+        { id: 'b', provider_name: 'deepseek-host' },
+      ],
+      allModels: { a: ['deepseek-v4'], b: ['llama-3'] },
+    });
+
+    const rows = await search(wrapper, 'deepseek');
+
+    expect(rows[0]).toContain('deepseek-v4');
+  });
+});

--- a/frontend/src/components/common/ProviderModelSearch.vue
+++ b/frontend/src/components/common/ProviderModelSearch.vue
@@ -53,12 +53,19 @@ const MAX_RESULTS = 40;// Dispatch fetches for every provider that hasn't loaded
 // invocations are cheap and always converge on fresh data. Per-provider
 // failures (missing API key, not connected) are silenced so unrelated
 // providers still populate.
-async function ensureAllProviderModelsLoaded(store) {
+// `only` narrows the sweep to a specific set of providers. The mount-time call
+// omits it and covers everything; the custom-provider watcher passes just the
+// custom ids, because re-sweeping everything would re-fetch every built-in that
+// has no models — which is most of them, since an unconnected provider never
+// gets any. Measured on a realistic 20-built-in store with 2 connected: the
+// unnarrowed watcher fired 20 requests to obtain the 2 that were wanted.
+async function ensureAllProviderModelsLoaded(store, only = null) {
   const { allModels = {}, providers = [], customProviders = [] } = store.state.aiProvider;
-  const targets = [
+  const pool = only || [
     ...providers,
     ...customProviders.map((cp) => cp.id),
-  ].filter((p) => !allModels[p] || allModels[p].length === 0);
+  ];
+  const targets = pool.filter((p) => !allModels[p] || allModels[p].length === 0);
 
   if (!targets.length) return;
   await Promise.all(
@@ -250,7 +257,10 @@ export default {
     // (SET_CUSTOM_PROVIDERS) and an in-place push (ADD_CUSTOM_PROVIDER).
     watch(
       () => (store.state.aiProvider.customProviders || []).map((cp) => cp.id).join(','),
-      () => ensureAllProviderModelsLoaded(store),
+      () => ensureAllProviderModelsLoaded(
+        store,
+        (store.state.aiProvider.customProviders || []).map((cp) => cp.id),
+      ),
     );
 
     return {

--- a/frontend/src/components/common/ProviderModelSearch.vue
+++ b/frontend/src/components/common/ProviderModelSearch.vue
@@ -25,7 +25,7 @@
       <template v-if="results.length">
         <div
           v-for="(result, idx) in results"
-          :key="`${result.provider}::${result.model}`"
+          :key="`${result.provider}::${result.model ?? '(provider-only)'}`"
           class="search-result"
           :class="{ active: idx === cursor }"
           @mousedown.prevent="select(result)"
@@ -33,7 +33,8 @@
         >
           <span class="result-provider">{{ result.providerLabel }}</span>
           <span class="result-divider">·</span>
-          <span class="result-model">{{ result.model }}</span>
+          <span v-if="result.model" class="result-model">{{ result.model }}</span>
+          <span v-else class="result-model result-model-none">no models loaded</span>
         </div>
       </template>
       <div v-else class="search-empty">No matches</div>
@@ -42,7 +43,7 @@
 </template>
 
 <script>
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useStore } from 'vuex';
 import { PROVIDER_DISPLAY_NAMES } from '@/store/app/aiProvider.js';
 
@@ -107,11 +108,24 @@ export default {
           entries.push({ provider, providerLabel: label, model });
         }
       }
+      // A custom provider is user-created, and the picker is the only place it
+      // can be edited or deleted — so it has to stay findable precisely when it
+      // is broken. Its model list comes from its own endpoint, so an unreachable
+      // one has no models and would contribute no rows at all, disappearing from
+      // search exactly when the user needs to go fix it. Emit a single
+      // provider-only row instead.
+      //
+      // Built-ins deliberately get no such row: an empty built-in means "not
+      // connected", and listing every unconnected provider would bury the ones
+      // that actually work.
       for (const cp of customProviders) {
         const label = `${cp.provider_name} (Custom)`;
         const models = allModels[cp.id] || [];
         for (const model of models) {
           entries.push({ provider: cp.id, providerLabel: label, model });
+        }
+        if (!models.length) {
+          entries.push({ provider: cp.id, providerLabel: label, model: null });
         }
       }
       return entries;
@@ -124,14 +138,18 @@ export default {
       if (!q) return [];
       const scored = [];
       for (const entry of allEntries.value) {
-        const modelLower = entry.model.toLowerCase();
-        const providerLower = entry.providerLabel.toLowerCase();
-        const modelIdx = modelLower.indexOf(q);
-        const providerIdx = providerLower.indexOf(q);
+        // A provider-only row has no model name to match against.
+        const modelIdx = entry.model ? entry.model.toLowerCase().indexOf(q) : -1;
+        const providerIdx = entry.providerLabel.toLowerCase().indexOf(q);
         if (modelIdx === -1 && providerIdx === -1) continue;
         const score = (modelIdx === -1 ? Infinity : modelIdx) + (providerIdx === -1 ? 100 : providerIdx) * 0.01;
         scored.push({ entry, score });
       }
+      // Every provider-name-only match scores Infinity, so those rows all tie
+      // at Infinity - Infinity = NaN. That is not the hazard it looks like:
+      // ECMA-262 SortCompare specifies "If v is NaN, return +0", so the engine
+      // reads it as a genuine tie and the sort stays stable. Left as-is
+      // deliberately — guarding it would be redundant with the spec.
       scored.sort((a, b) => a.score - b.score);
       return scored.slice(0, MAX_RESULTS).map((s) => s.entry);
     });
@@ -183,13 +201,37 @@ export default {
       if (!result) return;
       close();
       query.value = '';
+
+      // A provider-only row carries no model, so resolve one first. The fetch
+      // routes custom-provider ids to their own endpoint, which means a provider
+      // that was merely never fetched (rather than unreachable) ends up behaving
+      // exactly like an ordinary model hit.
+      let picked = result;
+      if (!picked.model) {
+        const models = await store
+          .dispatch('aiProvider/fetchProviderModels', { provider: picked.provider })
+          .catch(() => []);
+        picked = { ...picked, model: Array.isArray(models) && models.length ? models[0] : null };
+      }
+
       if (props.applyGlobally) {
         // setProvider auto-picks the first model for that provider; setModel
-        // immediately overrides it with the user's chosen pair.
-        await store.dispatch('aiProvider/setProvider', result.provider);
-        await store.dispatch('aiProvider/setModel', result.model);
+        // immediately overrides it with the user's chosen pair. With nothing
+        // resolved there is no pair to pin, and dispatching a null model would
+        // undo the selection the provider mutation just made.
+        await store.dispatch('aiProvider/setProvider', picked.provider);
+        if (picked.model) {
+          await store.dispatch('aiProvider/setModel', picked.model);
+        }
+      } else if (!picked.model) {
+        // A per-conversation override pins provider AND model; a null model
+        // writes a half-pin that cannot route. Selecting an unreachable provider
+        // globally is a meaningful way to reach its Edit button — pinning one
+        // conversation to it is not.
+        return;
       }
-      emit('selected', result);
+
+      emit('selected', picked);
     };    // Models for a provider are only fetched when that provider is first
     // selected. To make search cover every provider, kick off background
     // fetches on mount — fetchProviderModels uses stale-while-revalidate,
@@ -198,6 +240,18 @@ export default {
     onMounted(() => {
       ensureAllProviderModelsLoaded(store);
     });
+
+    // The mount-time sweep above cannot see custom providers. This component is
+    // a child of the provider picker, Vue mounts children before parents, and it
+    // is the PARENT that dispatches fetchCustomProviders — so on mount the list
+    // is still empty and every custom provider is skipped, permanently. Re-run
+    // the sweep when the ids actually change. Keying on the joined ids rather
+    // than the array reference catches both a wholesale replace
+    // (SET_CUSTOM_PROVIDERS) and an in-place push (ADD_CUSTOM_PROVIDER).
+    watch(
+      () => (store.state.aiProvider.customProviders || []).map((cp) => cp.id).join(','),
+      () => ensureAllProviderModelsLoaded(store),
+    );
 
     return {
       rootRef,
@@ -340,6 +394,11 @@ export default {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.result-model-none {
+  color: var(--color-med-navy);
+  font-style: italic;
 }
 
 .search-empty {


### PR DESCRIPTION
## What's broken

Type a custom provider's name into the provider search and you get **No matches** — even when the provider is healthy and serving models.

Found while trying to reach a custom provider's Edit/Delete buttons on a live install. Two active custom providers, neither findable:

| Provider | State | In search |
|---|---|---|
| `spark-deepseek` | healthy, `/models` → 200, 1 model | ❌ not found |
| `ollama-local` | endpoint down (ECONNREFUSED) | ❌ not found |

That second row is the one that stings: **the picker is the only place a custom provider can be edited or deleted**, so it disappears from search at exactly the moment you go looking for it to fix it.

## Root causes — two independent defects

**1. Structural.** `allEntries` flattens providers into one row per model:

```js
for (const model of models) entries.push({ provider, providerLabel, model });
```

A provider whose model list is empty contributes **zero rows**. Custom providers get their models from their own endpoint, so an unreachable one has none and is invisible.

**2. Timing** — this is why healthy `spark-deepseek` was also missing. `ensureAllProviderModelsLoaded` runs once in `onMounted` and reads `customProviders`. But this component is a **child** of `ProviderSelector`, Vue mounts children before parents, and it is the **parent** that dispatches `fetchCustomProviders`. The list is therefore always `[]` at mount, every custom provider is skipped, and nothing ever re-runs the sweep.

Fixing only the first defect would leave a healthy provider showing "no models loaded" forever — a fix that looks like a bug.

## The change

- A custom provider with no cached models emits one **provider-only row**, rendered as `no models loaded`. Built-ins deliberately get no such row: an empty built-in means "not connected", and listing every unconnected provider would bury the ones that work.
- A **watcher** keyed on the joined provider ids re-runs the model sweep when custom providers arrive. Keyed on ids rather than the array reference, so it catches both a wholesale replace (`SET_CUSTOM_PROVIDERS`) and an in-place push (`ADD_CUSTOM_PROVIDER`).
- Selecting a provider-only row **resolves a model on the fly**. `fetchProviderModels` already routes custom-provider ids to their own endpoint, so a provider that was merely never fetched behaves exactly like an ordinary model hit.

### Two edge cases worth calling out

**Global selection with nothing resolvable** dispatches `setProvider` but *not* `setModel`. `SET_SELECTED_PROVIDER` auto-picks a model when one is available and clears it otherwise, so dispatching `setModel(null)` would undo the selection that had just been made. Selecting an unreachable provider still needs to work — it is how you reach its Edit button.

**Per-conversation selection declines instead.** `ChatProviderSelector` pipes `result.model` straight into `chat/setConversationAi`, so a null model writes a conversation pin that cannot route. Selecting a broken provider *globally* is meaningful; pinning one conversation to it is not.

## Verification

- New spec: **13 tests**, mounted against a real store, asserting on rendered rows and dispatched actions rather than on source text
- Full frontend suite: **249 files / 4374 tests, 0 failures**
- `npm run eol:check` clean

**Mutation-tested against this base** — five mutations, each killed by a different group:

| Mutation | Tests killed |
|---|---|
| never emit the provider-only row | 7 |
| drop the watcher | 2 |
| dispatch `setModel` unconditionally | 2 |
| unguard the per-conversation emit | 1 |
| skip on-the-fly model resolution | 2 |

## Note for reviewers

Provider-name-only matches all score `Infinity` and subtract to `NaN` in the sort comparator. That looks like a latent bug and is **not** one: ECMA-262 SortCompare specifies *"If v is NaN, return +0"*, i.e. a genuine tie, and V8's sort is stable. I originally "fixed" it with `|| 0`; mutation testing showed reverting that changed nothing at 3 elements or at 30, so the change was dropped and the behaviour documented in place instead. The ordering test is labelled as characterization, not as a guard.

One pre-existing formatting quirk (`};    // Models for a provider…` on line 193) is left untouched to keep this diff to the bug.
