### PR TITLE
feat(providers): add Atlas Cloud template

### DIFF
--- a/backend/src/services/ai/providerConfigs.js
+++ b/backend/src/services/ai/providerConfigs.js
@@ -1297,6 +1297,17 @@ const PROVIDER_CONFIGS = [
 
 export const PROVIDER_TEMPLATES = [
   {
+    key: 'atlascloud',
+    name: 'Atlas Cloud',
+    baseURL: 'https://api.atlascloud.ai/v1',
+    defaultModel: 'qwen/qwen3.5-397b-a17b',
+    supportsTools: true,
+    supportsVision: true,
+    supportsStreaming: true,
+    description:
+      'Atlas Cloud - OpenAI-compatible access to text and multimodal models',
+  },
+  {
     key: 'cline-pass',
     name: 'Cline Pass',
     baseURL: 'https://api.cline.bot/api/v1',

--- a/backend/tests/providers/providerConfigs.test.js
+++ b/backend/tests/providers/providerConfigs.test.js
@@ -162,4 +162,18 @@ describe('PROVIDER_TEMPLATES', () => {
       expect(builtInKeys.has(template.key)).toBe(false);
     }
   });
+
+  test('Atlas Cloud template uses its OpenAI-compatible endpoint', () => {
+    const atlasCloud = templates.find(
+      (template) => template.key === 'atlascloud'
+    );
+    expect(atlasCloud).toMatchObject({
+      name: 'Atlas Cloud',
+      baseURL: 'https://api.atlascloud.ai/v1',
+      defaultModel: 'qwen/qwen3.5-397b-a17b',
+      supportsTools: true,
+      supportsVision: true,
+      supportsStreaming: true,
+    });
+  });
 });

--- a/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/ProviderSelector/CustomProviderDialog.spec.js
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/ProviderSelector/CustomProviderDialog.spec.js
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import source from './CustomProviderDialog.vue?raw';
+import CustomProviderDialog from './CustomProviderDialog.vue';
+
+let wrapper;
+afterEach(() => { wrapper?.unmount(); vi.unstubAllGlobals(); });
+describe('custom provider template menu', () => {
+  it('opens above the dialog and selecting Atlas fills the existing form', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ templates: [
+      { key: 'atlascloud', name: 'Atlas Cloud', baseURL: 'https://api.atlascloud.ai/v1', defaultModel: 'qwen/qwen3.5-397b-a17b', supportsTools: true, supportsVision: true, supportsStreaming: true },
+    ] }) }));
+    wrapper = mount(CustomProviderDialog, { attachTo: document.body, props: { isOpen: true }, global: { plugins: [createStore({})], directives: { tooltip: {} } } });
+    await flushPromises();
+    const trigger = document.querySelector('.template-select .selected');
+    trigger.click();
+    await flushPromises();
+    const menu = document.querySelector('.options-container');
+    expect(menu).not.toBeNull();
+    const overlayZ = Number(source.match(/\.dialog-overlay\s*\{[^}]*z-index:\s*(\d+)/s)[1]);
+    expect(Number(menu.style.zIndex)).toBeGreaterThan(overlayZ);
+    expect(menu.textContent).toContain('Atlas Cloud');
+    menu.querySelector('[role="option"]').click();
+    await flushPromises();
+    expect(document.querySelector('#provider-name').value).toBe('Atlas Cloud');
+    expect(document.querySelector('#base-url').value).toBe('https://api.atlascloud.ai/v1');
+    await vi.waitFor(() => expect(document.querySelector('.options-container')).toBeNull());
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/ProviderSelector/CustomProviderDialog.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Settings/components/ProviderSelector/CustomProviderDialog.vue
@@ -15,6 +15,7 @@
             <label for="template-select">Start from template</label>
             <CustomSelect
               class="template-select"
+              :z-index="10001"
               v-model="selectedTemplate"
               :disabled="isTesting || isSaving"
               placeholder="Custom (blank)"


### PR DESCRIPTION
## What problem this solves
AGNT supports custom OpenAI-compatible providers, but Atlas Cloud users currently need to enter the endpoint and capabilities manually. This adds an opt-in template that pre-fills the compatible endpoint and a current multimodal default model.

The change stays within the generic provider-template path and does not modify authentication, credential storage, or other restricted areas.

## Verification
- `npx --yes vitest@4.0.18 run backend/tests/providers/providerConfigs.test.js` (210 passed)
- `node --check backend/src/services/ai/providerConfigs.js`
- `node --check backend/tests/providers/providerConfigs.test.js`
- live `GET https://api.atlascloud.ai/v1/models` confirmed the default model and its tools, vision, and reasoning capabilities
- one live chat-completions request returned the exact expected response
