### PR TITLE
fix(ui): migrate deprecated Vue deep selectors

### DIFF
--- a/frontend/src/utils/deepSelectors.bdd.spec.js
+++ b/frontend/src/utils/deepSelectors.bdd.spec.js
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse, compileStyle } from '@vue/compiler-sfc';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const cases = [
+  ['views/_components/common/CreditPurchase.vue', ['.StripeElement', '.StripeElement--focus', '.StripeElement--invalid'].map(s => [`::v-deep ${s}`, `:deep(${s})`])],
+  ['views/Terminal/CenterPanel/screens/Connectors/Connectors.vue', [['::v-deep .col-actions', ':deep(.col-actions)']]],
+  ['views/Terminal/CenterPanel/screens/WorkflowForge/components/WorkflowDesigner/components/Canvas/components/Widgets/MarkdownPreview.vue', ['h1', 'h2', 'h3', 'code', 'pre', 'pre code', 'a', 'a:hover', 'ul', 'li', 'img', 'p'].map(s => [`.markdown-preview >>> ${s}`, `.markdown-preview :deep(${s})`])],
+];
+function styles(file) {
+  const result = parse(fs.readFileSync(path.join(root, file), 'utf8'), { filename: file });
+  expect(result.errors).toEqual([]);
+  return result.descriptor.styles;
+}
+function compile(source, scoped) {
+  const result = compileStyle({ source, filename: 'contract.vue', id: 'data-v-contract', scoped });
+  expect(result.errors).toEqual([]);
+  return result.code;
+}
+function vueFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(e => {
+    const p = path.join(dir, e.name);
+    return e.isDirectory() ? vueFiles(p) : e.name.endsWith('.vue') ? [path.relative(root, p)] : [];
+  });
+}
+
+describe('Given Vue scoped styles with deep descendants', () => {
+  it.each(cases)('When %s is compiled, Then modern deep selectors emit no deprecation warnings', (file, pairs) => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const blocks = styles(file);
+      const source = blocks.map(s => s.content).join('\n');
+      for (const [, modern] of pairs) expect(source).toContain(modern + ' {');
+      for (const block of blocks) compile(block.content, block.scoped);
+      expect(warn.mock.calls.flat().join('\n')).not.toMatch(/deprecated/i);
+    } finally { warn.mockRestore(); }
+  });
+
+  it.each(cases)('When %s migrates, Then compiled CSS is identical to the legacy selector form', (file, pairs) => {
+    // Reconstruct only the pinned old selectors; declarations and every other
+    // style remain the same. This catches moving :deep() across a scope boundary.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      for (const block of styles(file)) {
+        let legacy = block.content;
+        for (const [old, modern] of pairs) legacy = legacy.replace(modern + ' {', old + ' {');
+        expect(compile(block.content, block.scoped)).toBe(compile(legacy, block.scoped));
+      }
+    } finally { warn.mockRestore(); }
+  });
+
+  it('When any source SFC is added or edited, Then its style blocks cannot reintroduce deprecated deep combinators', () => {
+    const offenders = [];
+    for (const file of vueFiles(root)) {
+      for (const block of styles(file)) {
+        const css = block.content.replace(/\/\*[\s\S]*?\*\//g, '');
+        if (/::v-deep(?!\s*\()|>>>|\/deep\//.test(css)) offenders.push(file);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/frontend/src/views/Terminal/CenterPanel/screens/Connectors/Connectors.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Connectors/Connectors.vue
@@ -2880,7 +2880,7 @@ body.dark .form-actions {
   text-align: center;
 }
 
-::v-deep .col-actions {
+:deep(.col-actions) {
   gap: 8px;
   justify-content: flex-end;
 }

--- a/frontend/src/views/Terminal/CenterPanel/screens/WorkflowForge/components/WorkflowDesigner/components/Canvas/components/Widgets/MarkdownPreview.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/WorkflowForge/components/WorkflowDesigner/components/Canvas/components/Widgets/MarkdownPreview.vue
@@ -194,25 +194,25 @@ export default {
   overflow-wrap: break-word;
 }
 
-.markdown-preview >>> h1 {
+.markdown-preview :deep(h1) {
   /* font-size: 2em; */
   /* margin: 0 0 0.67em; */
   font-weight: 600;
 }
 
-.markdown-preview >>> h2 {
+.markdown-preview :deep(h2) {
   /* font-size: 1.5em; */
   /* margin: 0.75em 0; */
   font-weight: 600;
 }
 
-.markdown-preview >>> h3 {
+.markdown-preview :deep(h3) {
   /* font-size: 1.17em; */
   /* margin: 0.83em 0; */
   font-weight: 600;
 }
 
-.markdown-preview >>> code {
+.markdown-preview :deep(code) {
   /* background: #f5f5f5; */
   padding: 2px 6px;
   border-radius: 3px;
@@ -220,41 +220,41 @@ export default {
   /* font-size: 0.9em; */
 }
 
-.markdown-preview >>> pre {
+.markdown-preview :deep(pre) {
   /* background: #f5f5f5; */
   padding: 12px;
   border-radius: 4px;
   overflow-x: auto;
 }
 
-.markdown-preview >>> pre code {
+.markdown-preview :deep(pre code) {
   background: none;
   padding: 0;
 }
 
-.markdown-preview >>> a {
+.markdown-preview :deep(a) {
   color: var(--color-blue);
   text-decoration: none;
 }
 
-.markdown-preview >>> a:hover {
+.markdown-preview :deep(a:hover) {
   text-decoration: underline;
 }
 
-.markdown-preview >>> ul {
+.markdown-preview :deep(ul) {
   padding-left: 20px;
 }
 
-.markdown-preview >>> li {
+.markdown-preview :deep(li) {
   /* margin: 4px 0; */
 }
 
-.markdown-preview >>> img {
+.markdown-preview :deep(img) {
   max-width: 100%;
   height: auto;
 }
 
-.markdown-preview >>> p {
+.markdown-preview :deep(p) {
   margin-bottom: 16px;
 }
 

--- a/frontend/src/views/_components/common/CreditPurchase.vue
+++ b/frontend/src/views/_components/common/CreditPurchase.vue
@@ -435,16 +435,16 @@ button.button-ready {
 }
 
 /* Override Stripe's default styles */
-::v-deep .StripeElement {
+:deep(.StripeElement) {
   background-color: transparent !important;
   padding: 0 !important;
 }
 
-::v-deep .StripeElement--focus {
+:deep(.StripeElement--focus) {
   box-shadow: none !important;
 }
 
-::v-deep .StripeElement--invalid {
+:deep(.StripeElement--invalid) {
   border-color: var(--color-primary) !important;
 }
 


### PR DESCRIPTION
## Summary
Migrate all 16 deprecated Vue deep selectors in three components to `:deep(...)`:
- CreditPurchase: three Stripe selectors
- Connectors: one action-column selector
- MarkdownPreview: twelve descendant selectors, including `pre code` and `a:hover`

No declaration, template, runtime behavior, dependency, bundling configuration, or warning threshold changes. This branch is isolated from `origin/main` at `8b116452` and excludes ongoing browser, image, goal, and lifecycle work.

## Regression coverage / Gherkin-style RED–GREEN
Added `frontend/src/utils/deepSelectors.bdd.spec.js`:
- Given each affected SFC, when compiled, then modern selectors produce no deprecation warnings.
- Given the migration, when Vue compiles modern and reconstructed legacy selectors with the same scope ID, then all compiled CSS is byte-identical (including nested descendants/pseudo-classes).
- Given any source SFC, when its style blocks are scanned, then deprecated deep combinators cannot be reintroduced.

RED before migration: **4 failures, 3 passes** (three adoption assertions plus the source-wide guard failed).
GREEN after migration: **7/7 new cases pass**.
Combined with existing CreditPurchase coverage: **46 tests pass** in two files.

## Validation
- `cd frontend && node node_modules/vitest/vitest.mjs run src/utils/deepSelectors.bdd.spec.js src/views/_components/common/CreditPurchase.spec.js`
- `cd frontend && npm run build` — passed in 14.57s; zero deprecated deep-selector warnings.
- `git diff --check` — passed.

The separate >500 kB chunk warning remains intentionally unchanged. Bundle measurement and loading optimizations belong in separate PRs; this PR does not claim a speed improvement or hide warnings by raising thresholds.

## Scope / rollout
Only three Vue files plus one new regression test. Tested in an isolated source worktree using the existing installed dependency directories; Vite's dependency guard passed. Full frontend suite and browser visual E2E were not run; compiled CSS equivalence and existing CreditPurchase component tests are the evidence here.

Not applied to the running application's checkout or published frontend. No backend restart required for this CSS-only change; local adoption needs a frontend build/refresh after merge or an authorized cherry-pick.
