### PR TITLE
fix(ui): keep the header model selector available

### DIFF
--- a/docs/HEADER_MODEL_SELECTOR.md
+++ b/docs/HEADER_MODEL_SELECTOR.md
@@ -1,0 +1,37 @@
+# Header model selector
+
+The control beside the clock opens the account-default provider/model picker.
+It is available throughout the authenticated app shell, including while model
+settings are loading or when the model catalog is empty. Without a selected
+model its label is **Select model**; otherwise it shows the existing
+provider/model label.
+
+The control is a native button. Tab can focus it, Enter or Space opens the
+picker, and the picker closes on Escape or an outside click. Its
+`aria-expanded` state reflects whether the picker is open.
+
+## Why it could disappear
+
+Saved settings can use lowercase built-in provider keys such as `openai-codex`,
+while frontend provider identifiers and model-cache keys use `OpenAI-Codex`.
+A case-sensitive lookup in `loadUserSettings` skipped fetching models and then
+cleared the selected model. The header's `v-if` removed the entire control.
+
+Settings loading now resolves case variants using the existing
+`canonicalizeProviderCase` helper **before** fetching or committing the
+provider. Exact custom-provider IDs remain opaque, unknown providers are not
+mapped to another provider, and the existing model-validation behavior is
+unchanged. This is a display/settings-loading fix, not an authentication or
+provider-routing change. No new setting or migration is needed.
+
+## Regression coverage
+
+- `frontend/src/store/app/aiProvider.loadSettings.bdd.spec.js`: built-in casing,
+  both settings/provider-list completion orders, custom and unknown providers,
+  Local model loading, absent settings, and settings-service failure.
+- `frontend/src/canvas/CanvasScreen.modelSelector.bdd.spec.js`: fallback and
+  populated labels, opening/closing, reactive updates, and sign-in boundary.
+- `tests/e2e/header-model-selector.spec.js`: real built app and picker, model
+  persistence through reload, and keyboard/mouse recovery from an empty catalog.
+  Uses the existing isolated backend fixture and synthetic settings/model
+  responses; tagged `@ci` for the browser gate.

--- a/frontend/src/canvas/CanvasScreen.modelSelector.bdd.spec.js
+++ b/frontend/src/canvas/CanvasScreen.modelSelector.bdd.spec.js
@@ -1,0 +1,124 @@
+/** Mount the real header: an empty model must never remove the recovery control. */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import { nextTick } from 'vue';
+
+vi.mock('@/composables/useElectron', () => ({
+  useElectron: () => ({ isElectron: { value: false } }),
+  electronUtils: { window: { minimize: vi.fn(), maximize: vi.fn(), close: vi.fn() } },
+}));
+
+import CanvasScreen from './CanvasScreen.vue';
+import widgetLayoutModule from '@/store/features/widgetLayout.js';
+
+let wrapper;
+function renderHeader(selection = {}, authenticated = true) {
+  const page = { id: 'test-chat-page', name: 'Chat', route: 'ChatScreen', order: 0 };
+  const store = createStore({
+    modules: {
+      userAuth: { namespaced: true, getters: { isAuthenticated: () => authenticated } },
+      aiProvider: {
+        namespaced: true,
+        state: () => ({ selectedProvider: null, selectedModel: null, customProviders: [], ...selection }),
+      },
+      widgetLayout: {
+        ...widgetLayoutModule,
+        state: () => ({ pages: [page], activePageId: page.id, layouts: {}, isDirty: false, isLoaded: true }),
+        actions: { setActivePage: vi.fn() },
+      },
+      contentOutputs: { namespaced: true, getters: { unreadOutputIdSet: () => new Set() } },
+      chat: { namespaced: true, getters: { streamingOutputIds: () => new Set() } },
+    },
+  });
+  wrapper = mount(CanvasScreen, {
+    global: {
+      plugins: [store],
+      stubs: {
+        WidgetCanvas: true, WidgetCatalog: true, SimpleModal: true, Teleport: true,
+        Tooltip: { template: '<span><slot /></span>' },
+        ChatProviderSelector: {
+          name: 'ChatProviderSelector',
+          props: ['isOpen'],
+          emits: ['close'],
+          template: '<div class="test-provider-panel"><button @click="$emit(\'close\')">Close</button></div>',
+        },
+      },
+    },
+  });
+  return store;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.stubGlobal('ResizeObserver', class { observe() {} disconnect() {} });
+  vi.stubGlobal('fetch', vi.fn(() => { throw new Error('Header test must not access the network'); }));
+});
+afterEach(() => {
+  wrapper?.unmount();
+  wrapper = null;
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('Given the authenticated top bar next to the clock', () => {
+  it.each([
+    [null, null],
+    ['OpenAI-Codex', null],
+    ['OpenAI-Codex', ''],
+  ])('when provider=%s and model=%s, then Select model stays available and opens/closes the picker', async (provider, model) => {
+    renderHeader({ selectedProvider: provider, selectedModel: model });
+    expect(wrapper.find('#cvClock').exists()).toBe(true);
+    const control = wrapper.find('.cv-global-model-clickable');
+    expect(control.exists()).toBe(true);
+    expect(control.text()).toContain('Select model');
+    expect(control.element.tagName).toBe('BUTTON');
+    expect(control.attributes('type')).toBe('button');
+    expect(control.attributes('aria-label')).toBe('Change default AI model');
+    expect(control.attributes('aria-expanded')).toBe('false');
+    await control.trigger('click');
+    expect(wrapper.find('.test-provider-panel').exists()).toBe(true);
+    expect(control.attributes('aria-expanded')).toBe('true');
+    await wrapper.find('.test-provider-panel button').trigger('click');
+    expect(wrapper.find('.test-provider-panel').exists()).toBe(false);
+    expect(control.attributes('aria-expanded')).toBe('false');
+  });
+
+  it('preserves the provider/model label and lets the same button toggle the picker', async () => {
+    renderHeader({ selectedProvider: 'OpenAI-Codex', selectedModel: 'saved-test-model' });
+    const control = wrapper.find('.cv-global-model-clickable');
+    expect(control.text()).toContain('openai-codex/saved-test-model');
+    await control.trigger('click');
+    expect(wrapper.find('.test-provider-panel').exists()).toBe(true);
+    await control.trigger('click');
+    expect(wrapper.find('.test-provider-panel').exists()).toBe(false);
+  });
+
+  it('resolves a custom-provider ID to its friendly name', () => {
+    renderHeader({
+      selectedProvider: 'custom-123', selectedModel: 'private-model',
+      customProviders: [{ id: 'custom-123', provider_name: 'Private host' }],
+    });
+    expect(wrapper.find('.cv-global-model-clickable').text()).toContain('Private host/private-model');
+  });
+
+  it('updates the label after settings load, and remains usable if the model later becomes empty', async () => {
+    const store = renderHeader();
+    expect(wrapper.find('.cv-global-model-clickable').text()).toContain('Select model');
+    store.state.aiProvider.selectedProvider = 'OpenAI-Codex';
+    store.state.aiProvider.selectedModel = 'saved-test-model';
+    await nextTick();
+    expect(wrapper.find('.cv-global-model-clickable').text()).toContain('openai-codex/saved-test-model');
+    store.state.aiProvider.selectedModel = null;
+    await nextTick();
+    expect(wrapper.find('.cv-global-model-clickable').text()).toContain('Select model');
+    await wrapper.find('.cv-global-model-clickable').trigger('click');
+    expect(wrapper.find('.test-provider-panel').exists()).toBe(true);
+  });
+
+  it('does not expose the authenticated toolbar on the sign-in screen', () => {
+    renderHeader({}, false);
+    expect(wrapper.find('.cv-toolbar').exists()).toBe(false);
+    expect(wrapper.find('.cv-global-model-clickable').exists()).toBe(false);
+  });
+});

--- a/frontend/src/canvas/CanvasScreen.vue
+++ b/frontend/src/canvas/CanvasScreen.vue
@@ -29,11 +29,18 @@
       <!-- Right side controls -->
       <div class="cv-right">
         <span class="cv-clock" id="cvClock">{{ clock }}</span>
-        <Tooltip v-if="globalModelLabel" text="Click to change model" width="auto" position="bottom">
-          <span class="cv-global-model cv-global-model-clickable" @click="toggleGlobalProviderSelector">
-            {{ globalProviderLabel }}/{{ globalModelLabel }}
-            <i class="fas fa-caret-down"></i>
-          </span>
+        <Tooltip text="Click to change model" width="auto" position="bottom">
+          <button
+            type="button"
+            class="cv-global-model cv-global-model-clickable"
+            aria-label="Change default AI model"
+            :aria-expanded="isGlobalProviderSelectorOpen"
+            @click="toggleGlobalProviderSelector"
+          >
+            <template v-if="globalModelLabel">{{ globalProviderLabel }}/{{ globalModelLabel }}</template>
+            <template v-else>Select model</template>
+            <i class="fas fa-caret-down" aria-hidden="true"></i>
+          </button>
         </Tooltip>
         <Tooltip v-if="onCustomPage" text="Add widget">
           <button class="cv-btn" @click="showCatalog = true">+</button>
@@ -892,6 +899,8 @@ export default {
 }
 
 .cv-global-model {
+  background: transparent;
+  font-family: inherit;
   font-size: 11px;
   color: var(--color-primary);
   letter-spacing: 0.5px;

--- a/frontend/src/store/app/aiProvider.js
+++ b/frontend/src/store/app/aiProvider.js
@@ -1193,7 +1193,15 @@ export default {
 
           if (response.ok) {
             const settings = await response.json();
-            const provider = settings.selectedProvider;
+            // Settings can hold lowercase server keys while providers/model
+            // caches use canonical identifiers. Normalize before fetching or
+            // committing so boot order cannot clear an otherwise valid model.
+            // Custom-provider IDs remain opaque and must match exactly.
+            const savedProvider = settings.selectedProvider;
+            const isCustomProvider = state.customProviders.some((cp) => cp.id === savedProvider);
+            const provider = isCustomProvider
+              ? savedProvider
+              : canonicalizeProviderCase(state.providers, savedProvider) || savedProvider;
             const model = settings.selectedModel;
 
             if (settings.customInstructions !== undefined) {
@@ -1221,8 +1229,6 @@ export default {
             }
 
             if (provider) {
-              const isCustomProvider = state.customProviders.some((cp) => cp.id === provider);
-
               if (provider === 'Local') {
                 await dispatch('fetchLocalModels');
               } else if (isCustomProvider) {

--- a/frontend/src/store/app/aiProvider.loadSettings.bdd.spec.js
+++ b/frontend/src/store/app/aiProvider.loadSettings.bdd.spec.js
@@ -1,0 +1,174 @@
+/** Regression: case-drift in saved settings must not clear the toolbar model. */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createStore } from 'vuex';
+import aiProvider from './aiProvider.js';
+import { invalidateAllFreshness } from '../_utils/withFreshness.js';
+
+const models = ['recommended-test-model', 'saved-test-model'];
+function deferred() {
+  let resolve;
+  const promise = new Promise((r) => { resolve = r; });
+  return { promise, resolve };
+}
+let fetchMock;
+
+function makeStore(settings, overrides = {}) {
+  fetchMock = vi.fn(async (url, options = {}) => {
+    if ((options.method || 'GET') !== 'GET') throw new Error(`Unexpected settings write: ${url}`);
+    if (url.endsWith('/users/settings')) return { ok: true, json: async () => settings };
+    if (/\/models\/[^/]+\/models$/.test(url)) return { ok: true, json: async () => ({ models }) };
+    if (url.endsWith('/metadata')) return { ok: true, json: async () => ({ success: true, metadata: {} }) };
+    throw new Error(`Unexpected request: ${url}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return createStore({
+    modules: {
+      aiProvider: {
+        ...aiProvider,
+        state: () => ({
+          ...aiProvider.state,
+          providers: [...aiProvider.state.providers],
+          customProviders: [],
+          allModels: {},
+          loadingModels: {},
+          modelMetadata: {},
+          selectedProvider: null,
+          selectedModel: null,
+          ...overrides,
+        }),
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  invalidateAllFreshness();
+  localStorage.clear();
+  localStorage.setItem('token', 'synthetic-test-token');
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('Given an account default whose provider differs only in case', () => {
+  it.each([
+    ['openai-codex', 'OpenAI-Codex', 'openai-codex'],
+    ['OPENAI-CODEX', 'OpenAI-Codex', 'openai-codex'],
+    ['OpenAI-Codex', 'OpenAI-Codex', 'openai-codex'],
+    ['gemini-cli', 'Gemini-CLI', 'gemini-cli'],
+    ['claude-code', 'Claude-Code', 'claude-code'],
+    ['anthropic', 'Anthropic', 'anthropic'],
+    ['openai', 'OpenAI', 'openai'],
+    ['z.ai', 'Z.AI', 'zai'],
+  ])('when loading %s, then fetch via %s and retain the saved model', async (savedProvider, canonical, key) => {
+    const store = makeStore({ selectedProvider: savedProvider, selectedModel: models[1] });
+    await store.dispatch('aiProvider/loadUserSettings');
+
+    expect(store.state.aiProvider.selectedProvider).toBe(canonical);
+    expect(store.state.aiProvider.selectedModel).toBe(models[1]);
+    expect(store.state.aiProvider.allModels[canonical]).toEqual(models);
+    expect(localStorage.getItem('selectedProvider')).toBe(canonical);
+    expect(localStorage.getItem('selectedModel')).toBe(models[1]);
+    expect(fetchMock.mock.calls.some(([url]) => url.endsWith(`/models/${key}/models`))).toBe(true);
+    expect(fetchMock.mock.calls.every(([, opts = {}]) => (opts.method || 'GET') === 'GET')).toBe(true);
+  });
+
+  it('when another boot task has already canonicalized the selection, then settings loading does not undo it', async () => {
+    const store = makeStore({ selectedProvider: 'openai-codex', selectedModel: models[1] }, {
+      selectedProvider: 'OpenAI-Codex', selectedModel: models[1],
+      allModels: { 'OpenAI-Codex': [...models] },
+    });
+    localStorage.setItem('OpenAI-Codex_models', JSON.stringify({ models, timestamp: Date.now() }));
+    await store.dispatch('aiProvider/loadUserSettings');
+    expect(store.state.aiProvider.selectedProvider).toBe('OpenAI-Codex');
+    expect(store.state.aiProvider.selectedModel).toBe(models[1]);
+    expect(store.state.aiProvider.allModels['openai-codex']).toBeUndefined();
+  });
+});
+
+describe('Given settings outside the built-in provider case-drift path', () => {
+  it('preserves an exact custom-provider identifier and its dedicated fetch path', async () => {
+    const id = 'CUSTOM-A1b2';
+    const store = makeStore({ selectedProvider: id, selectedModel: models[1] }, {
+      customProviders: [{ id, provider_name: 'Private model host' }],
+    });
+    fetchMock.mockImplementation(async (url) => {
+      if (url.endsWith('/users/settings')) return { ok: true, json: async () => ({ selectedProvider: id, selectedModel: models[1] }) };
+      if (url.endsWith(`/custom-providers/${id}/models`)) return { ok: true, json: async () => ({ models }) };
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    await store.dispatch('aiProvider/loadUserSettings');
+    expect(store.state.aiProvider.selectedProvider).toBe(id);
+    expect(store.state.aiProvider.selectedModel).toBe(models[1]);
+    expect(fetchMock.mock.calls.some(([url]) => url.endsWith(`/custom-providers/${id}/models`))).toBe(true);
+  });
+
+  it('leaves a missing saved provider alone instead of choosing a different provider', async () => {
+    const store = makeStore({ selectedProvider: null, selectedModel: null });
+    await store.dispatch('aiProvider/loadUserSettings');
+    expect(store.state.aiProvider.selectedProvider).toBeNull();
+    expect(store.state.aiProvider.selectedModel).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reinterpret an unknown provider as a built-in or silently fetch another provider', async () => {
+    const store = makeStore({ selectedProvider: 'unknown-provider', selectedModel: models[1] });
+    await store.dispatch('aiProvider/loadUserSettings');
+    expect(store.state.aiProvider.selectedProvider).toBe('unknown-provider');
+    expect(store.state.aiProvider.selectedModel).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+
+describe('Given concurrent settings and provider-list initialization', () => {
+  it.each(['settings-first', 'providers-first'])('retains the saved model with %s completion', async (order) => {
+    const settings = { selectedProvider: 'openai-codex', selectedModel: models[1] };
+    const store = makeStore(settings, { selectedProvider: 'openai-codex' });
+    const settingsResponse = deferred();
+    const providersResponse = deferred();
+    fetchMock.mockImplementation(async (url) => {
+      if (url.endsWith('/users/settings')) return settingsResponse.promise;
+      if (url.endsWith('/custom-providers')) return providersResponse.promise;
+      if (url.endsWith('/models/openai-codex/models')) return { ok: true, json: async () => ({ models }) };
+      if (url.endsWith('/metadata')) return { ok: true, json: async () => ({ success: true, metadata: {} }) };
+      throw new Error('Unexpected request: ' + url);
+    });
+    const loadingSettings = store.dispatch('aiProvider/loadUserSettings');
+    const loadingProviders = store.dispatch('aiProvider/fetchCustomProviders', { forceRefresh: true });
+    if (order === 'settings-first') {
+      settingsResponse.resolve({ ok: true, json: async () => settings });
+      await loadingSettings;
+      providersResponse.resolve({ ok: true, json: async () => ({ providers: [] }) });
+    } else {
+      providersResponse.resolve({ ok: true, json: async () => ({ providers: [] }) });
+      await loadingProviders;
+      settingsResponse.resolve({ ok: true, json: async () => settings });
+    }
+    await Promise.all([loadingSettings, loadingProviders]);
+    expect(store.state.aiProvider.selectedProvider).toBe('OpenAI-Codex');
+    expect(store.state.aiProvider.selectedModel).toBe(models[1]);
+    expect(localStorage.getItem('selectedModel')).toBe(models[1]);
+    expect(fetchMock.mock.calls.every(([, options = {}]) => (options.method || 'GET') === 'GET')).toBe(true);
+  });
+});
+
+it('uses the dedicated Local fetcher for a lowercase saved Local provider', async () => {
+  const store = makeStore({ selectedProvider: 'local', selectedModel: models[1] });
+  localStorage.setItem('Local_models', JSON.stringify({ models, timestamp: Date.now() }));
+  await store.dispatch('aiProvider/loadUserSettings');
+  expect(store.state.aiProvider.selectedProvider).toBe('Local');
+  expect(store.state.aiProvider.selectedModel).toBe(models[1]);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+it('preserves current preferences when the settings service is unavailable', async () => {
+  const store = makeStore({}, { selectedProvider: 'OpenAI-Codex', selectedModel: models[1] });
+  fetchMock.mockResolvedValue({ ok: false, status: 503 });
+  await store.dispatch('aiProvider/loadUserSettings');
+  expect(store.state.aiProvider.selectedProvider).toBe('OpenAI-Codex');
+  expect(store.state.aiProvider.selectedModel).toBe(models[1]);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});

--- a/tests/e2e/header-model-selector.spec.js
+++ b/tests/e2e/header-model-selector.spec.js
@@ -1,0 +1,69 @@
+/** Real app/header/picker; synthetic settings and model responses, no provider calls. */
+import { test, expect, gotoApp } from './fixtures/appFixture.js';
+
+const savedModel = 'saved-test-model';
+const json = (body) => ({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+async function mockModelSettings(page, models) {
+  await page.route('**/api/users/settings', (route) => {
+    if (route.request().method() !== 'GET') return route.fulfill(json({ success: true }));
+    return route.fulfill(json({ selectedProvider: 'openai-codex', selectedModel: savedModel, routingMode: 'static' }));
+  });
+  await page.route('**/api/custom-providers', (route) => route.fulfill(json({ providers: [] })));
+  await page.route('**/api/models/*/models', (route) => route.fulfill(json({ models })));
+  await page.route('**/api/models/*/metadata', (route) => route.fulfill(json({ success: true, metadata: {} })));
+  await page.route('**/api/auth/connected', (route) => route.fulfill(json(['OpenAI-Codex'])));
+  // The real picker checks local-model availability on mount. No LM Studio
+  // instance is needed, and no request should reach an installed provider.
+  await page.route('http://127.0.0.1:1234/**', (route) => route.fulfill(json({ data: [] })));
+}
+
+test.describe('Top-right default model selector', () => {
+  test('loads a lowercase saved provider without losing its model @ci', async ({ appPage }) => {
+    await mockModelSettings(appPage, ['recommended-test-model', savedModel]);
+    await gotoApp(appPage, '/settings');
+    const selector = appPage.getByRole('button', { name: 'Change default AI model' });
+    await expect(selector).toBeVisible();
+    await expect(selector).toContainText('openai-codex/' + savedModel);
+    await expect.poll(() => appPage.evaluate(() => localStorage.getItem('selectedProvider'))).toBe('OpenAI-Codex');
+    await expect.poll(() => appPage.evaluate(() => localStorage.getItem('selectedModel'))).toBe(savedModel);
+    await appPage.reload({ waitUntil: 'domcontentloaded' });
+    await expect(selector).toBeVisible();
+    await expect(selector).toContainText('openai-codex/' + savedModel);
+  });
+
+  test('keeps a keyboard-operated recovery control with an empty catalog @ci', async ({ appPage }) => {
+    await mockModelSettings(appPage, []);
+    await gotoApp(appPage, '/settings');
+    // Wait for the actual settings action to settle, not just first paint.
+    await expect.poll(() => appPage.evaluate(() => localStorage.getItem('selectedProvider'))).toBe('OpenAI-Codex');
+    await expect.poll(() => appPage.evaluate(() => localStorage.getItem('selectedModel'))).toBeNull();
+    const selector = appPage.getByRole('button', { name: 'Change default AI model' });
+    const picker = appPage.locator('.cv-toolbar-selector');
+    await expect(appPage.locator('#cvClock')).toBeVisible();
+    await expect(selector).toBeVisible();
+    await expect(selector).toHaveText('Select model');
+    await expect(selector).toHaveAttribute('aria-expanded', 'false');
+
+    await selector.focus();
+    await expect(selector).toBeFocused();
+    await appPage.keyboard.press('Enter');
+    await expect(picker).toBeVisible();
+    await expect(selector).toHaveAttribute('aria-expanded', 'true');
+    // Await the real picker's mounted hook, which registers Escape after
+    // its local-server check and nextTick selection synchronization.
+    await expect(picker.locator('.selector-label-row')).toBeVisible();
+    await appPage.keyboard.press('Escape');
+    await expect(picker).toHaveCount(0);
+    await expect(selector).toHaveAttribute('aria-expanded', 'false');
+
+    await selector.focus();
+    await appPage.keyboard.press('Space');
+    await expect(picker).toBeVisible();
+    await expect(selector).toHaveAttribute('aria-expanded', 'true');
+    await appPage.locator('#cvClock').click();
+    await expect(picker).toHaveCount(0);
+    await expect(selector).toBeVisible();
+    await expect(selector).toHaveAttribute('aria-expanded', 'false');
+  });
+});


### PR DESCRIPTION
## What problem does this solve?

The default model selector beside the top-right clock can disappear after startup even though the account still has a saved provider/model.

The settings API can return `openai-codex`, while the frontend provider list and model cache use `OpenAI-Codex`. `loadUserSettings` did case-sensitive lookups, skipped fetching that provider's models, and then cleared the selected model. The header's `v-if="globalModelLabel"` removed the entire recovery control.

## How does it solve it?

- Reuse `canonicalizeProviderCase` **before** fetching, cache lookup, and provider commit. Exact custom-provider IDs remain opaque; unknown providers are not remapped.
- Keep the header control available without a selected model, labeled **Select model**.
- Use a native `type="button"` control with an accessible name and live `aria-expanded` state.
- Add 23 store/component cases plus two real-app Playwright tests tagged `@ci`. Cover both settings/provider-list completion orders, lowercase providers, Local/custom/unknown paths, settings failure, model persistence through reload, and Enter/Space/Escape/outside-click behavior.
- Document the control and regression contract in `docs/HEADER_MODEL_SELECTOR.md`.

Scope: six files only, based directly on current upstream main `5ede8e72`. No backend, auth/session, credential-handling, dependency, workflow, generated-build, or pending image/Codex-account feature changes. The production source patch is the same one confirmed working by the reporter in the app.

## How did you verify it?

Watched the new store/component tests fail on unpatched upstream:

```text
Test Files  2 failed (2)
     Tests  15 failed | 8 passed (23)
```

After applying the fix in a clean linked worktree:

```text
Focused regression tests
Test Files  2 passed (2)
     Tests  23 passed (23)

Full frontend suite
Test Files  262 passed (262)
     Tests  4459 passed (4459)

Full backend suite (local Node 26 compatibility setup described below)
Test Files  374 passed (374)
     Tests  5910 passed | 1 skipped (5911)

Full tagged browser suite
27 passed (32.1s)

Production frontend build: passed
Working-tree line-ending check: 2699 attributed files, 0 rewrites
Git whitespace check: passed
```

**Local environment disclosure:** local Node is 26.8.1, whereas repository CI uses Node 20. Frontend/jsdom runs used `NODE_OPTIONS=--no-experimental-webstorage`. The first unadjusted backend run hit Vitest resolution errors for Node built-ins `stream` and `stream/promises`, plus a browser launch failure from a long Unix socket path. Re-running the complete suite with a workspace-only config aliasing those two names to their `node:` forms, and a shorter workspace-owned `TMPDIR`, passed without exclusions or changed assertions. Browser tests used installed Chromium and an isolated fixture server on a non-production port. All local compatibility configs and test artifacts remain outside the PR. CI must verify the unmodified repository configuration on Node 20; local results are not a claim that CI has passed.

Existing assets and live user settings were not touched during PR preparation. Tests use synthetic settings/model responses and the existing isolated data/backend fixtures.

## Checklist

- [x] This does not modify auth, sessions, or credential handling
- [x] This is not a fix for a security vulnerability
- [ ] Unmodified `npm test` passes in CI (pending; complete local run passed with disclosed Node 26 compatibility setup)
- [x] Full frontend suite passes locally (Node 26 jsdom flag noted above)
- [x] New behaviour has tests, and I watched them fail before the fix
- [x] Docs updated for the visible fallback/button behavior
- [x] Commit subject is 72 characters or fewer
