### PR TITLE
feat(worktrees): add read-only PR lifecycle planning

### DIFF
--- a/docs/WORKTREE_LIFECYCLE.md
+++ b/docs/WORKTREE_LIFECYCLE.md
@@ -1,0 +1,130 @@
+# PR-aware worktree lifecycle planning
+
+Tracking/design: [issue #123](https://github.com/agnt-gg/agnt/issues/123).
+
+## Design: plan first, never guess that a checkout is disposable
+
+Keep one canonical worktree per active PR. Start independent changes from fresh
+upstream main, reuse that worktree for revisions, and keep durable evidence
+outside it. Keep local main free of feature work. Updating main does not mean
+rebasing every open PR: update a PR base when conflicts, dependencies or CI
+require it. After a merge, inspect and retire the finished work instead of
+rebasing it.
+
+GitHub deleting a remote branch, `fetch.prune`, and `git worktree prune` do not
+remove local branches and existing worktree directories. A clean worktree can
+still contain ignored evidence, serve a live process, or supply dependencies to
+another worktree. A squash/rebase merge may not preserve local ancestry.
+
+This phase adds **read-only planning** to the existing `npm run wt` entry point.
+It does not implement a scheduler, cleanup hook, deletion executor, automatic
+rebase, main update, process killer or permission escalation. No plan is a
+capability token. `authorized: false` means the planner grants no authorization;
+it does not revoke a human's separately recorded approval.
+
+## Commands
+
+Requirements: Node 20+, Git supporting `worktree list --porcelain -z`, and the
+GitHub CLI (`gh`) configured through its normal authentication. No credentials
+are discovered, printed, minted, stored or passed by this helper.
+
+```sh
+npm run wt -- doctor --github agnt-gg/agnt --author YOUR_GITHUB_LOGIN
+npm run wt -- sync --dry-run --github agnt-gg/agnt --author YOUR_GITHUB_LOGIN
+npm run wt -- retire --dry-run --pr 123 --worktree /absolute/worktree/path --github agnt-gg/agnt --author YOUR_GITHUB_LOGIN
+```
+
+Use `--repo /path/to/checkout` to inspect another local checkout in the same
+invocation. The default is the current directory; registered worktrees from
+its Git common directory are inventoried, including paths outside `.worktrees/`.
+`doctor --help`, `sync --help` and `retire --help` work offline outside Git.
+`npm --silent run wt -- ...` suppresses npm's banner for machine-readable JSON.
+
+Explicit repository and author flags prevent accidentally selecting another
+contributor's PR. The upstream must be GitHub.com `origin`, with local
+`origin/main` and base `main`; HTTPS and standard Git SSH origins are accepted.
+Other remote layouts, GitHub Enterprise and base names are not yet supported.
+A GitHub/base failure is unknown, not an empty successful inventory. Fetch
+upstream separately when authorized if local origin/main is stale; the planner
+never fetches, including lazy fetching of missing objects.
+
+| Command | Result |
+| --- | --- |
+| `doctor` | Worktrees, current exact-head PRs, local state, link and process observations |
+| `sync --dry-run` | Full main/upstream SHAs, ahead/behind, and proposed fast-forward strategy; divergence stops the plan |
+| `retire --dry-run` | Exact worktree/branch/HEAD, selected merged PR, patch-equivalence signal and blockers |
+
+All results have `readOnly: true`, `canExecute: false`. Exit 0 means the report
+or plan was produced without blockers; exit 1 means invalid arguments or a
+collection failure; exit 2 means blockers, including incomplete process
+visibility in an otherwise successful doctor report. Retire always requires
+external owner/consumer review, so even an otherwise clear retirement plan
+exits 2. Read the JSON rather than interpreting any exit as permission to delete.
+
+## Retirement evidence
+
+The planner refuses to clear primary, dirty, untracked, ignored, locked,
+in-progress, active-process or dependency-provider worktrees. All ignored paths
+need explicit disposition: it does not assume every `node_modules` path is a
+safe symlink or every test result is disposable. The named branch must match
+the selected PR; detached copies require an exact PR-head match. Local branches
+renamed for publication require manual reconciliation rather than guesswork.
+
+The selected PR must be merged into main. `git cherry` provides a conservative
+ordinary-commit patch-equivalence signal against origin/main, not final proof
+of semantic integration. Local merge commits absent upstream are blockers
+because cherry omits merge-resolution changes. Squashed multi-commit branches,
+rewritten PRs and subsequent upstream changes may require manual blob/diff
+review. Do not replace this review with `git branch -D`.
+
+Before any later user-approved retirement: refresh exact identities, verify
+recoverability of commits/local evidence, resolve all blockers and owner leases,
+review external consumers, then remove only the approved directory/local ref.
+Never delete a shared parent evidence directory or follow a dependency symlink.
+Unknown or stale evidence requires another observation, not a force flag.
+
+## Observation limits
+
+- Git queries disable optional index locks and fsmonitor. They do not write
+  refs/index, prune registrations or refresh upstream. Beginning/end worktree,
+  main and upstream ref checks detect ref drift but do not create an atomic
+  filesystem snapshot. Files and processes can change during or after inspection.
+- Subprocesses have a 15-second timeout and 12 MiB output cap. Collection checks
+  a 90-second budget before subprocesses; filesystem scans have 20-second
+  traversal budgets and caps. These bound traversal/admission, not cancellation
+  of an individual hung filesystem operation. Do not treat them as a real-time
+  OS-level deadline guarantee.
+- PR enumeration is capped at 1000; reaching the cap is incomplete. GitHub and
+  Git errors never echo raw stderr or response bodies.
+- Dependency scanning never recursively follows symlinks. It records lexical
+  and resolved targets to detect chains between registered worktrees, including
+  dependency package entries. It skips package internals and generated output
+  recursion. It does not find every external symlink, hardlink, scheduler or
+  active-agent lease. A missing registered-consumer edge is not global proof.
+- Process inspection supports Linux `/proc`, same UID only, at one point in
+  time. It checks cwd/executable/file descriptors and argv path references,
+  plus process start identity. Raw argv and unrelated fd paths are discarded.
+  The planner's own argv is excluded, but its cwd/fds are not. Stable permission
+  denial blocks; unsupported platforms return unknown. Already-loaded code,
+  other users, memory mappings and future launches require external review.
+- `doctor` is observational: it does not issue service-health requests or
+  identify an app as safe to restart. Do not switch files beneath a running app.
+
+## Existing command compatibility
+
+`create`, `remove`, `list`, and non-dry `sweep` retain their existing semantics.
+They are **not retrofitted with these PR/process gates**, so a blocked plan is
+not permission to fall back to legacy forced removal. Legacy `findOrphans`
+still prunes by default; `sweep --dry` now explicitly disables that prune so
+its metadata stays untouched. Dry mode is a preview of current registrations,
+not a simulated prune.
+
+## Verification contract
+
+Blocking root Vitest tests cover strict NUL parsing, arguments, PR/ref targeting,
+permission and cap failures, dependency chains, PID/ref races, merged-patch
+limits, JSON exit semantics and real disposable Git repositories. A regression
+must demonstrate expired registration metadata disappearing before the dry-mode
+fix and surviving afterward, with index/refs unchanged. Default non-dry sweep
+must still prune. Test output and local dogfood belong in the PR description;
+this document does not claim a particular run passed.

--- a/scripts/worktree-lifecycle-regressions.test.js
+++ b/scripts/worktree-lifecycle-regressions.test.js
@@ -1,0 +1,93 @@
+import { it, expect } from 'vitest';
+import { parseStatus, parseWorktrees, planLifecycle } from './worktree-lifecycle/planning.mjs';
+import { collect, scanProcesses } from './worktree-lifecycle/observations.mjs';
+import { runPlanner } from './worktree-lifecycle/cli.mjs';
+
+const head = 'a'.repeat(40), base = 'b'.repeat(40);
+const enoent = () => { throw Object.assign(new Error(), { code: 'ENOENT' }); };
+const complete = () => ({ complete: true, hits: [], edges: [], errors: [], boundary: 'fixture' });
+function runner({ merges = false, remote = 'https://github.com/o/r.git', drift = false } = {}) {
+  let seen = 0;
+  return (exe, args) => {
+    if (exe === 'gh') return args[0] === 'pr' ? '[]' : JSON.stringify({ sha: base });
+    if (args.includes('--get-url')) return remote;
+    if (args.includes('--porcelain')) return `worktree /repo\0HEAD ${++seen > 1 && drift ? base : head}\0branch refs/heads/feature\0\0`;
+    if (args.includes('rev-parse')) {
+      if (args.includes('--git-path')) return '/repo/.git/' + args.at(-1);
+      if (args.includes('--show-toplevel')) return '/repo';
+      return args.at(-1) === 'refs/heads/main' ? base : base;
+    }
+    if (args.includes('status') || args.includes('ls-files') || args.includes('cherry')) return '';
+    if (args.includes('rev-list')) return args.includes('--merges') ? merges ? head + '\n' : '' : '0\t0';
+    throw new Error('Unexpected fixture command');
+  };
+}
+const options = { repo: '/repo', github: 'o/r', author: 'me', base: 'main' };
+const dependencies = { io: { lstat: enoent }, processScan: complete, linkScan: complete };
+
+it.each([' M file', 'R  new\0old'])('rejects truncated status stream %j', input => {
+  expect(() => parseStatus(input)).toThrow();
+});
+it('rejects non-absolute or duplicate worktree paths', () => {
+  expect(() => parseWorktrees(`worktree relative\0HEAD ${head}\0\0`)).toThrow();
+  expect(() => parseWorktrees(`worktree /repo\0HEAD ${head}\0\0worktree /repo\0HEAD ${base}\0\0`)).toThrow();
+});
+it('unrepresented merge commits cannot be proved integrated by empty git cherry', async () => {
+  const s = await collect(options, { ...dependencies, run: runner({ merges: true }) });
+  expect(s.worktrees[0].patchEquivalent).toBe(false);
+});
+it('remote repository mismatch is an explicit blocker', async () => {
+  const s = await collect(options, { ...dependencies, run: runner({ remote: 'https://github.com/other/repo.git' }) });
+  expect(s.errors).toContain('origin does not match the explicit GitHub repository');
+});
+it('ref drift during collection invalidates the observation', async () => {
+  const s = await collect(options, { ...dependencies, run: runner({ drift: true }) });
+  expect(s.errors).toContain('worktree refs changed during observation');
+});
+it('process start identity change is incomplete', async () => {
+  let statReads = 0;
+  const io = {
+    readdir: async p => p === '/proc' ? ['12'] : [],
+    stat: async () => ({ uid: 1000 }),
+    readlink: async () => '/unrelated',
+    readFile: async p => p.endsWith('/stat') ? `12 (worker) S 1 ${Array(17).fill('0').join(' ')} ${++statReads} 0` : '',
+  };
+  const s = await scanProcesses([], { io, uid: 1000, platform: 'linux' });
+  expect(s.complete).toBe(false);
+});
+it('help is offline and malformed flags never invoke collection', async () => {
+  let observed = false;
+  const output = [];
+  const deps = { observe: async () => { observed = true; }, print: x => output.push(x) };
+  expect(await runPlanner(['doctor', '--help'], deps)).toBe(0);
+  expect(await runPlanner(['retire', '--force'], deps)).toBe(1);
+  expect(observed).toBe(false);
+});
+it('doctor reports partial visibility with exit 2', async () => {
+  const s = await collect(options, { ...dependencies, run: runner() });
+  s.processes.complete = false;
+  expect(await runPlanner(['doctor', '--github', 'o/r', '--author', 'me'], { observe: async () => s, print: () => {} })).toBe(2);
+});
+it('collection deadline stops admitting subprocesses', async () => {
+  let calls = 0;
+  await expect(collect(options, { ...dependencies, now: () => 0, timeoutMs: 0, run: () => { calls++; } })).rejects.toThrow(/deadline/);
+  expect(calls).toBe(0);
+});
+it('duplicate GitHub PR records invalidate collection', async () => {
+  const run = runner();
+  const pr = { number: 1, state: 'MERGED', mergedAt: '2026-09-08T00:00:00Z', headRefName: 'feature', headRefOid: head, baseRefName: 'main', url: 'https://github.com/o/r/pull/1' };
+  const s = await collect(options, { ...dependencies, run: (exe, args, cwd) => exe === 'gh' && args[0] === 'pr' ? JSON.stringify([pr, pr]) : run(exe, args, cwd) });
+  expect(s.githubComplete).toBe(false);
+});
+it('hitting the PR enumeration cap is explicitly incomplete', async () => {
+  const run = runner();
+  const prs = Array.from({length: 1000}, (_, i) => ({number: i + 1, state: 'OPEN', headRefName: 'feature', headRefOid: head, baseRefName: 'main', url: `https://github.com/o/r/pull/${i + 1}`}));
+  const s = await collect(options, { ...dependencies, run: (exe, args, cwd) => exe === 'gh' && args[0] === 'pr' ? JSON.stringify(prs) : run(exe, args, cwd) });
+  expect(s.githubComplete).toBe(false);
+});
+it('CLI never relays collector exception contents', async () => {
+  let output;
+  const code = await runPlanner(['doctor', '--github', 'o/r', '--author', 'me'], { observe: async () => { throw new Error('private content'); }, print: x => { output = x; } });
+  expect(code).toBe(1);
+  expect(output).not.toContain('private content');
+});

--- a/scripts/worktree-lifecycle.test.js
+++ b/scripts/worktree-lifecycle.test.js
@@ -1,0 +1,237 @@
+import {
+  it as test,
+  afterAll
+} from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  parseArgs,
+  parseWorktrees,
+  parseStatus,
+  planLifecycle
+} from './worktree-lifecycle/planning.mjs';
+const sha = 'a'.repeat(40),
+  base = 'b'.repeat(40);
+
+function sample() {
+  return {
+    timestamp: '2026-09-09T00:00:00Z',
+    repo: '/repo',
+    github: 'o/r',
+    author: 'me',
+    base: 'main',
+    errors: [],
+    boundaries: ['external leases not verified'],
+    githubComplete: true,
+    originMain: base,
+    remoteMain: base,
+    main: {
+      head: sha,
+      behind: 2,
+      ahead: 0
+    },
+    processes: {
+      complete: true,
+      hits: [],
+      errors: []
+    },
+    links: {
+      complete: true,
+      edges: [],
+      errors: []
+    },
+    prs: [{
+      number: 1,
+      state: 'MERGED',
+      headRefName: 'feat/x',
+      headRefOid: sha,
+      baseRefName: 'main',
+      mergedAt: '2026-09-08',
+      url: 'https://github.com/o/r/pull/1'
+    }],
+    worktrees: [{
+      path: '/repo',
+      head: base,
+      branch: 'integration',
+      primary: true,
+      status: [],
+      ignored: [],
+      markers: [],
+      patchEquivalent: true
+    }, {
+      path: '/wt x',
+      head: sha,
+      branch: 'feat/x',
+      primary: false,
+      status: [],
+      ignored: [],
+      markers: [],
+      patchEquivalent: true
+    }]
+  };
+}
+const opts = {
+  command: 'retire',
+  pr: 1,
+  worktree: '/wt x'
+};
+test('NUL worktree parser preserves spaces/newlines without quote ambiguity', () => {
+  const rows = parseWorktrees(
+    `worktree /repo\0HEAD ${base}\0branch refs/heads/main\0\0worktree /wt\nspace\0HEAD ${sha}\0detached\0locked owner\0\0`
+    );
+  assert.equal(rows[1].path, '/wt\nspace');
+  assert.equal(rows[1].branch, null);
+  assert.deepEqual(rows[1].markers, ['locked owner']);
+});
+test('porcelain NUL rename and untracked paths parse exactly', () => {
+  assert.deepEqual(parseStatus('R  new name\0old name\0?? file\nname\0'), [{
+    code: 'R ',
+    path: 'new name',
+    originalPath: 'old name'
+  }, {
+    code: '??',
+    path: 'file\nname'
+  }]);
+});
+test('reject malformed worktree records', () => assert.throws(() => parseWorktrees('HEAD x\0\0')));
+test('reject incomplete rename', () => assert.throws(() => parseStatus('R  new\0')));
+test('strict required GitHub and author options', () => assert.throws(() => parseArgs(['doctor'])));
+test('parse explicit read-only target', () => assert.deepEqual(parseArgs(['retire', '--repo', '/repo', '--github',
+  'o/r', '--author', 'me', '--pr', '1', '--worktree', '/wt x', '--dry-run'
+]), {
+  command: 'retire',
+  repo: '/repo',
+  github: 'o/r',
+  author: 'me',
+  base: 'main',
+  pr: 1,
+  worktree: '/wt x',
+  dryRun: true
+}));
+for (const args of [
+    ['sync', '--execute'],
+    ['retire', '--force'],
+    ['doctor', '--token', 'secret'],
+    ['doctor', '--github', '../x', '--author', 'a'],
+    ['doctor', '--github', 'o/r', '--github', 'a/b', '--author', 'a'],
+    ['retire', '--github', 'o/r', '--author', 'a', '--pr', 'NaN'],
+    ['sync', '--github', 'o/r', '--author', 'a'],
+    ['doctor', '--github', 'o/r', '--author', 'a', '--pr', '1']
+  ]) test('reject args ' + JSON.stringify(args), () => assert.throws(() => parseArgs(args)));
+test('merged clean worktree remains human-review only, not authorized', () => {
+  const p = planLifecycle(sample(), opts);
+  assert.equal(p.action, 'NEEDS_OWNER_REVIEW');
+  assert.equal(p.authorized, false);
+  assert.equal(p.canExecute, false);
+  assert.ok(p.blockers.includes('external-owner-and-consumer-review-required'));
+  assert.equal(p.targets[0].head, sha);
+});
+for (const [name, mutate, reason] of [
+    ['open PR', s => s.prs[0].state = 'OPEN', 'pr-not-merged'],
+    ['dirty', s => s.worktrees[1].status = [{
+      code: ' M',
+      path: 'x'
+    }], 'uncommitted-work'],
+    ['untracked', s => s.worktrees[1].status = [{
+      code: '??',
+      path: 'x'
+    }], 'uncommitted-work'],
+    ['ignored', s => s.worktrees[1].ignored = ['dist/'], 'ignored-files-need-disposition'],
+    ['markers', s => s.worktrees[1].markers = ['MERGE_HEAD'], 'operation-or-lock-active'],
+    ['process', s => s.processes.hits = [{
+      pid: 1,
+      path: '/wt x'
+    }], 'active-process'],
+    ['unreadable process', s => s.processes.complete = false, 'process-scan-incomplete'],
+    ['dependent', s => s.links.edges = [{
+      consumer: '/consumer',
+      provider: '/wt x'
+    }], 'dependency-provider'],
+    ['link scan capped', s => s.links.complete = false, 'link-scan-incomplete'],
+    ['unmerged patch', s => s.worktrees[1].patchEquivalent = false, 'patch-not-verified-upstream'],
+    ['GH incomplete', s => s.githubComplete = false, 'github-observation-incomplete'],
+    ['fetch needed', s => s.remoteMain = 'c'.repeat(40), 'upstream-ref-stale'],
+    ['new local branch', s => s.worktrees[1].branch = 'feat/y', 'pr-target-mismatch'],
+    ['observation error', s => s.errors.push('Git failed'), 'observation-errors'],
+    ['PR wrong base', s => s.prs[0].baseRefName = 'other', 'pr-base-mismatch'],
+  ]) test(name + ' blocks retirement', () => {
+  const s = sample();
+  mutate(s);
+  assert.ok(planLifecycle(s, opts).blockers.includes(reason));
+  assert.equal(planLifecycle(s, opts).canExecute, false);
+});
+test('primary checkout cannot be retired', () => {
+  const p = planLifecycle(sample(), {
+    ...opts,
+    worktree: '/repo'
+  });
+  assert.ok(p.blockers.includes('primary-worktree'));
+});
+test('unknown target not silently selected', () => assert.ok(planLifecycle(sample(), {
+  ...opts,
+  worktree: '/missing'
+}).blockers.includes('target-not-registered')));
+test('doctor labels only exact OPEN PR heads active', () => {
+  const s = sample();
+  s.prs[0].state = 'OPEN';
+  assert.equal(planLifecycle(s, {
+    command: 'doctor'
+  }).targets[1].disposition, 'KEEP_ACTIVE');
+  s.prs[0].headRefOid = base;
+  assert.equal(planLifecycle(s, {
+    command: 'doctor'
+  }).targets[1].disposition, 'INVESTIGATE');
+});
+test('sync reports ff path but no execution', () => {
+  const p = planLifecycle(sample(), {
+    command: 'sync'
+  });
+  assert.equal(p.main.strategy, 'fast-forward-ref-after-approval');
+  assert.equal(p.canExecute, false);
+});
+test('sync refuses divergence', () => {
+  const s = sample();
+  s.main.ahead = 1;
+  assert.ok(planLifecycle(s, {
+    command: 'sync'
+  }).blockers.includes('main-diverged'));
+});
+test('sync refuses dirty checked-out main', () => {
+  const s = sample();
+  s.worktrees[0].branch = 'main';
+  s.worktrees[0].status = [{
+    code: '??',
+    path: 'x'
+  }];
+  assert.ok(planLifecycle(s, {
+    command: 'sync'
+  }).blockers.includes('main-worktree-not-clean'));
+});
+test('sync refuses live checked-out main', () => {
+  const s = sample();
+  s.worktrees[0].branch = 'main';
+  s.processes.hits = [{
+    pid: 1,
+    path: '/repo'
+  }];
+  assert.ok(planLifecycle(s, {
+    command: 'sync'
+  }).blockers.includes('main-active-process'));
+});
+test('unchanged main needs no update', () => {
+  const s = sample();
+  s.main = {
+    head: base,
+    ahead: 0,
+    behind: 0
+  };
+  assert.equal(planLifecycle(s, {
+    command: 'sync'
+  }).main.strategy, 'already-current');
+});
+test('missing main is not invented', () => {
+  const s = sample();
+  s.main = null;
+  assert.ok(planLifecycle(s, {
+    command: 'sync'
+  }).blockers.includes('main-unavailable'));
+});

--- a/scripts/worktree-lifecycle/cli.mjs
+++ b/scripts/worktree-lifecycle/cli.mjs
@@ -1,0 +1,40 @@
+import { parseArgs, planLifecycle } from './planning.mjs';
+import { collect } from './observations.mjs';
+
+const HELP = `Read-only worktree lifecycle planning (Node 20+, Git, GitHub CLI)
+  npm run wt -- doctor --github OWNER/REPO --author USER [--repo PATH]
+  npm run wt -- sync --dry-run --github OWNER/REPO --author USER [--repo PATH]
+  npm run wt -- retire --dry-run --pr N --worktree PATH --github OWNER/REPO --author USER [--repo PATH]
+
+These commands never fetch, prune, switch branches, update main or delete.
+Only origin/main and base main are supported in this first planning phase.
+Use npm --silent run wt -- ... for JSON without npm's banner.
+Exit 0: report/plan produced; 1: arguments or collection failed; 2: blockers.
+A partial doctor report exits 2. No output authorizes or executes retirement.
+See docs/WORKTREE_LIFECYCLE.md for limits and the approval workflow.
+`;
+
+export async function runPlanner(args, { observe = collect, print = console.log } = {}) {
+  if (args.length === 2 && ['doctor', 'sync', 'retire'].includes(args[0]) && ['--help', '-h'].includes(args[1])) {
+    print(HELP);
+    return 0;
+  }
+  let options;
+  try {
+    options = parseArgs(args);
+  } catch (error) {
+    print(JSON.stringify({ readOnly: true, canExecute: false, error: error.message }));
+    return 1;
+  }
+  try {
+    const observations = await observe(options);
+    const plan = planLifecycle(observations, options);
+    print(JSON.stringify({ plan, observations }, null, 2));
+    if (observations.errors.length) return 1;
+    return plan.blockers.length ? 2 : 0;
+  } catch {
+    // Do not echo subprocess stderr, headers, raw argv or server bodies.
+    print(JSON.stringify({ readOnly: true, canExecute: false, error: 'Observation failed; no state was changed' }));
+    return 1;
+  }
+}

--- a/scripts/worktree-lifecycle/observations.mjs
+++ b/scripts/worktree-lifecycle/observations.mjs
@@ -1,0 +1,333 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  execFileSync
+} from 'node:child_process';
+import {
+  parseStatus,
+  parseWorktrees
+} from './planning.mjs';
+const within = (p, root) => p === root || p.startsWith(root + path.sep);
+const vanished = e => ['ENOENT', 'ESRCH'].includes(e.code);
+export function command(exe, args, cwd) {
+  try {
+    return execFileSync(exe, args, {
+      cwd,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GIT_OPTIONAL_LOCKS: '0',
+        GH_PROMPT_DISABLED: '1',
+        GH_HOST: 'github.com',
+        GIT_TERMINAL_PROMPT: '0',
+        GIT_NO_LAZY_FETCH: '1'
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15000,
+      maxBuffer: 12 * 1024 * 1024
+    });
+  } catch {
+    throw new Error(`${exe} observation failed (nonzero exit, timeout or output limit)`);
+  }
+}
+export async function scanLinks(worktrees, {
+  io = fs,
+  maxEntries = 180000,
+  timeoutMs = 20000
+} = {}) {
+  const edges = [],
+    errors = [];
+  let entries = 0;
+  const until = Date.now() + timeoutMs;
+  const add = (consumer, target, link) => {
+    for (const provider of worktrees)
+      if (provider.path !== consumer.path && within(target, provider.path)) {
+        let e = edges.find(e => e.consumer === consumer.path && e.provider === provider.path);
+        if (!e) {
+          e = {
+            consumer: consumer.path,
+            provider: provider.path,
+            count: 0,
+            examples: []
+          };
+          edges.push(e);
+        }
+        e.count++;
+        if (e.examples.length < 3) e.examples.push(link);
+      }
+  };
+  async function walk(dir, owner, mode = 'source', depth = 0) {
+    if (++entries > maxEntries || Date.now() > until || depth > 16) throw new Error('link scan cap/deadline');
+    for (const e of await io.readdir(dir, {
+        withFileTypes: true
+      })) {
+      if (++entries > maxEntries || Date.now() > until) throw new Error('link scan cap/deadline');
+      if (e.name === '.git') continue;
+      const p = path.join(dir, e.name);
+      if (e.isSymbolicLink()) {
+        const target = path.resolve(dir, await io.readlink(p));
+        add(owner, target, p);
+        try {
+          const real = await io.realpath(p);
+          if (real !== target) add(owner, real, p);
+        } catch (e) {
+          errors.push({
+            path: p,
+            reason: e.code ?? 'unresolved-link'
+          });
+        }
+      } else if (e.isDirectory()) {
+        if (e.name === 'node_modules') await walk(p, owner, 'packages', depth + 1);
+        else if (mode === 'packages' && (e.name.startsWith('@') || e.name === '.bin')) await walk(p, owner,
+          'entries', depth + 1);
+        else if (mode === 'source' && !['dist', '.cache', '.vite', 'coverage', 'test-results', 'playwright-report',
+            '.worktrees', '__pycache__'
+          ].includes(e.name)) await walk(p, owner, 'source', depth + 1);
+      }
+    }
+  }
+  for (const w of worktrees) try {
+    await walk(w.path, w);
+  } catch (e) {
+    errors.push({
+      path: w.path,
+      reason: e.code ?? 'scan-capped-or-failed'
+    });
+  }
+  return {
+    complete: errors.length === 0,
+    entries,
+    edges,
+    errors,
+    boundary: 'Registered worktrees only; generated dirs and dependency internals skipped; no external lease/hardlink/consumer proof'
+  };
+}
+function processStart(text) {
+  const start = text.slice(text.lastIndexOf(')') + 2).trim().split(/\s+/)[19];
+  if (!/^\d+$/.test(start ?? '')) throw new Error('Invalid process identity');
+  return start;
+}
+
+export async function scanProcesses(worktrees, {
+  io = fs,
+  platform = process.platform,
+  uid = process.getuid?.(),
+  root = '/proc',
+  timeoutMs = 20000,
+  maxDescriptors = 200000,
+  observerPid = process.pid
+} = {}) {
+  const hits = [],
+    errors = [];
+  let examined = 0,
+    descriptors = 0;
+  const until = Date.now() + timeoutMs;
+  if (platform !== 'linux' || uid === undefined) return {
+    complete: false,
+    hits,
+    errors: [{
+      reason: 'process inspection unsupported'
+    }]
+  };
+  const add = (pid, p, kind) => {
+    for (const w of worktrees)
+      if (within(p.replace(/ \(deleted\)$/, ''), w.path)) {
+        if (!hits.some(h => h.pid === pid && h.path === w.path && h.kind === kind)) hits.push({
+          pid,
+          path: w.path,
+          kind
+        });
+      }
+  };
+  try {
+    for (const name of await io.readdir(root)) {
+      if (!/^\d+$/.test(name)) continue;
+      if (Date.now() > until) throw new Error('deadline');
+      const p = path.join(root, name),
+        pid = +name;
+      try {
+        if ((await io.stat(p)).uid !== uid) continue;
+        examined++;
+        const start = processStart(await io.readFile(p + '/stat', 'utf8'));
+        const denied = [];
+        for (const kind of ['cwd', 'exe']) try {
+          add(pid, await io.readlink(p + '/' + kind), kind);
+        } catch (e) {
+          if (!vanished(e)) denied.push({
+            kind,
+            reason: e.code ?? 'unknown'
+          });
+        }
+        try {
+          const argv = await io.readFile(p + '/cmdline', 'utf8');
+          for (const w of worktrees)
+            if (pid !== observerPid && argv.includes(w.path)) add(pid, w.path, 'argv-reference');
+        } catch (e) {
+          if (!vanished(e)) denied.push({
+            kind: 'argv',
+            reason: e.code ?? 'unknown'
+          });
+        }
+        try {
+          for (const fd of await io.readdir(p + '/fd')) {
+            if (++descriptors > maxDescriptors || Date.now() > until) throw new Error('process scan cap/deadline');
+            try {
+              add(pid, await io.readlink(p + '/fd/' + fd), 'fd');
+            } catch (e) {
+              if (!vanished(e) && !denied.some(d => d.kind === 'fdlink')) denied.push({
+                kind: 'fdlink',
+                reason: e.code ?? 'unknown'
+              });
+            }
+          }
+        } catch (e) {
+          if (!vanished(e)) denied.push({
+            kind: 'fd',
+            reason: e.code ?? 'cap-or-unknown'
+          });
+        }
+        if (start !== processStart(await io.readFile(p + '/stat', 'utf8'))) {
+          denied.push({ kind: 'identity', reason: 'process-start-changed' });
+        }
+        if (denied.length) errors.push({
+          pid,
+          denied
+        });
+      } catch (e) {
+        if (!vanished(e)) errors.push({
+          pid,
+          reason: e.code ?? 'unknown'
+        });
+      }
+    }
+  } catch (e) {
+    errors.push({
+      reason: e.code ?? 'process-scan-capped-or-failed'
+    });
+  }
+  return {
+    complete: errors.length === 0,
+    hits,
+    errors,
+    examined,
+    descriptors,
+    boundary: 'same UID point-in-time; unreadable processes block; no cross-user/global ownership proof'
+  };
+}
+export async function collect(o, {
+  run = command,
+  io = fs,
+  processScan = scanProcesses,
+  linkScan = scanLinks,
+  timeoutMs = 90000,
+  now = Date.now
+} = {}) {
+  const errors = [];
+  const deadline = now() + timeoutMs;
+  const observe = (exe, args, cwd) => {
+    if (now() >= deadline) throw new Error('Observation deadline reached');
+    return run(exe, args, cwd);
+  };
+  const git = (args, cwd = o.repo) => observe('git', ['--no-optional-locks', '-c', 'core.fsmonitor=false', ...args], cwd);
+  const worktreeSnapshot = git(['worktree', 'list', '--porcelain', '-z']);
+  const worktrees = parseWorktrees(worktreeSnapshot);
+  try {
+    const remote = git(['ls-remote', '--get-url', 'origin']).trim();
+    const escapedRepo = o.github.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const expected = new RegExp(`^(?:https://github\\.com/|git@github\\.com:|ssh://git@github\\.com/)${escapedRepo}(?:\\.git)?/?$`, 'i');
+    if (!expected.test(remote)) errors.push('origin does not match the explicit GitHub repository');
+  } catch {
+    errors.push('origin identity unavailable');
+  }
+  const originMain = git(['rev-parse', '--verify', 'refs/remotes/origin/main']).trim();
+  let main = null;
+  try {
+    const head = git(['rev-parse', '--verify', 'refs/heads/main']).trim();
+    const [behind, ahead] = git(['rev-list', '--left-right', '--count', originMain + '...' + head]).trim().split(
+      /\s+/).map(Number);
+    if (![behind, ahead].every(Number.isSafeInteger)) throw new Error();
+    main = {
+      head,
+      behind,
+      ahead
+    };
+  } catch {
+    errors.push('main observation failed');
+  }
+  for (const w of worktrees) {
+    w.status = [];
+    w.ignored = [];
+    w.patchEquivalent = null;
+    try {
+      w.status = parseStatus(git(['status', '--porcelain=v1', '-z', '--untracked-files=all'], w.path));
+      w.ignored = git(['ls-files', '--others', '--ignored', '--exclude-standard', '--directory', '-z'], w.path).split(
+        '\0').filter(Boolean);
+      for (const marker of ['MERGE_HEAD', 'CHERRY_PICK_HEAD', 'rebase-merge', 'rebase-apply', 'BISECT_LOG']) {
+        const p = git(['rev-parse', '--git-path', marker], w.path).trim();
+        try {
+          await io.lstat(path.resolve(w.path, p));
+          w.markers.push(marker);
+        } catch (e) {
+          if (!vanished(e)) throw e;
+        }
+      }
+      const cherry = git(['cherry', originMain, w.head]).trim();
+      if (cherry && !cherry.split('\n').every(l => /^[+-] [a-f0-9]{40,64}$/.test(l))) throw new Error(
+        'Invalid cherry output');
+      // git cherry ignores merge commits: a merge resolution can contain
+      // unique work even when all ordinary patches are equivalent upstream.
+      const uniqueMerges = git(['rev-list', '--merges', `${originMain}..${w.head}`]).trim();
+      w.patchEquivalent = !uniqueMerges && !cherry.split('\n').some(l => l.startsWith('+'));
+    } catch {
+      errors.push(`worktree observation failed: ${w.path}`);
+      w.markers.push('observation-incomplete');
+    }
+  }
+  let prs = [],
+    remoteMain = null,
+    githubComplete = false;
+  try {
+    const data = JSON.parse(observe('gh', ['pr', 'list', '--repo', o.github, '--author', o.author, '--state', 'all',
+      '--limit', '1000', '--json', 'number,title,state,mergedAt,headRefName,headRefOid,baseRefName,url'
+    ], o.repo));
+    if (!Array.isArray(data) || data.length >= 1000 || data.some(p => !Number.isSafeInteger(p.number) || !['OPEN',
+          'CLOSED', 'MERGED'
+        ].includes(p.state) || typeof p.headRefName !== 'string' || typeof p.baseRefName !== 'string' || typeof p
+        .url !== 'string' || !/^[a-f0-9]{40,64}$/.test(p.headRefOid))) throw new Error();
+    if (new Set(data.map(pr => pr.number)).size !== data.length) throw new Error('Duplicate PR records');
+    prs = data;
+    const r = JSON.parse(observe('gh', ['api', `repos/${o.github}/commits/main`, '--jq', '{sha:.sha}'], o.repo));
+    if (!/^[a-f0-9]{40,64}$/.test(r.sha)) throw new Error();
+    remoteMain = r.sha;
+    githubComplete = true;
+  } catch {
+    errors.push('GitHub observation failed or incomplete');
+  }
+  const [processes, links] = await Promise.all([processScan(worktrees), linkScan(worktrees)]);
+  try {
+    if (git(['worktree', 'list', '--porcelain', '-z']) !== worktreeSnapshot) errors.push('worktree refs changed during observation');
+    if (git(['rev-parse', '--verify', 'refs/remotes/origin/main']).trim() !== originMain) errors.push('upstream ref changed during observation');
+    if (main && git(['rev-parse', '--verify', 'refs/heads/main']).trim() !== main.head) errors.push('main ref changed during observation');
+  } catch {
+    errors.push('final ref observation failed or deadline reached');
+  }
+  return {
+    timestamp: new Date().toISOString(),
+    repo: o.repo,
+    github: o.github,
+    author: o.author,
+    base: o.base,
+    originMain,
+    remoteMain,
+    main,
+    worktrees,
+    prs,
+    githubComplete,
+    errors,
+    processes,
+    links,
+    boundaries: [processes.boundary, links.boundary,
+      'No fetch, prune, ref/index writes, repo-file writes, permission changes or deletions; outside owner review mandatory'
+    ]
+  };
+}

--- a/scripts/worktree-lifecycle/planning.mjs
+++ b/scripts/worktree-lifecycle/planning.mjs
@@ -1,0 +1,196 @@
+import path from 'node:path';
+
+export function parseWorktrees(text) {
+  const rows = [];
+  let w;
+  for (const field of text.split('\0')) {
+    if (!field) {
+      if (w) {
+        if (!w.head && !w.bare) throw new Error('Missing worktree HEAD');
+        rows.push(w);
+        w = null;
+      }
+      continue;
+    }
+    if (field.startsWith('worktree ')) {
+      if (w) throw new Error('Missing worktree separator');
+      w = {
+        path: field.slice(9),
+        head: null,
+        branch: null,
+        markers: []
+      };
+    } else if (!w) throw new Error('Invalid worktree record');
+    else if (field.startsWith('HEAD ')) {
+      w.head = field.slice(5);
+      if (!/^[a-f0-9]{40,64}$/.test(w.head)) throw new Error('Invalid HEAD');
+    } else if (field.startsWith('branch refs/heads/')) w.branch = field.slice(18);
+    else if (field === 'bare') w.bare = true;
+    else if (field === 'detached') continue;
+    else if (/^(locked|prunable)( |$)/.test(field)) w.markers.push(field);
+    else throw new Error('Unknown worktree field');
+  }
+  if (w || !text.endsWith('\0\0')) throw new Error('Unterminated worktree record');
+  const paths = rows.map(row => row.path);
+  if (paths.some(p => !path.isAbsolute(p)) || new Set(paths).size !== paths.length) {
+    throw new Error('Worktree paths must be absolute and unique');
+  }
+  if (!rows.length) throw new Error('No worktrees');
+  rows.forEach((r, i) => {
+    r.primary = i === 0;
+  });
+  return rows;
+}
+export function parseStatus(text) {
+  if (text && !text.endsWith('\0')) throw new Error('Unterminated status stream');
+  const fields = text.split('\0'),
+    rows = [];
+  for (let i = 0; i < fields.length; i++) {
+    const f = fields[i];
+    if (!f) continue;
+    if (f.length < 4 || f[2] !== ' ') throw new Error('Invalid status record');
+    const row = {
+      code: f.slice(0, 2),
+      path: f.slice(3)
+    };
+    if (/[RC]/.test(row.code)) {
+      if (!fields[i + 1]) throw new Error('Missing rename path');
+      row.originalPath = fields[++i];
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+export function parseArgs(argv) {
+  const [command, ...args] = argv;
+  if (!['doctor', 'sync', 'retire'].includes(command)) throw new Error('Expected doctor, sync or retire');
+  const o = {
+    command,
+    repo: process.cwd(),
+    base: 'main'
+  };
+  const seen = new Set();
+  const fields = new Map([
+    ['--repo', 'repo'],
+    ['--github', 'github'],
+    ['--author', 'author'],
+    ['--base', 'base'],
+    ['--pr', 'pr'],
+    ['--worktree', 'worktree']
+  ]);
+  while (args.length) {
+    const f = args.shift();
+    if (seen.has(f)) throw new Error('Duplicate option');
+    seen.add(f);
+    if (f === '--dry-run') {
+      o.dryRun = true;
+      continue;
+    }
+    const k = fields.get(f);
+    if (!k || !args.length || args[0].startsWith('--')) throw new Error(
+      'Unknown or missing option; read-only commands only');
+    o[k] = args.shift();
+  }
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(o.github ?? '') || o.github.split('/').some(p => p === '.' || p ===
+      '..')) throw new Error('Explicit owner/repo required');
+  if (!/^[A-Za-z0-9][A-Za-z0-9-]*$/.test(o.author ?? '')) throw new Error('Explicit GitHub author required');
+  if (o.base !== 'main') throw new Error('Only main is supported in phase one');
+  if (command !== 'doctor' && !o.dryRun) throw new Error('sync/retire require --dry-run; no executor installed');
+  if (command === 'retire') {
+    if (!/^[1-9]\d*$/.test(o.pr ?? '') || !Number.isSafeInteger(+o.pr) || !o.worktree) throw new Error(
+      'Exact --pr and --worktree required');
+    o.pr = +o.pr;
+    o.worktree = path.resolve(o.worktree);
+  } else if (o.pr || o.worktree) throw new Error('Target flags require retire');
+  o.repo = path.resolve(o.repo);
+  return o;
+}
+export function planLifecycle(s, o) {
+  const blockers = [];
+  if (s.errors.length) blockers.push('observation-errors');
+  if (!s.githubComplete) blockers.push('github-observation-incomplete');
+  if (!s.remoteMain || s.remoteMain !== s.originMain) blockers.push('upstream-ref-stale');
+  if (!s.processes.complete) blockers.push('process-scan-incomplete');
+  if (!s.links.complete) blockers.push('link-scan-incomplete');
+  const targets = s.worktrees.map(w => {
+    const exact = s.prs.filter(p => p.state === 'OPEN' && p.headRefOid === w.head && p.baseRefName === s.base);
+    const active = s.processes.hits.some(p => p.path === w.path);
+    const consumers = s.links.edges.filter(e => e.provider === w.path).map(e => e.consumer);
+    const disposition = w.primary || active || w.status.length || w.markers.length ? 'PRESERVE' : exact.length ?
+      'KEEP_ACTIVE' : 'INVESTIGATE';
+    return {
+      path: w.path,
+      branch: w.branch,
+      head: w.head,
+      disposition,
+      currentPRs: exact.map(p => p.number),
+      activeProcess: active,
+      consumers,
+      status: w.status,
+      ignored: w.ignored,
+      markers: w.markers
+    };
+  });
+  // Plans are advisory evidence, never an authorization or a deletion token.
+  const result = {
+    schemaVersion: 1,
+    command: o.command,
+    readOnly: true,
+    authorized: false,
+    canExecute: false,
+    timestamp: s.timestamp,
+    repo: s.repo,
+    github: s.github,
+    author: s.author,
+    upstream: {
+      local: s.originMain,
+      remote: s.remoteMain
+    },
+    blockers,
+    targets,
+    boundaries: s.boundaries
+  };
+  if (o.command === 'retire') {
+    const t = targets.find(t => t.path === o.worktree),
+      w = s.worktrees.find(t => t.path === o.worktree),
+      pr = s.prs.find(p => p.number === o.pr);
+    result.targets = t ? [t] : [];
+    result.pr = pr ?? {
+      number: o.pr,
+      state: 'UNKNOWN'
+    };
+    if (!t) blockers.push('target-not-registered');
+    if (!pr || pr.state !== 'MERGED' || !pr.mergedAt) blockers.push('pr-not-merged');
+    if (pr && pr.baseRefName !== s.base) blockers.push('pr-base-mismatch');
+    if (t) {
+      if (w.primary) blockers.push('primary-worktree');
+      if (w.bare) blockers.push('bare-worktree');
+      if (w.status.length) blockers.push('uncommitted-work');
+      if (w.ignored.length) blockers.push('ignored-files-need-disposition');
+      if (w.markers.length) blockers.push('operation-or-lock-active');
+      if (t.activeProcess) blockers.push('active-process');
+      if (t.consumers.length) blockers.push('dependency-provider');
+      if (w.patchEquivalent !== true) blockers.push('patch-not-verified-upstream');
+      if (pr && (w.branch ? w.branch !== pr.headRefName : w.head !== pr.headRefOid)) blockers.push(
+      'pr-target-mismatch');
+    }
+    result.action = blockers.length ? 'BLOCKED' : 'NEEDS_OWNER_REVIEW';
+    blockers.push('external-owner-and-consumer-review-required');
+  } else if (o.command === 'sync') {
+    if (!s.main) blockers.push('main-unavailable');
+    else {
+      if (s.main.ahead > 0) blockers.push('main-diverged');
+      for (const t of targets.filter(t => t.branch === s.base)) {
+        if (t.status.length || t.ignored.length || t.markers.length) blockers.push('main-worktree-not-clean');
+        if (t.activeProcess) blockers.push('main-active-process');
+      }
+      result.main = {
+        ...s.main,
+        strategy: s.main.ahead > 0 ? 'stop-diverged' : s.main.behind === 0 ? 'already-current' : targets.some(t => t
+          .branch === s.base) ? 'fast-forward-checkout-after-approval' : 'fast-forward-ref-after-approval'
+      };
+    }
+    result.action = blockers.length ? 'BLOCKED' : 'PLAN_ONLY';
+  } else result.action = 'REPORT_ONLY';
+  return result;
+}

--- a/scripts/worktree-observations.test.js
+++ b/scripts/worktree-observations.test.js
@@ -1,0 +1,218 @@
+import {
+  it as test,
+  afterAll
+} from 'vitest';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  execFileSync
+} from 'node:child_process';
+import {
+  collect,
+  scanLinks,
+  scanProcesses
+} from './worktree-lifecycle/observations.mjs';
+const fixtures = [];
+const temp = async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'agnt-lifecycle-'));
+  fixtures.push(dir);
+  return dir;
+};
+afterAll(async () => {
+  for (const dir of fixtures) await fs.rm(dir, {
+    recursive: true,
+    force: true
+  });
+});
+const complete = () => ({
+  complete: true,
+  hits: [],
+  edges: [],
+  errors: [],
+  boundary: 'fixture only'
+});
+
+function procIO(denied = false) {
+  const fail = Object.assign(new Error('Denied'), {
+    code: 'EACCES'
+  });
+  return {
+    readdir: async p => p === '/proc' ? ['11'] : ['3'],
+    stat: async () => ({
+      uid: 1000
+    }),
+    readlink: async p => {
+      if (denied) throw fail;
+      return p.endsWith('exe') ? '/bin/node' : '/wt/sub/file';
+    },
+    readFile: async p => p.endsWith('/stat') ? `11 (worker) S 1 ${Array(17).fill('0').join(' ')} 100 0` : '/bin/node\0/wt/server.js\0'
+  };
+}
+test('process hits bound to exact worktree paths', async () => {
+  const r = await scanProcesses([{
+    path: '/wt'
+  }], {
+    io: procIO(),
+    platform: 'linux',
+    uid: 1000
+  });
+  assert.equal(r.complete, true);
+  assert.ok(r.hits.length);
+  assert.ok(r.hits.every(h => h.path === '/wt' && h.pid === 11));
+});
+test('observer own argv is excluded but its cwd/fds still protect a tree', async () => {
+  const r = await scanProcesses([{
+    path: '/wt'
+  }], {
+    io: procIO(),
+    platform: 'linux',
+    uid: 1000,
+    observerPid: 11
+  });
+  assert.ok(!r.hits.some(h => h.kind === 'argv-reference'));
+  assert.ok(r.hits.some(h => h.kind === 'cwd'));
+  assert.ok(r.hits.some(h => h.kind === 'fd'));
+});
+test('EACCES is incomplete not a clean scan', async () => {
+  const r = await scanProcesses([{
+    path: '/wt'
+  }], {
+    io: procIO(true),
+    platform: 'linux',
+    uid: 1000
+  });
+  assert.equal(r.complete, false);
+  assert.ok(r.errors.length);
+});
+test('unsupported OS reports unknown', async () => assert.equal((await scanProcesses([], {
+  platform: 'darwin'
+})).complete, false));
+test('descriptor cap cannot look like complete scan', async () => assert.equal((await scanProcesses([], {
+  io: procIO(),
+  platform: 'linux',
+  uid: 1000,
+  maxDescriptors: 0
+})).complete, false));
+test('process traversal disappearing is tolerated', async () => {
+  const io = procIO();
+  io.stat = async () => {
+    throw Object.assign(new Error(), {
+      code: 'ENOENT'
+    });
+  };
+  assert.equal((await scanProcesses([], {
+    io,
+    platform: 'linux',
+    uid: 1000
+  })).complete, true);
+});
+test('link scanning includes lexical provider even when resolved provider differs', async () => {
+  const dir = await temp();
+  for (const p of ['consumer/node_modules', 'middle', 'provider/pkg']) await fs.mkdir(path.join(dir, p), {
+    recursive: true
+  });
+  await fs.symlink(dir + '/provider', dir + '/middle/node_modules');
+  await fs.symlink(dir + '/middle/node_modules/pkg', dir + '/consumer/node_modules/pkg');
+  const r = await scanLinks(['consumer', 'middle', 'provider'].map(p => ({
+    path: dir + '/' + p
+  })));
+  assert.equal(r.complete, true);
+  assert.ok(r.edges.some(e => e.consumer === dir + '/consumer' && e.provider === dir + '/middle'));
+  assert.ok(r.edges.some(e => e.consumer === dir + '/consumer' && e.provider === dir + '/provider'));
+});
+test('broken links and caps report incomplete', async () => {
+  const dir = await temp();
+  await fs.symlink(dir + '/absent', dir + '/broken');
+  assert.equal((await scanLinks([{
+    path: dir
+  }])).complete, false);
+  assert.equal((await scanLinks([{
+    path: dir
+  }], {
+    maxEntries: 0
+  })).complete, false);
+});
+test('real Git read-only collection preserves refs/index/status and does not invoke mutators', async () => {
+  const dir = await temp();
+  const git = (args) => execFileSync('git', args, {
+    cwd: dir,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_NOSYSTEM: '1'
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  git(['init', '--initial-branch=main']);
+  git(['config', 'user.name', 'Fixture']);
+  git(['config', 'commit.gpgsign', 'false']);
+  git(['remote', 'add', 'origin', 'https://github.com/o/r.git']);
+  git(['config', 'user.email', 'fixture@example.invalid']);
+  await fs.writeFile(dir + '/tracked.txt', 'fixture\n');
+  git(['add', 'tracked.txt']);
+  git(['-c', 'core.hooksPath=/dev/null', 'commit', '-m', 'fixture']);
+  const sha = git(['rev-parse', 'HEAD']).trim();
+  git(['update-ref', 'refs/remotes/origin/main', sha]);
+  const before = await fs.readFile(dir + '/.git/index'),
+    refs = git(['show-ref']);
+  const calls = [];
+  const run = (exe, args, cwd) => {
+    calls.push({
+      exe,
+      args
+    });
+    if (exe === 'gh') return args[0] === 'pr' ? '[]' : JSON.stringify({
+      sha
+    });
+    return execFileSync(exe, args, {
+      cwd,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GIT_OPTIONAL_LOCKS: '0',
+        GIT_CONFIG_GLOBAL: '/dev/null',
+        GIT_CONFIG_NOSYSTEM: '1'
+      },
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+  };
+  const o = {
+    repo: dir,
+    github: 'o/r',
+    author: 'me',
+    base: 'main'
+  };
+  const s = await collect(o, {
+    run,
+    processScan: complete,
+    linkScan: complete
+  });
+  assert.equal(s.errors.length, 0);
+  assert.equal(s.worktrees.length, 1);
+  assert.equal(s.worktrees[0].patchEquivalent, true);
+  assert.deepEqual(await fs.readFile(dir + '/.git/index'), before);
+  assert.equal(git(['show-ref']), refs);
+  assert.equal(git(['status', '--porcelain']), '');
+  assert.ok(!calls.some(c => c.args.some(x => ['fetch', 'prune', 'merge', 'reset', 'update-ref', 'write-tree',
+    'checkout', 'switch', 'clean'
+  ].includes(x))));
+  const failed = await collect(o, {
+    run: (exe, args, cwd) => {
+      if (exe === 'gh') throw new Error('secret stderr must not leak');
+      return run(exe, args, cwd);
+    },
+    processScan: complete,
+    linkScan: complete
+  });
+  assert.equal(failed.githubComplete, false);
+  assert.ok(!JSON.stringify(failed).includes('secret stderr'));
+  const invalid = await collect(o, {
+    run: (exe, args, cwd) => exe === 'gh' ? '{}' : run(exe, args, cwd),
+    processScan: complete,
+    linkScan: complete
+  });
+  assert.equal(invalid.githubComplete, false);
+});

--- a/scripts/worktree.mjs
+++ b/scripts/worktree.mjs
@@ -6,6 +6,9 @@
  *   npm run wt -- remove <slug> [--force]
  *   npm run wt -- sweep [--dry]
  *   npm run wt -- list
+ *   npm run wt -- doctor --github owner/repo --author user
+ *   npm run wt -- sync --dry-run --github owner/repo --author user
+ *   npm run wt -- retire --dry-run --pr N --worktree PATH --github owner/repo --author user
  *
  * WHY A SCRIPT AND NOT FOUR GIT COMMANDS
  * ──────────────────────────────────────
@@ -284,8 +287,8 @@ export function removeWorktree(repoRoot, slug, { force = false } = {}) {
  * prune` has dropped stale admin entries, anything left on disk that is not
  * registered is a leak by definition.
  */
-export function findOrphans(repoRoot) {
-  git(repoRoot, ['worktree', 'prune']);
+export function findOrphans(repoRoot, { prune = true } = {}) {
+  if (prune) git(repoRoot, ['worktree', 'prune']);
   const base = path.join(repoRoot, WORKTREES_DIR);
   if (!fs.existsSync(base)) return [];
   const registered = listWorktrees(repoRoot).map((w) => w.path);
@@ -299,7 +302,7 @@ export function findOrphans(repoRoot) {
 }
 
 export function sweepOrphans(repoRoot, { dry = false } = {}) {
-  const orphans = findOrphans(repoRoot);
+  const orphans = findOrphans(repoRoot, { prune: !dry });
   const removed = [];
   for (const p of orphans) {
     if (dry) continue;
@@ -317,8 +320,15 @@ function flag(args, name) {
   return i === -1 ? undefined : args[i + 1];
 }
 
-function main(argv) {
+async function main(argv) {
   const [cmd, ...rest] = argv;
+  // Dispatch before primaryRoot: help works outside Git, and the planner
+  // owns its explicit read-only target instead of the legacy primary root.
+  if (['doctor', 'sync', 'retire'].includes(cmd)) {
+    const { runPlanner } = await import('./worktree-lifecycle/cli.mjs');
+    process.exitCode = await runPlanner(argv);
+    return;
+  }
   const root = primaryRoot();
   const rel = (p) => path.relative(root, p) || '.';
 
@@ -352,14 +362,14 @@ function main(argv) {
       return;
     }
     default:
-      console.error('usage: worktree.mjs <create|remove|sweep|list> ...');
+      console.error('usage: worktree.mjs <create|remove|sweep|list|doctor|sync|retire> ...');
       process.exitCode = 2;
   }
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
   try {
-    main(process.argv.slice(2));
+    await main(process.argv.slice(2));
   } catch (err) {
     console.error(`worktree: ${err.message}`);
     process.exitCode = 1;

--- a/scripts/worktree.test.js
+++ b/scripts/worktree.test.js
@@ -172,6 +172,34 @@ describe('sweep', () => {
     expect(onDisk()).toEqual(['ghost']);
   });
 
+  it('--dry preserves expired registration metadata and the index byte-for-byte', () => {
+    const gone = createWorktree(root, 'gone');
+    fs.rmSync(gone.path, { recursive: true, force: true });
+    git(['config', 'gc.worktreePruneExpire', 'now']);
+    const admin = path.join(root, '.git', 'worktrees', 'gone');
+    const old = new Date('2000-01-01');
+    fs.utimesSync(path.join(admin, 'gitdir'), old, old);
+    const metadata = new Map(fs.readdirSync(admin).filter((name) => fs.statSync(path.join(admin, name)).isFile()).map((name) => [name, fs.readFileSync(path.join(admin, name))]));
+    const index = fs.readFileSync(path.join(root, '.git', 'index'));
+    const refs = git(['show-ref']);
+
+    sweepOrphans(root, { dry: true });
+    expect(fs.existsSync(admin), 'dry-run must not prune an expired registration').toBe(true);
+    for (const [name, bytes] of metadata) expect(fs.readFileSync(path.join(admin, name))).toEqual(bytes);
+    expect(fs.readFileSync(path.join(root, '.git', 'index'))).toEqual(index);
+    expect(git(['show-ref'])).toBe(refs);
+
+    sweepOrphans(root);
+    expect(fs.existsSync(admin), 'non-dry sweep retains its existing prune behavior').toBe(false);
+  });
+
+  it('dispatches doctor before trying to resolve a primary checkout', () => {
+    const script = fileURLToPath(new URL('./worktree.mjs', import.meta.url));
+    const output = execFileSync(process.execPath, [script, 'doctor', '--help'], { cwd: os.tmpdir(), encoding: 'utf8' });
+    expect(output).toContain('Read-only');
+    expect(output).toContain('--github');
+  });
+
   it('deletes the leak, and the real node_modules survives its junctions', () => {
     const p = leak('ghost');
     expect(fs.lstatSync(path.join(p, 'node_modules')).isSymbolicLink()).toBe(true);


### PR DESCRIPTION
## What problem does this solve?

Closes #123 (read-only planning phase).

A contributor can accumulate merged-PR worktrees and stale branches even with fetch.prune enabled. Clean Git status is not proof a worktree is disposable: it may contain ignored evidence, serve a process, or supply dependencies to another checkout. Existing `sweep --dry` also calls `worktree prune` and changes metadata.

## How does it solve it?

Adds three **read-only** commands through the existing npm entry point:

```sh
npm run wt -- doctor --github agnt-gg/agnt --author YOUR_LOGIN
npm run wt -- sync --dry-run --github agnt-gg/agnt --author YOUR_LOGIN
npm run wt -- retire --dry-run --pr N --worktree PATH --github agnt-gg/agnt --author YOUR_LOGIN
```

- Explicit GitHub origin/base/author and exact worktree/branch/HEAD targeting; strict NUL parsers.
- Dirty, untracked, ignored, in-progress, process and dependency observations; partial/unknown is not clear.
- Conservative patch-equivalence check; local merge commits absent upstream block because git cherry ignores merge-resolution changes.
- Beginning/end ref checks and process-start checks; capped GitHub responses, finite subprocess and traversal budgets, sanitized errors.
- Linux same-UID process inspection only. Unsupported OS/permission denial is explicit incomplete evidence, not claimed cross-platform inactivity.
- `sweep --dry` opts out of pruning, tested against expired registration metadata. Existing create/remove/list/non-dry sweep semantics unchanged.

**No deletion/sync executor, automatic approval, scheduler, rebase, fetch, backend control or elevation.** Plans always have `canExecute: false`; retirement always needs external owner/consumer review. Exit 2 denotes blockers, including a partial doctor report. Legacy destructive commands do not gain these new checks and are not a sanctioned fallback.

Nine files; only two existing files changed (`scripts/worktree.mjs`, `scripts/worktree.test.js`). No package/lockfile, auth, credential, server or frontend changes. New guide documents scope, exit semantics and false-positive/evidence limitations.

## How did you verify it?

Local Node 20.20.1, existing installed dependencies linked directly to the primary checkout (no scratch-to-scratch dependency chain). Tests use isolated data/temp paths.

```text
root Vitest (final):
  Test Files 377 passed
  Tests      5973 passed | 1 existing platform skip

frontend Vitest (unchanged source, full rerun):
  Test Files 260 passed
  Tests      4436 passed, no unhandled errors

new/affected focused suites: 81 tests total
  existing worktree suite 20 (18 old + 2 new)
  planning 39, observations 9, hardening/CLI 13

normalize-eol --check: 2706 attributed files, 0 rewrites
git diff --cached --check: clean
```

Backend browser-dependent tests used the existing documented `AGNT_BROWSER_PATH` headless Chromium override and `AGNT_BROWSER_HEADLESS=1`. No test-source exclusion or production changes.

Observed RED → GREEN:
- two integration regressions: expired registration disappeared in dry mode; help dispatch erroneously required a repository;
- seven hardening failures: truncation/ambiguous paths, unrepresented merge commits, wrong origin, ref drift and PID identity;
- one duplicate-PR regression.
The prototype had its own earlier RED/48-test verification; the shipped behavior now runs in blocking Vitest rather than report-only node:test.

Real `npm --silent run wt` dogfood against a 20-worktree contributor repository: doctor, sync dry-run and three retirement plans. All emitted JSON and correctly refused incomplete process visibility. Main refs, all refs, registration list, primary index bytes and status were identical before/after. A transient argv path hit was retained as a conservative blocker, not called safe. No worktrees or branches removed.

**Qualification:** initial backend baseline overlapped newly added RED tests (not claimed a clean baseline); an initial unchanged frontend run had all4436 assertions pass but two pre-existing PopupTutorial teardown errors. Full repeat passed without edits. Both logs retained. Local full production build was refused by workstation heavy-job admission (exit74, incomplete retained-run process scan); no bypass. Local Playwright was not run. CI production build/browser jobs must supply those gates.

Review was bounded source/test self-review, not an independent security audit. Process/link census is deliberately not global or atomic; read the guide before interpreting a report. Per-operation budgets cannot cancel an individual stuck filesystem operation.

## Checklist

- [x] No auth/session/credential handling changes
- [x] Not a security vulnerability fix
- [x] Backend suite passes with documented environment override
- [x] Frontend suite passes on full rerun; prior failure disclosed
- [x] New behavior tested with observed RED before fixes
- [x] Operator/design documentation added
- [x] Commit subject under 72 characters
- [x] Upstream exact-head build/browser CI verified

## CI completion

[Run 34329969316](https://github.com/agnt-gg/agnt/actions/runs/34329969316) completed successfully on `b0a42c057f7ae025269dd4ccc452f755329c9d39`. All four blocking jobs passed: backend, frontend tests + production build, browser suite + its production build, and line endings. The report-only node:test job is not counted as a passing test suite: its allowed-failure command could not find files for the quoted glob. No local worktree deletion, main update, deployment or live restart is implied by CI.
