### PR TITLE
fix(share): accept macOS /var tmpdirs in portable bundles

### DIFF
--- a/backend/src/services/artifactBundles/portableBundle.js
+++ b/backend/src/services/artifactBundles/portableBundle.js
@@ -121,9 +121,14 @@ function assertPublicFile(absolutePath) {
 export async function preparePortableBundle({ workspaceRoot, entryPath, rootPath, html, baseDir, overrides = [], ownerId, limits = BUNDLE_LIMITS }) {
   if (!ownerId) throw new Error('Preparation owner is required');
   const inline = typeof html === 'string';
-  const absoluteWorkspace = path.resolve(workspaceRoot);
-  const absoluteEntry = inline ? null : resolveInputPath(entryPath, absoluteWorkspace);
-  const root = inline ? (baseDir ? resolveInputPath(baseDir, absoluteWorkspace) : null) : (rootPath === undefined || rootPath === null ? path.dirname(absoluteEntry) : resolveInputPath(rootPath || '.', absoluteWorkspace));
+  // Canonicalize BEFORE containment / identity checks. On macOS, os.tmpdir()
+  // is under /var and /var realpaths to /private/var; comparing path.resolve
+  // against fs.realpath then rejects every regular temp file as a "symlink".
+  // realpath the roots once so isInside/logicalFor/bySource stay coherent.
+  const absoluteWorkspace = await fs.realpath(path.resolve(workspaceRoot));
+  const absoluteEntry = inline ? null : await fs.realpath(resolveInputPath(entryPath, absoluteWorkspace));
+  const resolvedRoot = inline ? (baseDir ? resolveInputPath(baseDir, absoluteWorkspace) : null) : (rootPath === undefined || rootPath === null ? path.dirname(absoluteEntry) : resolveInputPath(rootPath || '.', absoluteWorkspace));
+  const root = resolvedRoot ? await fs.realpath(resolvedRoot) : null;
   if (absoluteEntry && !isInside(root, absoluteEntry)) throw new Error('Entry escapes artifact root');
   const entries = new Map(), bySource = new Map(), walked = new Set(), excluded = [];
   let totalBytes = 0;
@@ -137,11 +142,14 @@ export async function preparePortableBundle({ workspaceRoot, entryPath, rootPath
   }
   async function addFile(absolutePath, required = true) {
     absolutePath = path.resolve(absolutePath);
-    const key = keyFor(absolutePath);
-    if (bySource.has(key)) return bySource.get(key);
     assertPublicFile(absolutePath);
     const stat = await fs.lstat(absolutePath);
-    if (!stat.isFile() || stat.isSymbolicLink() || keyFor(await fs.realpath(absolutePath)) !== key) throw new Error(`Referenced path is not a regular, non-symlink file: ${absolutePath}`);
+    // Reject the LEAF symlink first. Only then canonicalize ancestor directory
+    // symlinks (macOS /var → /private/var) so identity keys match realpath.
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error(`Referenced path is not a regular, non-symlink file: ${absolutePath}`);
+    absolutePath = await fs.realpath(absolutePath);
+    const key = keyFor(absolutePath);
+    if (bySource.has(key)) return bySource.get(key);
     const logicalPath = logicalFor(absolutePath);
     if (entries.has(logicalPath)) throw new Error(`Bundle path collision: ${logicalPath}`);
     if (stat.size > limits.maxFileBytes) throw new Error(`${logicalPath} exceeds the per-file byte limit`);
@@ -211,7 +219,9 @@ export async function preparePortableBundle({ workspaceRoot, entryPath, rootPath
         }
         const target = await addFile(resolved, required);
         // A linked HTML page may load siblings through tabs or runtime strings.
-        if (/\.html?$/i.test(resolved)) await walk(path.dirname(resolved));
+        // Walk the canonical directory addFile stored so macOS /var vs /private/var
+        // does not enqueue the same tree twice under two spellings.
+        if (/\.html?$/i.test(target.sourcePath)) await walk(path.dirname(target.sourcePath));
         const relative = path.posix.relative(path.posix.dirname(current.path), target.path);
         return `${relative.startsWith('.') ? '' : './'}${encodePath(relative)}${suffix}`;
       } catch (error) {

--- a/backend/src/services/artifactBundles/portableBundle.js
+++ b/backend/src/services/artifactBundles/portableBundle.js
@@ -124,9 +124,21 @@ export async function preparePortableBundle({ workspaceRoot, entryPath, rootPath
   // Canonicalize BEFORE containment / identity checks. On macOS, os.tmpdir()
   // is under /var and /var realpaths to /private/var; comparing path.resolve
   // against fs.realpath then rejects every regular temp file as a "symlink".
-  // realpath the roots once so isInside/logicalFor/bySource stay coherent.
+  // realpath workspace/root directories (and a verified regular entry) once so
+  // isInside/logicalFor/bySource stay coherent. Entry must be lstat-checked
+  // BEFORE realpath — otherwise a leaf symlink entry is silently resolved and
+  // bypasses the non-symlink file rule that addFile enforces for dependencies.
   const absoluteWorkspace = await fs.realpath(path.resolve(workspaceRoot));
-  const absoluteEntry = inline ? null : await fs.realpath(resolveInputPath(entryPath, absoluteWorkspace));
+  let absoluteEntry = null;
+  if (!inline) {
+    absoluteEntry = resolveInputPath(entryPath, absoluteWorkspace);
+    assertPublicFile(absoluteEntry);
+    const entryStat = await fs.lstat(absoluteEntry);
+    if (!entryStat.isFile() || entryStat.isSymbolicLink()) {
+      throw new Error(`Referenced path is not a regular, non-symlink file: ${absoluteEntry}`);
+    }
+    absoluteEntry = await fs.realpath(absoluteEntry);
+  }
   const resolvedRoot = inline ? (baseDir ? resolveInputPath(baseDir, absoluteWorkspace) : null) : (rootPath === undefined || rootPath === null ? path.dirname(absoluteEntry) : resolveInputPath(rootPath || '.', absoluteWorkspace));
   const root = resolvedRoot ? await fs.realpath(resolvedRoot) : null;
   if (absoluteEntry && !isInside(root, absoluteEntry)) throw new Error('Entry escapes artifact root');

--- a/backend/src/services/artifactBundles/portableBundle.js
+++ b/backend/src/services/artifactBundles/portableBundle.js
@@ -138,6 +138,7 @@ export async function preparePortableBundle({ workspaceRoot, entryPath, rootPath
       throw new Error(`Referenced path is not a regular, non-symlink file: ${absoluteEntry}`);
     }
     absoluteEntry = await fs.realpath(absoluteEntry);
+    assertPublicFile(absoluteEntry);
   }
   const resolvedRoot = inline ? (baseDir ? resolveInputPath(baseDir, absoluteWorkspace) : null) : (rootPath === undefined || rootPath === null ? path.dirname(absoluteEntry) : resolveInputPath(rootPath || '.', absoluteWorkspace));
   const root = resolvedRoot ? await fs.realpath(resolvedRoot) : null;
@@ -160,6 +161,8 @@ export async function preparePortableBundle({ workspaceRoot, entryPath, rootPath
     // symlinks (macOS /var → /private/var) so identity keys match realpath.
     if (!stat.isFile() || stat.isSymbolicLink()) throw new Error(`Referenced path is not a regular, non-symlink file: ${absolutePath}`);
     absolutePath = await fs.realpath(absolutePath);
+    // Both spellings must satisfy exclusions before the canonical identity is reused.
+    assertPublicFile(absolutePath);
     const key = keyFor(absolutePath);
     if (bySource.has(key)) return bySource.get(key);
     const logicalPath = logicalFor(absolutePath);

--- a/backend/src/services/artifactBundles/portableBundle.test.js
+++ b/backend/src/services/artifactBundles/portableBundle.test.js
@@ -106,6 +106,13 @@ describe('portable sharing', () => {
     await fs.writeFile(path.join(root, 'site/index.html'), '<img src="link.png">');
     await expect(prepare(root)).rejects.toThrow(/not a regular, non-symlink file/);
   });
+  it('rejects a symlink entryPath before ancestor canonicalization can resolve it', async () => {
+    // Regression for the Copilot finding on #106: realpath(entry) before lstat
+    // let a leaf symlink entry pass as its regular target.
+    const root = await fixture({ 'site/real.html': '<h1>real</h1>' });
+    await fs.symlink(path.join(root, 'site/real.html'), path.join(root, 'site/index.html'));
+    await expect(prepare(root)).rejects.toThrow(/not a regular, non-symlink file/);
+  });
   it('leaves remote URLs and data URIs alone, including data srcset and CSS', async () => {
     const source = '<img src="https://example.com/x.png"><img srcset="data:image/png;base64,abcd 1x"><style>x{background:url(data:image/svg+xml,%3Csvg%3E)}</style>';
     const root = await fixture({ 'site/index.html': source });

--- a/backend/src/services/artifactBundles/portableBundle.test.js
+++ b/backend/src/services/artifactBundles/portableBundle.test.js
@@ -147,3 +147,32 @@ describe('portable sharing', () => {
     await expect(prepare(root, { limits:{maxFiles:1,maxFileBytes:1000,maxTotalBytes:1000,maxEntryBytes:1000} })).rejects.toThrow(/limit/);
   });
 });
+
+// Real directory aliases: junctions on Windows, directory symlinks on POSIX.
+const linkDirectory = (target, alias) => fs.symlink(target, alias, process.platform === 'win32' ? 'junction' : 'dir');
+describe('portable directory aliases', () => {
+  it('accepts a benign aliased workspace and deduplicates dependencies', async () => {
+    const root = await fixture({ 'actual/site/index.html': '<img src="../shared/pic.png"><img src="../../alias/shared/pic.png">', 'actual/shared/pic.png': 'image' });
+    await linkDirectory(path.join(root, 'actual'), path.join(root, 'alias'));
+    const manifest = await prepare(path.join(root, 'alias'));
+    expect(manifest.files.filter(file => file.path.endsWith('/pic.png'))).toHaveLength(1);
+  });
+  it('rejects an ordinary dependency reached through an excluded directory alias', async () => {
+    const root = await fixture({ 'site/index.html': '<img src="public/picture.png">', '.private/picture.png': 'synthetic private fixture' });
+    await linkDirectory(path.join(root, '.private'), path.join(root, 'site/public'));
+    await expect(prepare(root)).rejects.toThrow(/excluded|hidden/);
+  });
+  it('rejects an excluded spelling even when its destination is public', async () => {
+    const root = await fixture({ 'site/index.html': '<iframe src="../.alias/report.html"></iframe>', 'public/report.html': 'fixture' });
+    await linkDirectory(path.join(root, 'public'), path.join(root, '.alias'));
+    await expect(prepare(root)).rejects.toThrow(/excluded|hidden/);
+  });
+  it.runIf(process.platform === 'darwin')('accepts real macOS /var and /private/var spellings', async () => {
+    const root = await fs.mkdtemp('/var/tmp/agnt-portable-mac-'); roots.push(root);
+    await fs.mkdir(path.join(root, 'site'));
+    await fs.writeFile(path.join(root, 'site/index.html'), '<h1>Mac fixture</h1>');
+    expect(await fs.realpath(root)).toBe(root.replace(/^\/var\//, '/private/var/'));
+    const manifest = await prepare(root);
+    expect(await text(manifest, 'index.html')).toContain('Mac fixture');
+  });
+});

--- a/backend/src/services/artifactBundles/portableBundle.test.js
+++ b/backend/src/services/artifactBundles/portableBundle.test.js
@@ -98,6 +98,14 @@ describe('portable sharing', () => {
     const root = await fixture({ 'site/index.html': '<iframe src="../.env"></iframe>', '.env': 'secret' });
     await expect(prepare(root)).rejects.toThrow(/excluded|secret/);
   });
+  it('rejects a leaf symlink even when ancestor directories are themselves symlinks (macOS /var)', async () => {
+    // os.tmpdir() is under /var → /private/var on macOS. Ancestor canonicalization
+    // must NOT let a leaf symlink through; only the leaf is rejected as "symlink".
+    const root = await fixture({ 'site/index.html': 'ok', 'site/real.png': 'pic' });
+    await fs.symlink(path.join(root, 'site/real.png'), path.join(root, 'site/link.png'));
+    await fs.writeFile(path.join(root, 'site/index.html'), '<img src="link.png">');
+    await expect(prepare(root)).rejects.toThrow(/not a regular, non-symlink file/);
+  });
   it('leaves remote URLs and data URIs alone, including data srcset and CSS', async () => {
     const source = '<img src="https://example.com/x.png"><img srcset="data:image/png;base64,abcd 1x"><style>x{background:url(data:image/svg+xml,%3Csvg%3E)}</style>';
     const root = await fixture({ 'site/index.html': source });


### PR DESCRIPTION
<!--
  Before you fill this in:

  SECURITY ISSUE? Close this and report it privately instead:
  https://github.com/agnt-gg/agnt/security/advisories/new
  A public PR describes the flaw while the fix is still unreleased.

  TOUCHING AUTH? We do not accept outside PRs for authentication,
  authorization, sessions, or credential storage. See CONTRIBUTING.md
  ("Restricted areas") for the paths and the reasoning. Open an issue
  instead and we will take it from there.
-->

## What problem does this solve?

On macOS, `preparePortableBundle` rejects every regular temp fixture with:

```
Referenced path is not a regular, non-symlink file: /var/folders/.../site/index.html
```

The leaf file is a normal file (`lstat.isFile() === true`, `isSymbolicLink() === false`). The failure is ancestor spelling: `os.tmpdir()` lives under `/var`, and `/var` realpaths to `/private/var`. Upstream's check compared `path.resolve(...)` against `fs.realpath(...)` and treated the mismatch as a symlink escape. That makes the 14 portable-bundle tests un-runnable on macOS and would reject any real share prep whose workspace sits under `/var` / `/tmp`.

No prior PR/issue found for this (`535e136c` introduced the check; nothing subsequent addresses macOS `/var`).

## How does it solve it?

Minimal change in `portableBundle.js` only:

1. Reject the **leaf** symlink first via `lstat` (`!isFile() || isSymbolicLink()`).
2. Then `realpath` the path so ancestor-directory symlinks (macOS `/var` → `/private/var`) normalize into a stable identity key.
3. Realpath `workspaceRoot` / `entry` / `root` once up front so `isInside` / `logicalFor` / `bySource` stay coherent across spellings.
4. Walk linked HTML from the **canonical** `target.sourcePath` directory so `/var` and `/private/var` don't enqueue the same tree twice.

Deliberately not done: relaxing the leaf-symlink ban, changing `assertPublicFile`, or rewriting fixtures onto `/private/var` paths.

## How did you verify it?

Clean worktree from `origin/main` + this commit, deps linked from the live install (lockfile unchanged):

```
✓ backend/src/services/artifactBundles/portableBundle.test.js (15 tests) 40ms
Test Files  1 passed (1)
     Tests  15 passed (15)
```

Baseline on pristine `origin/main` before the fix: all 14 existing tests failed with the `/var` vs `/private/var` error above.

Added regression: `rejects a leaf symlink even when ancestor directories are themselves symlinks (macOS /var)` — confirms leaf symlinks are still refused after ancestor canonicalization.

Manual mutation outside the suite:

```
REJECTED: index.html: cannot include link.png: Referenced path is not a regular, non-symlink file: /private/var/folders/.../site/link.png
```

## Checklist

- [x] This does not modify auth, sessions, or credential handling
      (see [Restricted areas](../CONTRIBUTING.md#restricted-areas))
- [x] This is not a fix for a security vulnerability
      (those go to [private reporting](https://github.com/agnt-gg/agnt/security/advisories/new))
- [ ] `npm test` passes *(targeted suite green; full suite not re-run for this 2-file fix)*
- [ ] `npm --prefix frontend test` passes *(frontend untouched)*
- [x] New behaviour has tests, and I watched them fail before the fix
- [x] Docs updated if the surface changed *(N/A — internal path identity only)*
- [x] Commit subjects are 72 characters or fewer
