### PR TITLE
fix(browser): readable welcome address and accurate scheme handling

### DIFF
--- a/frontend/src/canvas/widgets/BrowserToolbar.spec.js
+++ b/frontend/src/canvas/widgets/BrowserToolbar.spec.js
@@ -70,6 +70,16 @@ describe('Given honest address handling', () => {
 });
 
 describe('BrowserToolbar', () => {
+  it('Given focused address text, When the page changes then focus leaves, Then the actual current URL is shown',async()=>{
+    const w=mount(BrowserToolbar,{props:{url:'https://old.example'}});
+    await w.get('input').trigger('focus');await w.setProps({url:'https://new.example'});
+    await w.get('input').trigger('blur');expect(w.get('input').element.value).toBe('https://new.example');w.unmount();
+  });
+  it('Given busy navigation, When form submit is triggered, Then no duplicate navigation is emitted',async()=>{
+    const w=mount(BrowserToolbar,{props:{url:'https://example.com',busy:true}});
+    await w.get('form').trigger('submit');expect(w.emitted('navigate')).toBeUndefined();w.unmount();
+  });
+
   it('turns a hostname into an HTTPS navigation', async () => {
     const wrapper = mount(BrowserToolbar, { props: { url: 'about:blank' } });
     const input = wrapper.get('input[aria-label="Address"]');

--- a/frontend/src/canvas/widgets/BrowserToolbar.spec.js
+++ b/frontend/src/canvas/widgets/BrowserToolbar.spec.js
@@ -2,6 +2,73 @@ import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import BrowserToolbar from './BrowserToolbar.vue';
 
+// Pin the actual internal page contract; near-matches must remain visible.
+const welcomeHtml = '<!doctype html><title>AGNT Browser</title>'
+  + '<body style="margin:0;height:100vh;display:grid;place-items:center;'
+  + 'background:#0d0d16;color:#8b8ba3;font:15px system-ui">'
+  + '<div style="text-align:center"><div style="font-size:34px;margin-bottom:12px">🌐</div>'
+  + 'AGNT Browser — ready.<br>Ask Annie to browse something.</div>';
+const welcomeUrl = 'data:text/html;charset=utf-8,' + encodeURIComponent(welcomeHtml);
+
+describe('Given the internal AGNT welcome page', () => {
+  it('When displayed, Then it has an empty address with a readable placeholder and Go does nothing', async () => {
+    const w = mount(BrowserToolbar, {props:{url:welcomeUrl}});
+    expect(w.get('input').element.value).toBe('');
+    expect(w.get('input').attributes('placeholder')).toBe('AGNT Browser — ready');
+    expect(w.get('.go-button').attributes('disabled')).toBeDefined();
+    await w.get('form').trigger('submit');
+    expect(w.emitted('navigate')).toBeUndefined();
+    w.unmount();
+  });
+  it('When cancelled or blurred empty, Then the encoded page does not reappear', async () => {
+    const w = mount(BrowserToolbar, {props:{url:welcomeUrl}});
+    await w.get('input').setValue('example.com');
+    await w.get('input').trigger('keydown', {key:'Escape'});
+    expect(w.get('input').element.value).toBe('');
+    await w.get('input').trigger('blur');
+    expect(w.get('input').element.value).toBe('');
+    await w.setProps({url:'https://example.com/path'});
+    expect(w.get('input').element.value).toBe('https://example.com/path');
+    await w.setProps({url:welcomeUrl});
+    expect(w.get('input').element.value).toBe('');
+    w.unmount();
+  });
+  it('When a data page only resembles the welcome page, Then its address is not disguised', () => {
+    const url='data:text/html;charset=utf-8,'+encodeURIComponent(welcomeHtml+'<script>1</script>');
+    const w=mount(BrowserToolbar,{props:{url}});
+    expect(w.get('input').element.value).toBe(url);
+    w.unmount();
+  });
+});
+
+describe('Given honest address handling', () => {
+  it.each(['http://example.com', welcomeUrl, 'about:blank'])('When not HTTPS, Then no lock is shown: %s', url => {
+    const w=mount(BrowserToolbar,{props:{url}});
+    expect(w.find('.fa-lock').exists()).toBe(false);
+    w.unmount();
+  });
+  it('When the current page is HTTPS, Then its lock stays tied to the page rather than the draft', async () => {
+    const w=mount(BrowserToolbar,{props:{url:'https://example.com'}});
+    expect(w.find('.fa-lock').exists()).toBe(true);
+    await w.get('input').setValue('http://example.net');
+    expect(w.find('.fa-lock').exists()).toBe(true);
+    w.unmount();
+  });
+  it.each(['data:text/html,hello', 'about:blank', 'javascript:alert(1)', 'file:///tmp/test', 'ftp://example.com'])('When Go is submitted for a non-web scheme, Then no navigation is emitted: %s', async url => {
+    const w=mount(BrowserToolbar,{props:{url}});
+    await w.get('form').trigger('submit');
+    expect(w.emitted('navigate')).toBeUndefined();
+    w.unmount();
+  });
+  it('When a bare host includes a port, Then it is still normalized to HTTPS', async () => {
+    const w=mount(BrowserToolbar,{props:{url:'about:blank'}});
+    await w.get('input').setValue('localhost:3000/path');
+    await w.get('form').trigger('submit');
+    expect(w.emitted('navigate')).toEqual([['https://localhost:3000/path']]);
+    w.unmount();
+  });
+});
+
 describe('BrowserToolbar', () => {
   it('turns a hostname into an HTTPS navigation', async () => {
     const wrapper = mount(BrowserToolbar, { props: { url: 'about:blank' } });

--- a/frontend/src/canvas/widgets/BrowserToolbar.vue
+++ b/frontend/src/canvas/widgets/BrowserToolbar.vue
@@ -91,6 +91,7 @@ function normalizeBrowserAddress(value) {
 }
 
 function submitAddress() {
+  if (props.busy) return;
   const url = normalizeBrowserAddress(draftUrl.value);
   if (!url) return;
   draftUrl.value = url;
@@ -101,7 +102,8 @@ function submitAddress() {
 
 function finishEditing() {
   editing.value = false;
-  if (!draftUrl.value.trim()) draftUrl.value = displayAddress(props.url);
+  // On blur show the actual page, never stale draft text from before a redirect.
+  draftUrl.value = displayAddress(props.url);
 }
 
 function cancelEditing() {

--- a/frontend/src/canvas/widgets/BrowserToolbar.vue
+++ b/frontend/src/canvas/widgets/BrowserToolbar.vue
@@ -27,12 +27,13 @@
       ><i class="fas fa-redo-alt"></i></button>
     </div>
 
-    <i class="fas fa-lock address-security" aria-hidden="true"></i>
+    <i class="fas address-security" :class="isHttps ? 'fa-lock is-https' : 'fa-globe'" aria-hidden="true"></i>
     <input
       ref="addressRef"
       v-model="draftUrl"
       class="address-input"
       aria-label="Address"
+      :placeholder="isWelcomePage ? 'AGNT Browser — ready' : 'Enter a website address'"
       autocomplete="off"
       autocapitalize="off"
       spellcheck="false"
@@ -40,12 +41,12 @@
       @blur="finishEditing"
       @keydown.esc="cancelEditing"
     />
-    <button type="submit" class="go-button" :disabled="busy || !draftUrl.trim()">Go</button>
+    <button type="submit" class="go-button" :disabled="busy || !normalizeBrowserAddress(draftUrl)">Go</button>
   </form>
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 const props = defineProps({
   url: { type: String, default: '' },
@@ -56,18 +57,37 @@ const props = defineProps({
 
 const emit = defineEmits(['back', 'forward', 'reload', 'navigate']);
 const addressRef = ref(null);
-const draftUrl = ref(props.url || 'about:blank');
+// Exact match only: do not disguise arbitrary data pages by title or prefix.
+// Kept in sync with browserFallbackSurface.js START_PAGE by the toolbar tests.
+const welcomeUrl = 'data:text/html;charset=utf-8,' + encodeURIComponent(
+  '<!doctype html><title>AGNT Browser</title>'
+  + '<body style="margin:0;height:100vh;display:grid;place-items:center;'
+  + 'background:#0d0d16;color:#8b8ba3;font:15px system-ui">'
+  + '<div style="text-align:center"><div style="font-size:34px;margin-bottom:12px">🌐</div>'
+  + 'AGNT Browser — ready.<br>Ask Annie to browse something.</div>',
+);
+const isWelcomePage = computed(() => props.url === welcomeUrl);
+const isHttps = computed(() => {
+  try { return new URL(props.url).protocol === 'https:'; } catch { return false; }
+});
+const displayAddress = url => url === welcomeUrl ? '' : (url || 'about:blank');
+const draftUrl = ref(displayAddress(props.url));
 const editing = ref(false);
 
 watch(() => props.url, (url) => {
-  if (!editing.value) draftUrl.value = url || 'about:blank';
+  if (!editing.value) draftUrl.value = displayAddress(url);
 });
 
 function normalizeBrowserAddress(value) {
   const address = String(value || '').trim();
   if (!address) return '';
-  if (/^https?:\/\//i.test(address)) return address;
-  return `https://${address}`;
+  if (/^https?:\/\//i.test(address)) {
+    try { return new URL(address).hostname ? address : ''; } catch { return ''; }
+  }
+  // A numeric host port is not a URL scheme (e.g. localhost:3000).
+  const hostWithPort = /^(?:localhost|[a-z0-9.-]+|\[[0-9a-f:]+\]):\d+(?:[/?#]|$)/i.test(address);
+  if (/^[a-z][a-z0-9+.-]*:/i.test(address) && !hostWithPort) return '';
+  try { return new URL(`https://${address}`).hostname ? `https://${address}` : ''; } catch { return ''; }
 }
 
 function submitAddress() {
@@ -81,11 +101,11 @@ function submitAddress() {
 
 function finishEditing() {
   editing.value = false;
-  if (!draftUrl.value.trim()) draftUrl.value = props.url || 'about:blank';
+  if (!draftUrl.value.trim()) draftUrl.value = displayAddress(props.url);
 }
 
 function cancelEditing() {
-  draftUrl.value = props.url || 'about:blank';
+  draftUrl.value = displayAddress(props.url);
   editing.value = false;
   addressRef.value?.blur();
 }
@@ -141,8 +161,12 @@ function cancelEditing() {
 
 .address-security {
   margin-left: 2px;
-  color: var(--color-green);
+  color: var(--color-text-muted);
   font-size: 10px;
+}
+
+.address-security.is-https {
+  color: var(--color-green);
 }
 
 .address-input {


### PR DESCRIPTION
## Summary
Keep AGNT's exact built-in welcome data URL out of the address field without disguising arbitrary data pages. Show a readable placeholder, use the lock only for HTTPS, and reject non-web scheme submissions while preserving host:port navigation.

Independent two-file frontend change; no recovery-protocol dependency. Companion to browser recovery, not bundle optimization. No browser launch, navigation, or backend restart required to adopt; rebuild/refresh the frontend.

## RED–GREEN and local verification
- Earlier local RED: 10 failures before implementation; targeted toolbar suite 17 passed afterward.
- Fresh clean-upstream worktree: **28 tests pass** (toolbar, BrowserUsability, streamGeometry).
- Production frontend build passes; unrelated deep-selector and large-chunk warnings remain outside scope.
- Already installed/published in the running local app; tests cover exact welcome match, near-match remains visible, cancel/blur, HTTPS icon, blocked schemes and host ports. No fresh visual screenshot comparison claimed.

## Scope
Exactly BrowserToolbar.vue and BrowserToolbar.spec.js. No unrelated dirty-checkout changes. Draft for review, not merge authorization.


## Merge-readiness follow-up (2026-09-10)
Two additional RED failures fixed: stale page URL after blur, and form submissions while busy. 30 focused tests and production build pass. Latest CI at 9e347ff0 is green; node:test is still report-only with known failures.

No reviewer approval or merge implied. New hardening is not installed in the running app. Welcome HTML is duplicated for exact matching: future start-page changes must update the match/tests together.
