### PR TITLE
feat(themes): add Everforest, a theme that follows the desktop

### DIFF
--- a/frontend/src/store/app/theme.js
+++ b/frontend/src/store/app/theme.js
@@ -6,29 +6,40 @@ const SUPPORTED_THEMES = ['light', 'dark', 'cyberpunk', 'midnight', 'ember', 'no
 /* Themes that carry their own light and dark face and follow the desktop's colour scheme. */
 const SYSTEM_FOLLOWING_THEMES = ['everforest'];
 
+/* Which face of a system-following theme to show. 'auto' asks the desktop; the other two are an
+   explicit choice by the user, which is the only thing that works on a desktop that has no
+   day/night switch to ask -- there, `prefers-color-scheme` answers light forever. */
+export const THEME_FACES = ['auto', 'light', 'dark'];
+
+function readStoredFace() {
+  const stored = localStorage.getItem('themeFace');
+  return THEME_FACES.includes(stored) ? stored : 'auto';
+}
+
 function prefersDarkScheme() {
   return typeof window !== 'undefined' && typeof window.matchMedia === 'function'
     ? window.matchMedia('(prefers-color-scheme: dark)').matches
     : true;
 }
 
-/* The legacy isDarkMode flag. A system-following theme is dark only while the desktop is. */
-function isDarkFace(theme) {
-  return SYSTEM_FOLLOWING_THEMES.includes(theme)
-    ? prefersDarkScheme()
-    : !['light', 'rose'].includes(theme);
+/* The legacy isDarkMode flag, and the one rule for which face is showing. */
+function isDarkFace(theme, face = 'auto') {
+  if (!SYSTEM_FOLLOWING_THEMES.includes(theme)) return !['light', 'rose'].includes(theme);
+  if (face === 'dark') return true;
+  if (face === 'light') return false;
+  return prefersDarkScheme();
 }
 
 /* One place that decides which classes a theme puts on <body>, so startup and later switches
-   cannot drift apart. A system-following theme adds `.dark` only while the desktop asks for it. */
-function applyThemeClasses(theme) {
+   cannot drift apart. A system-following theme adds `.dark` only while its face resolves dark. */
+function applyThemeClasses(theme, face = 'auto') {
   document.body.classList.remove(
     'dark', 'cyberpunk', 'midnight', 'ember', 'nord', 'hacker', 'rose', 'everforest',
   );
   const darkVariants = ['dark', 'cyberpunk', 'midnight', 'ember', 'nord', 'hacker'];
   if (SYSTEM_FOLLOWING_THEMES.includes(theme)) {
     document.body.classList.add(theme);
-    if (prefersDarkScheme()) {
+    if (isDarkFace(theme, face)) {
       document.body.classList.add('dark');
     }
   } else if (darkVariants.includes(theme)) {
@@ -42,19 +53,19 @@ function applyThemeClasses(theme) {
   // light theme has no classes (default)
 }
 
-/* Re-apply on a desktop day/night flip. Registered once; a no-op unless the active theme
-   follows the system. */
+/* Re-apply on a desktop day/night flip. Registered once; a no-op unless the active theme follows
+   the system AND the user has not pinned a face, because a pinned face outranks the desktop. */
 let systemSchemeWatcher = null;
-function watchSystemScheme(getTheme, onSchemeChange) {
+function watchSystemScheme(getContext, onSchemeChange) {
   if (systemSchemeWatcher || typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
     return;
   }
   systemSchemeWatcher = window.matchMedia('(prefers-color-scheme: dark)');
   const onChange = () => {
-    const theme = getTheme();
-    if (!SYSTEM_FOLLOWING_THEMES.includes(theme)) return;
-    applyThemeClasses(theme);
-    onSchemeChange(theme);
+    const { theme, face } = getContext();
+    if (!SYSTEM_FOLLOWING_THEMES.includes(theme) || face !== 'auto') return;
+    applyThemeClasses(theme, face);
+    onSchemeChange(theme, face);
   };
   if (typeof systemSchemeWatcher.addEventListener === 'function') {
     systemSchemeWatcher.addEventListener('change', onChange);
@@ -198,6 +209,9 @@ export default {
     rateLimitInfo: null, // { resetAt, limit, window, currentPlan, hitCount }
     rateLimitHitCount: 0,
 
+    /* 'auto' follows the desktop; 'light'/'dark' pin a system-following theme's face. */
+    themeFace: readStoredFace(),
+
     // Legacy support - computed from currentTheme
     isDarkMode: localStorage.getItem('currentTheme') !== null ? !['light', 'rose'].includes(localStorage.getItem('currentTheme')) : true,
     isCyberpunkMode: localStorage.getItem('currentTheme') !== null ? localStorage.getItem('currentTheme') === 'cyberpunk' : true,
@@ -208,15 +222,28 @@ export default {
       state.currentTheme = theme;
       localStorage.setItem('currentTheme', theme);
 
+      // Choosing a theme from the picker starts it following the desktop again. That is also the
+      // way back to 'auto' after pinning a face, without a third control in the UI.
+      state.themeFace = 'auto';
+      localStorage.setItem('themeFace', 'auto');
+
       // Update legacy state for backward compatibility
-      state.isDarkMode = isDarkFace(theme);
+      state.isDarkMode = isDarkFace(theme, state.themeFace);
       state.isCyberpunkMode = theme === 'cyberpunk';
 
       // Apply theme classes to body
-      applyThemeClasses(theme);
+      applyThemeClasses(theme, state.themeFace);
     },
 
     // Legacy mutations for backward compatibility
+    /* Pin or release the face of a system-following theme. */
+    SET_THEME_FACE(state, face) {
+      state.themeFace = THEME_FACES.includes(face) ? face : 'auto';
+      localStorage.setItem('themeFace', state.themeFace);
+      applyThemeClasses(state.currentTheme, state.themeFace);
+      state.isDarkMode = isDarkFace(state.currentTheme, state.themeFace);
+    },
+
     SET_DARK_MODE(state, isDarkMode) {
       state.isDarkMode = isDarkMode;
       localStorage.setItem('darkMode', isDarkMode);
@@ -364,11 +391,11 @@ export default {
     async initTheme({ commit, state, dispatch }) {
       // Apply CSS classes IMMEDIATELY from localStorage state (no async dependency)
       // This prevents theme flash while IndexedDB loads background images
-      applyThemeClasses(state.currentTheme);
-      commit('SET_DARK_MODE', isDarkFace(state.currentTheme));
+      applyThemeClasses(state.currentTheme, state.themeFace);
+      commit('SET_DARK_MODE', isDarkFace(state.currentTheme, state.themeFace));
       watchSystemScheme(
-        () => state.currentTheme,
-        (theme) => commit('SET_DARK_MODE', isDarkFace(theme)),
+        () => ({ theme: state.currentTheme, face: state.themeFace }),
+        (theme, face) => commit('SET_DARK_MODE', isDarkFace(theme, face)),
       );
 
       // Initialize greyscale and visual settings synchronously
@@ -384,6 +411,13 @@ export default {
 
     // Legacy actions for backward compatibility
     toggleDarkMode({ commit, state }) {
+      // For a theme that carries both faces, the toggle chooses one and keeps it. Without this it
+      // would flip the class and the next desktop event, or any re-apply, would undo it -- and on
+      // a desktop with no day/night switch there would be no way to reach the other face at all.
+      if (SYSTEM_FOLLOWING_THEMES.includes(state.currentTheme)) {
+        commit('SET_THEME_FACE', state.isDarkMode ? 'light' : 'dark');
+        return;
+      }
       commit('SET_DARK_MODE', !state.isDarkMode);
     },
     initDarkMode({ commit, state }) {
@@ -684,6 +718,7 @@ export default {
 
     // Legacy getters for backward compatibility
     isDarkMode: (state) => state.isDarkMode,
+    themeFace: (state) => state.themeFace,
     isCyberpunkMode: (state) => state.isCyberpunkMode,
     isGreyscaleMode: (state) => state.isGreyscaleMode,
     isAssetPanelFullWidth: (state) => state.isAssetPanelFullWidth,

--- a/frontend/src/store/app/theme.js
+++ b/frontend/src/store/app/theme.js
@@ -1,7 +1,67 @@
 import { mediaStorage } from '../../utils/mediaStorage.js';
 import { maxBytesFor, formatMb } from '../../services/backgroundLimits.js';
 
-const SUPPORTED_THEMES = ['light', 'dark', 'cyberpunk', 'midnight', 'ember', 'nord', 'hacker', 'rose'];
+const SUPPORTED_THEMES = ['light', 'dark', 'cyberpunk', 'midnight', 'ember', 'nord', 'hacker', 'rose', 'everforest'];
+
+/* Themes that carry their own light and dark face and follow the desktop's colour scheme. */
+const SYSTEM_FOLLOWING_THEMES = ['everforest'];
+
+function prefersDarkScheme() {
+  return typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-color-scheme: dark)').matches
+    : true;
+}
+
+/* The legacy isDarkMode flag. A system-following theme is dark only while the desktop is. */
+function isDarkFace(theme) {
+  return SYSTEM_FOLLOWING_THEMES.includes(theme)
+    ? prefersDarkScheme()
+    : !['light', 'rose'].includes(theme);
+}
+
+/* One place that decides which classes a theme puts on <body>, so startup and later switches
+   cannot drift apart. A system-following theme adds `.dark` only while the desktop asks for it. */
+function applyThemeClasses(theme) {
+  document.body.classList.remove(
+    'dark', 'cyberpunk', 'midnight', 'ember', 'nord', 'hacker', 'rose', 'everforest',
+  );
+  const darkVariants = ['dark', 'cyberpunk', 'midnight', 'ember', 'nord', 'hacker'];
+  if (SYSTEM_FOLLOWING_THEMES.includes(theme)) {
+    document.body.classList.add(theme);
+    if (prefersDarkScheme()) {
+      document.body.classList.add('dark');
+    }
+  } else if (darkVariants.includes(theme)) {
+    document.body.classList.add('dark');
+    if (theme !== 'dark') {
+      document.body.classList.add(theme);
+    }
+  } else if (theme === 'rose') {
+    document.body.classList.add('rose');
+  }
+  // light theme has no classes (default)
+}
+
+/* Re-apply on a desktop day/night flip. Registered once; a no-op unless the active theme
+   follows the system. */
+let systemSchemeWatcher = null;
+function watchSystemScheme(getTheme, onSchemeChange) {
+  if (systemSchemeWatcher || typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return;
+  }
+  systemSchemeWatcher = window.matchMedia('(prefers-color-scheme: dark)');
+  const onChange = () => {
+    const theme = getTheme();
+    if (!SYSTEM_FOLLOWING_THEMES.includes(theme)) return;
+    applyThemeClasses(theme);
+    onSchemeChange(theme);
+  };
+  if (typeof systemSchemeWatcher.addEventListener === 'function') {
+    systemSchemeWatcher.addEventListener('change', onChange);
+  } else if (typeof systemSchemeWatcher.addListener === 'function') {
+    systemSchemeWatcher.addListener(onChange);
+  }
+}
 
 function mediaKeyFor(theme) {
   return `customBackgroundImage_${theme}`;
@@ -149,21 +209,11 @@ export default {
       localStorage.setItem('currentTheme', theme);
 
       // Update legacy state for backward compatibility
-      state.isDarkMode = !['light', 'rose'].includes(theme);
+      state.isDarkMode = isDarkFace(theme);
       state.isCyberpunkMode = theme === 'cyberpunk';
 
       // Apply theme classes to body
-      document.body.classList.remove('dark', 'cyberpunk', 'midnight', 'ember', 'nord', 'hacker', 'rose');
-      const darkVariants = ['dark', 'cyberpunk', 'midnight', 'ember', 'nord', 'hacker'];
-      if (darkVariants.includes(theme)) {
-        document.body.classList.add('dark');
-        if (theme !== 'dark') {
-          document.body.classList.add(theme);
-        }
-      } else if (theme === 'rose') {
-        document.body.classList.add('rose');
-      }
-      // light theme has no classes (default)
+      applyThemeClasses(theme);
     },
 
     // Legacy mutations for backward compatibility
@@ -314,16 +364,12 @@ export default {
     async initTheme({ commit, state, dispatch }) {
       // Apply CSS classes IMMEDIATELY from localStorage state (no async dependency)
       // This prevents theme flash while IndexedDB loads background images
-      document.body.classList.remove('dark', 'cyberpunk', 'midnight', 'ember', 'nord', 'hacker', 'rose');
-      const darkVariants = ['dark', 'cyberpunk', 'midnight', 'ember', 'nord', 'hacker'];
-      if (darkVariants.includes(state.currentTheme)) {
-        document.body.classList.add('dark');
-        if (state.currentTheme !== 'dark') {
-          document.body.classList.add(state.currentTheme);
-        }
-      } else if (state.currentTheme === 'rose') {
-        document.body.classList.add('rose');
-      }
+      applyThemeClasses(state.currentTheme);
+      commit('SET_DARK_MODE', isDarkFace(state.currentTheme));
+      watchSystemScheme(
+        () => state.currentTheme,
+        (theme) => commit('SET_DARK_MODE', isDarkFace(theme)),
+      );
 
       // Initialize greyscale and visual settings synchronously
       document.documentElement.classList.toggle('greyscale', state.isGreyscaleMode);

--- a/frontend/src/store/app/theme.systemFace.spec.js
+++ b/frontend/src/store/app/theme.systemFace.spec.js
@@ -1,0 +1,170 @@
+// A theme that carries BOTH faces has to answer two questions the other themes
+// never raise: which face right now, and who decides.
+//
+// The desktop decides by default. But `prefers-color-scheme` answers "light"
+// forever on a desktop that has no day/night switch at all, so following it can
+// never be the only mechanism -- those users would be locked out of the dark
+// face with no control that reaches it. An explicit face outranks the desktop,
+// and re-picking the theme hands control back.
+//
+// If any of these go red, one of those two is broken.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createStore } from 'vuex';
+
+vi.mock('../../utils/mediaStorage.js', () => ({
+  mediaStorage: {
+    setItem: vi.fn().mockResolvedValue(undefined),
+    getItem: vi.fn().mockResolvedValue(null),
+    removeItem: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// theme.js reads localStorage at MODULE LOAD to build initial state, so both
+// stubs have to exist before the dynamic import below.
+const stored = new Map();
+Object.defineProperty(globalThis, 'localStorage', {
+  writable: true,
+  value: {
+    getItem: vi.fn((k) => (stored.has(k) ? stored.get(k) : null)),
+    setItem: vi.fn((k, v) => stored.set(k, String(v))),
+    removeItem: vi.fn((k) => stored.delete(k)),
+    clear: vi.fn(() => stored.clear()),
+  },
+});
+
+let desktopPrefersDark = false;
+const schemeListeners = [];
+Object.defineProperty(globalThis.window, 'matchMedia', {
+  writable: true,
+  value: vi.fn((query) => ({
+    media: query,
+    get matches() {
+      return query.includes('dark') && desktopPrefersDark;
+    },
+    addEventListener: (_event, handler) => schemeListeners.push(handler),
+    removeEventListener: vi.fn(),
+  })),
+});
+/** Fire a desktop day/night flip at whoever is listening. */
+const flipDesktopTo = (dark) => {
+  desktopPrefersDark = dark;
+  for (const handler of schemeListeners) handler({ matches: dark });
+};
+
+const { default: themeModule } = await import('./theme.js');
+const BASE_STATE = structuredClone(themeModule.state);
+const makeStore = () => createStore({
+  modules: { theme: { ...themeModule, namespaced: true, state: structuredClone(BASE_STATE) } },
+});
+
+const faceOf = () => (document.body.classList.contains('dark') ? 'dark' : 'light');
+
+beforeEach(() => {
+  stored.clear();
+  document.body.className = '';
+  desktopPrefersDark = false;
+});
+
+describe('a theme with two faces', () => {
+  it('takes its face from the desktop', () => {
+    const store = makeStore();
+
+    desktopPrefersDark = true;
+    store.commit('theme/SET_THEME', 'everforest');
+    expect(document.body.classList.contains('everforest')).toBe(true);
+    expect(faceOf()).toBe('dark');
+    expect(store.state.theme.isDarkMode).toBe(true);
+
+    desktopPrefersDark = false;
+    store.commit('theme/SET_THEME', 'everforest');
+    expect(document.body.classList.contains('everforest')).toBe(true);
+    expect(faceOf()).toBe('light');
+    expect(store.state.theme.isDarkMode).toBe(false);
+  });
+
+  it('lets a desktop with no dark mode reach the dark face anyway', () => {
+    const store = makeStore();
+    store.commit('theme/SET_THEME', 'everforest');
+    expect(faceOf()).toBe('light');
+
+    // The one control such a user has. It must stick, not flip a class back.
+    store.dispatch('theme/toggleDarkMode');
+    expect(faceOf()).toBe('dark');
+    expect(store.state.theme.themeFace).toBe('dark');
+    expect(store.state.theme.isDarkMode).toBe(true);
+    expect(stored.get('themeFace')).toBe('dark');
+  });
+
+  // The desktop watcher is registered once, by initTheme, and closes over that store's state --
+  // so both halves of this contract have to be driven through the same store.
+  it('follows a desktop flip on auto, and stops following once a face is pinned', async () => {
+    const store = makeStore();
+    store.commit('theme/SET_THEME', 'everforest');
+    await store.dispatch('theme/initTheme');
+    expect(schemeListeners.length).toBeGreaterThan(0); // anti-vacuity: something is listening
+
+    flipDesktopTo(true);
+    expect(faceOf()).toBe('dark');
+    expect(store.state.theme.isDarkMode).toBe(true);
+
+    flipDesktopTo(false);
+    expect(faceOf()).toBe('light');
+
+    store.commit('theme/SET_THEME_FACE', 'light');
+    flipDesktopTo(true);
+    expect(faceOf()).toBe('light');
+    expect(store.state.theme.themeFace).toBe('light');
+
+    store.commit('theme/SET_THEME_FACE', 'dark');
+    flipDesktopTo(false);
+    expect(faceOf()).toBe('dark');
+  });
+
+  it('hands control back to the desktop when the theme is picked again', () => {
+    const store = makeStore();
+    store.commit('theme/SET_THEME', 'everforest');
+    store.commit('theme/SET_THEME_FACE', 'dark');
+    expect(faceOf()).toBe('dark');
+
+    desktopPrefersDark = false;
+    store.commit('theme/SET_THEME', 'everforest');
+
+    expect(store.state.theme.themeFace).toBe('auto');
+    expect(faceOf()).toBe('light');
+  });
+
+  it('refuses a face it does not recognise rather than storing it', () => {
+    const store = makeStore();
+    store.commit('theme/SET_THEME', 'everforest');
+    store.commit('theme/SET_THEME_FACE', 'chartreuse');
+    expect(store.state.theme.themeFace).toBe('auto');
+  });
+});
+
+describe('the single-face themes are untouched by any of it', () => {
+  it('still resolve from the theme name alone', () => {
+    const store = makeStore();
+    desktopPrefersDark = false;
+
+    store.commit('theme/SET_THEME', 'nord');
+    expect(document.body.classList.contains('nord')).toBe(true);
+    expect(faceOf()).toBe('dark');
+    expect(store.state.theme.isDarkMode).toBe(true);
+
+    store.commit('theme/SET_THEME', 'light');
+    expect(document.body.className).toBe('');
+    expect(store.state.theme.isDarkMode).toBe(false);
+
+    store.commit('theme/SET_THEME', 'rose');
+    expect(document.body.classList.contains('rose')).toBe(true);
+    expect(faceOf()).toBe('light');
+  });
+
+  it('still toggle dark mode the legacy way', () => {
+    const store = makeStore();
+    store.commit('theme/SET_THEME', 'light');
+    store.dispatch('theme/toggleDarkMode');
+    expect(store.state.theme.isDarkMode).toBe(true);
+    expect(store.state.theme.themeFace).toBe('auto');
+  });
+});

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -27,6 +27,8 @@
 @import './themes/_nord.css';
 @import './themes/_rose.css';
 @import './themes/_hacker.css';
+/* After _light.css on purpose: the light face ties on specificity and wins by order. */
+@import './themes/_everforest.css';
 /* Semantic role-named tokens. MUST load last: resolves equal-specificity ties
    against the per-theme blocks above. */
 @import './themes/_semantic.css';

--- a/frontend/src/styles/themes/_everforest.css
+++ b/frontend/src/styles/themes/_everforest.css
@@ -1,0 +1,172 @@
+/* EVERFOREST THEME - Follows the desktop between day and night.
+ *
+ * Unlike the other themes, `everforest` is a single id with two faces. The store adds `.dark`
+ * alongside `.everforest` when the desktop asks for a dark colour scheme, so this one theme
+ * tracks the system the way the terminal and the desktop shell already do.
+ *
+ * The dark face rides `body.dark` and the light face rides the default light base. The light
+ * selector carries `:not(.dark)` so it matches `_light.css`'s specificity, and this file is
+ * imported after it, so equal weight resolves in source order to the values below.
+ *
+ * Palette: Everforest Dark Hard and Everforest Light Medium, the same two the terminal uses.
+ */
+
+body.dark.everforest {
+  --color-background: #1e2326;
+  --color-background-rgb: 30, 35, 38;
+
+  /* Background hierarchy — Everforest bg0 through bg5 */
+  --color-black-navy: var(--color-background); /* alias, not a copy — see themeCanvas.spec.js */
+  --color-ultra-dark-navy: #232a2e;
+  --color-dark-navy: #272e33;
+  --color-navy: #2e383c;
+  --color-dull-navy: #374145;
+  --color-duller-navy: #4f585e;
+
+  /* Text hierarchy — Everforest greys against the tan foreground */
+  --color-med-navy: #859289;
+  --color-light-med-navy: #d3c6aa;
+  --color-light-navy: #9da9a0;
+  --color-bright-light-navy: #7a8478;
+  --color-ultra-light-navy: #2e383c;
+  --color-dull-white: #d3c6aa;
+  --color-white: #f2efdf;
+
+  /* Accent colors — the terminal's own palette, so a card reads like its output */
+  --color-green: #a7c080;
+  --color-blue: #7fbbb3;
+  --color-pink: #d699b6;
+  --color-red: #e67e80;
+  --color-yellow: #dbbc7f;
+  --color-orange: #e69875;
+  --color-indigo: #d699b6;
+  --color-violet: #d699b6;
+
+  /* Semantic colors */
+  --color-light-green: #d3c6aa;
+  --color-primary: #a7c080;
+  --color-secondary: #7fbbb3;
+  --svg-gradient-start: #a7c080;
+  --svg-gradient-end: #7fbbb3;
+
+  /* Overlays */
+  --color-popup: rgba(35, 42, 46, 0.95);
+  --color-lighter-0: rgba(211, 198, 170, 0.06);
+  --color-lighter-1: rgba(211, 198, 170, 0.1);
+  --color-lighter-2: rgba(211, 198, 170, 0.18);
+  --color-lighter-3: rgba(211, 198, 170, 0.3);
+  --color-darker-0: rgba(0, 0, 0, 0.2);
+  --color-darker-1: rgba(0, 0, 0, 0.3);
+  --color-darker-2: rgba(0, 0, 0, 0.45);
+  --color-darker-3: rgba(0, 0, 0, 0.6);
+  --color-dark-0: rgba(0, 0, 0, 0.2);
+  --color-dark-1: rgba(0, 0, 0, 0.3);
+  --color-dark-2: rgba(0, 0, 0, 0.45);
+  --color-dark-3: rgba(0, 0, 0, 0.6);
+
+  /* Terminal */
+  --terminal-border-color: #374145;
+  --terminal-border-color-light: #4f585e;
+  --terminal-muted-color: #374145;
+
+  /* Text */
+  --color-text: #d3c6aa;
+  --color-text-muted: #9da9a0;
+  --color-text-secondary: #a6b0a0;
+  --color-text-dull: #4f585e;
+
+  /* RGB components */
+  --green-rgb: 167, 192, 128;
+  --blue-rgb: 127, 187, 179;
+  --pink-rgb: 214, 153, 182;
+  --red-rgb: 230, 126, 128;
+  --yellow-rgb: 219, 188, 127;
+  --indigo-rgb: 214, 153, 182;
+  --primary-rgb: 167, 192, 128;
+}
+
+body.everforest:not(.dark) {
+  --color-background: #efebd4;
+  --color-background-rgb: 239, 235, 212;
+
+  /* Background hierarchy — light warm parchment, raised surfaces lighter */
+  --color-black-navy: var(--color-background); /* alias, not a copy — see themeCanvas.spec.js */
+  --color-ultra-dark-navy: #fdf6e3;
+  --color-dark-navy: #f4f0d9;
+  --color-navy: #fdf6e3;
+  --color-dull-navy: #e6e2cc;
+  --color-duller-navy: #bdc3af;
+
+  /* Text hierarchy — dark slate greens */
+  --color-med-navy: #829181;
+  --color-light-med-navy: #4f585e;
+  --color-light-navy: #e0dcc7;
+  --color-bright-light-navy: #d3cfbb;
+  --color-ultra-light-navy: #fdf6e3;
+  --color-dull-white: #5c6a72;
+  --color-white: #fdf6e3;
+
+  /* Accent colors — Everforest's bright light-mode set, dark enough to read on parchment */
+  --color-green: #8da101;
+  --color-blue: #3a94c5;
+  --color-pink: #df69ba;
+  --color-red: #f85552;
+  --color-yellow: #dfa000;
+  --color-orange: #f57d26;
+  --color-indigo: #df69ba;
+  --color-violet: #df69ba;
+
+  /* Semantic colors */
+  --color-light-green: #5c6a72;
+  --color-primary: #8da101;
+  --color-secondary: #3a94c5;
+  --svg-gradient-start: #8da101;
+  --svg-gradient-end: #3a94c5;
+
+  /* Overlays */
+  --color-popup: rgba(244, 240, 217, 0.95);
+  --color-darker-0: rgba(92, 106, 114, 0.06);
+  --color-darker-1: rgba(92, 106, 114, 0.1);
+  --color-darker-2: rgba(92, 106, 114, 0.18);
+  --color-darker-3: rgba(92, 106, 114, 0.3);
+  --color-lighter-0: rgba(253, 246, 227, 0.3);
+  --color-lighter-1: rgba(253, 246, 227, 0.5);
+  --color-lighter-2: rgba(253, 246, 227, 0.7);
+  --color-lighter-3: rgba(253, 246, 227, 0.9);
+  --color-dark-0: rgba(92, 106, 114, 0.06);
+  --color-dark-1: rgba(92, 106, 114, 0.1);
+  --color-dark-2: rgba(92, 106, 114, 0.18);
+  --color-dark-3: rgba(92, 106, 114, 0.3);
+
+  /* Terminal */
+  --terminal-width: 100%;
+  --terminal-height: 100%;
+  --terminal-border-radius: 0;
+  --terminal-border-color: #e0dcc7;
+  --terminal-border-color-light: #d3cfbb;
+  --terminal-screen-lines: 0.125;
+  --terminal-box-shadow: none;
+  --terminal-muted-color: #e0dcc7;
+
+  /* Text — each tier one step darker than Everforest Light's own #5c6a72 foreground.
+     secondaryInkContrast.spec.js composites --color-text at the dimming alphas this codebase
+     uses (down to 0.78) over BOTH the page and the raised card; #5c6a72 lands at 3.11:1 and
+     #4f585e at 3.75:1, so the readable ink here is the darker slate #374145 (4.90:1 worst case). */
+  --color-text: #374145;
+  --color-text-muted: #4f585e;
+  --color-text-secondary: #5c6a72;
+  --color-text-dull: #bdc3af;
+
+  /* RGB components */
+  --green-rgb: 141, 161, 1;
+  --blue-rgb: 58, 148, 197;
+  --pink-rgb: 223, 105, 186;
+  --red-rgb: 248, 85, 82;
+  --yellow-rgb: 223, 160, 0;
+  --indigo-rgb: 223, 105, 186;
+  --primary-rgb: 141, 161, 1;
+
+  font-size: var(--font-size-sm);
+  line-height: 1.25;
+  color: var(--color-text);
+}

--- a/frontend/src/views/Docs/Docs.vue
+++ b/frontend/src/views/Docs/Docs.vue
@@ -88,8 +88,9 @@ export default {
 
     // detect if dark mode so we can change doc images
     const updateDarkMode = () => {
-      const theme = localStorage.getItem('currentTheme') || 'dark';
-      isDarkMode.value = !['light', 'rose'].includes(theme);
+      // The store keeps this class on <body> for every theme, including the ones that follow
+      // the desktop, so reading it beats re-deriving the rule from the theme name.
+      isDarkMode.value = document.body.classList.contains('dark');
     };
 
     const getConverter = async () => {

--- a/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/ThemeSelector/ThemeSelector.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/ThemeSelector/ThemeSelector.vue
@@ -143,6 +143,7 @@ export default {
         { id: 'ember', name: 'Ember', icon: 'fas fa-fire' },
         { id: 'nord', name: 'Nord', icon: 'fas fa-snowflake' },
         { id: 'hacker', name: 'Hacker', icon: 'fas fa-terminal' },
+        { id: 'everforest', name: 'Everforest', icon: 'fas fa-tree' },
         { id: 'light', name: 'Light', icon: 'fas fa-sun' },
         { id: 'rose', name: 'Rose', icon: 'fas fa-heart' },
       ],


### PR DESCRIPTION
## What

Adds **Everforest**, the first theme that follows the desktop's colour scheme
instead of pinning one face, and de-duplicates the theme-class logic it had to
touch to get there.

## Why

Every existing theme is one fixed palette. A terminal-shaped app tends to sit
next to a terminal that already flips at sunrise and sunset, and the app
staying dark at noon is the thing you notice. Everforest ships both faces, so
`everforest` is one entry in the picker that renders light by day and dark by
night.

## How

`everforest` is a single theme id with two faces. The store adds `.dark`
alongside `.everforest` when `prefers-color-scheme` is dark, and removes it on
the flip.

Three pieces of duplication were in the way, and each is now single-sourced:

| Before | After |
| --- | --- |
| `SET_THEME` and `initTheme` each carried their own copy of the body-class block | `applyThemeClasses(theme)` |
| `isDarkMode` derived inline from `!['light','rose'].includes(theme)`, in three places | `isDarkFace(theme)` |
| `Docs.vue` re-derived light/dark from the theme name to choose image variants | reads the `.dark` class the store already maintains |

That last one is why the de-duplication is not cosmetic: `Docs.vue` reading the
theme *name* cannot ever be right for a theme whose face depends on the
desktop. Reading the class the store owns makes it right for every theme,
including the ones added after this.

A `matchMedia('(prefers-color-scheme: dark)')` listener re-applies the classes
**and** the `isDarkMode` flag on a day/night flip. The listener is registered
once and is a no-op unless the active theme follows the system.

## Following the desktop is not enough on its own

A desktop with no day/night switch answers `prefers-color-scheme: light`
forever. If following the system were the only mechanism, those users would
reach Everforest's light face and nothing else — no control in the UI would get
them to the dark one. So the face is a preference, not just an observation:

`themeFace` is `'auto' | 'light' | 'dark'`, persisted alongside the theme.
`'auto'` asks the desktop. The other two outrank it, and the watcher stands
down while one is set.

The control is the dark-mode toggle **already** in Settings. It used to flip
the `.dark` class directly, which for a system-following theme the next
re-apply silently undid; it now pins the face. Re-picking the theme in the
picker resets to `'auto'` — the way back, without a third control in the UI.

Single-face themes keep their existing behaviour on both paths, and
`theme.systemFace.spec.js` covers that so it stays true.

## The light ink is not Everforest's own foreground

Everforest Light Medium's foreground is `#5c6a72`. This codebase dims body copy
with `color: var(--color-text); opacity: 0.78 … 0.85`, and
`secondaryInkContrast.spec.js` composites that over both the page fill and the
raised card:

| ink | worst pairing |
| --- | --- |
| `#5c6a72` (Everforest Light fg) | 3.11:1 |
| `#4f585e` | 3.75:1 |
| **`#374145`** (shipped) | **4.90:1** |

So the light face uses the darker slate. With Everforest's own foreground the
gate failed across the marketplace, schema, plan and stat surfaces; with
`#374145` it is green.

## Tests

`npm --prefix frontend test -- --run src/styles src/store/app/theme.*.spec.js`
→ **13 files, 142 tests, all passing**, including `themeCanvas`,
`secondaryInkContrast`, `themeTokens`, `themeSurfaces`, `onFillContrast` and
the new `theme.systemFace.spec.js` (7 tests, with an anti-vacuity assertion
that the desktop watcher is actually registered before the flip is fired).

The full frontend suite reports 93 failed files / 848 failed tests both **with
and without** this branch — identical counts, measured against `origin/main` in
a clean worktree. They come from `user.config.js` reading `localStorage` at
module scope under the node environment, and are untouched by this change.

## Known boundary, worth a look on your side

`secondaryInkContrast.spec.js` resolves a theme's tokens with "last declaration
in the file wins". A one-file two-face theme therefore only ever gets its
*second* block measured — here, the light face. The dark face is unmeasured by
that guard. I checked it by hand against the same maths: worst pairing 5.02:1,
comfortably over AA. But the guard has a blind spot for this theme shape, and
it is yours to decide how to close.
