### PR TITLE
chore: map local and GitHub author variants via .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,17 @@
+# .mailmap — canonical author/committer identities
+#
+# Re-labels historical commits WITHOUT rewriting them. No commit hash,
+# tree, parent or signature is touched; git simply substitutes the
+# canonical identity at display time in log / shortlog / blame.
+#
+# Format:  Canonical Name <canonical@email>  Commit Name <commit@email>
+#
+# ---------------------------------------------------------------------
+# Rimas committed as "Tom <tom@AI-Stack.local>" between 2026-07-26 and
+# 2026-07-31 (27 commits). That identity was auto-derived by git from the
+# macOS account name ("tom", RealName "Tom") and the hostname
+# ("AI-Stack") because no user.name / user.email was configured yet.
+# It is not a second contributor — it is the same person, same machine.
+# Fixed at source on 2026-07-31 by setting the global git identity.
+# ---------------------------------------------------------------------
+rimusz <rimusz@users.noreply.github.com> Tom <tom@AI-Stack.local>

--- a/.mailmap
+++ b/.mailmap
@@ -15,3 +15,15 @@
 # Fixed at source on 2026-07-31 by setting the global git identity.
 # ---------------------------------------------------------------------
 rimusz <rimusz@users.noreply.github.com> Tom <tom@AI-Stack.local>
+
+# ---------------------------------------------------------------------
+# Same person, same email, two display names: commits made from the CLI
+# are stamped "rimusz", while commits created by GitHub itself (squash /
+# merge of a PR) are stamped with the GitHub profile name "Rimantas
+# (Rimas) Mocevicius". Both already carry the canonical email, so this
+# line normalises the NAME only and discloses no new address.
+#
+# The single-identity form below maps by email alone, so any future
+# display-name variation on this address is normalised automatically.
+# ---------------------------------------------------------------------
+rimusz <rimusz@users.noreply.github.com>


### PR DESCRIPTION
<!--
  Before you fill this in:

  SECURITY ISSUE? Close this and report it privately instead:
  https://github.com/agnt-gg/agnt/security/advisories/new
  A public PR describes the flaw while the fix is still unreleased.

  TOUCHING AUTH? We do not accept outside PRs for authentication,
  authorization, sessions, or credential storage. See CONTRIBUTING.md
  ("Restricted areas") for the paths and the reasoning. Open an issue
  instead and we will take it from there.
-->

## What problem does this solve?

Shortlog / blame / log currently show two extra identities that are both me:

1. **`Tom <tom@AI-Stack.local>`** — 27 commits between 2026-07-26 and 2026-07-31. Auto-derived by git from the macOS account name + hostname before `user.name` / `user.email` were configured. Same person, same machine as `rimusz`.
2. **`Rimantas (Rimas) Mocevicius <rimusz@users.noreply.github.com>`** — GitHub's squash/merge stamp using the profile display name, while CLI commits use `rimusz` on the same email.

Neither is a second contributor. Without a `.mailmap`, contributor charts and `git shortlog` inflate the count.

No prior PR/issue found for this.

## How does it solve it?

Adds a `.mailmap` that re-labels those identities to `rimusz <rimusz@users.noreply.github.com>` at **display time only**. No commit hash, tree, parent, or signature is rewritten.

Two commits, one file (`+29`):

- `5fb4d65f` — map the auto-derived `Tom <tom@AI-Stack.local>` identity
- `f38f2242` — map the GitHub profile display-name variant by email

Deliberately **not** opened from `rimusz:main` — that tip also carries the portable-bundle fix already in #106. Head is `chore/mailmap-rimusz` at `f38f2242` so this PR stays mailmap-only.

## How did you verify it?

```
$ git log --oneline origin/main..chore/mailmap-rimusz
f38f2242 chore: map the GitHub profile name to rimusz
5fb4d65f chore: add .mailmap mapping the auto-derived Tom identity to rimusz

$ git diff --stat origin/main...chore/mailmap-rimusz
 .mailmap | 29 +++++++++++++++++++++++++++++
 1 file changed, 29 insertions(+)
```

Compare API: `ahead_by: 2`, `behind_by: 0`, only those two commits.

## Checklist

- [x] This does not modify auth, sessions, or credential handling
      (see [Restricted areas](../CONTRIBUTING.md#restricted-areas))
- [x] This is not a fix for a security vulnerability
      (those go to [private reporting](https://github.com/agnt-gg/agnt/security/advisories/new))
- [x] `npm test` passes *(N/A — `.mailmap` only, no code)*
- [x] `npm --prefix frontend test` passes *(N/A)*
- [x] New behaviour has tests, and I watched them fail before the fix *(N/A — display-time identity map)*
- [x] Docs updated if the surface changed *(self-documented in `.mailmap` comments)*
- [x] Commit subjects are 72 characters or fewer
