### PR TITLE
fix(goals): show NEEDS REVIEW and clear stale chat progress

### DIFF
--- a/frontend/src/store/features/goals.js
+++ b/frontend/src/store/features/goals.js
@@ -92,6 +92,13 @@ const getters = {
   getGoalTaskProgress: (state) => (goalId) => state.goalTaskProgress[goalId] || null,
 };
 
+function clearInactiveProgress(state, goal) {
+  if (['needs_review','validated','completed','failed','error','stopped','paused','planning','pending'].includes(goal.status)) {
+    const { [goal.id]: obsolete, ...rest } = state.liveIteration;
+    state.liveIteration = rest;
+  }
+}
+
 const mutations = {
   SET_LOADING(state, loading) {
     state.isLoading = loading;
@@ -107,6 +114,7 @@ const mutations = {
 
   SET_GOALS(state, goals) {
     state.goals = goals;
+    goals.forEach(goal => clearInactiveProgress(state, goal));
   },
 
   SET_GOALS_SUMMARY(state, goals) {
@@ -126,7 +134,10 @@ const mutations = {
     const index = state.goals.findIndex((goal) => goal.id === updatedGoal.id);
     if (index !== -1) {
       state.goals.splice(index, 1, { ...state.goals[index], ...updatedGoal });
+    } else if (updatedGoal.status) {
+      state.goals.push(updatedGoal);
     }
+    clearInactiveProgress(state, updatedGoal);
   },
 
   REMOVE_GOAL(state, goalId) {
@@ -1261,6 +1272,8 @@ const actions = {
       if (!response.ok) return;
 
       const status = await response.json();
+      if (status.status) commit('UPDATE_GOAL', { id: goalId, status: status.status,
+        ...(status.loop_status !== undefined ? {loop_status:status.loop_status} : {}) });
       if (!status.allTasks || status.allTasks.length === 0) return;
 
       // Hydrate goalTaskProgress from the API response

--- a/frontend/src/store/features/goals.reviewState.spec.js
+++ b/frontend/src/store/features/goals.reviewState.spec.js
@@ -1,0 +1,20 @@
+import { describe,it,expect,vi,afterEach } from 'vitest';
+vi.mock('@/tt.config.js',()=>({API_CONFIG:{BASE_URL:'http://fixture/api'}}));
+vi.hoisted(()=>{const data=new Map();Object.defineProperty(globalThis,'localStorage',{configurable:true,value:{getItem:k=>data.get(k)??null,setItem:(k,v)=>data.set(k,v),clear:()=>data.clear()}});});
+import { mount,flushPromises } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import goals from './goals.js';
+import Widget from '../../views/Terminal/CenterPanel/screens/Chat/components/GoalProgressWidget.vue';
+function storeFor(status='executing') {
+ return createStore({modules:{goals:{...goals,state:()=>({...goals.state,goals:status?[{id:'g',status}]:[],liveIteration:{g:{phase:'evaluating',iteration:6}},goalTaskProgress:{g:{total:4,completed:4,running:0,failed:0,tasks:{}}},requestCache:new Map(),goalStatusSubscriptions:new Map()}),actions:{...goals.actions,fetchGoals:vi.fn()}}}});
+}
+afterEach(()=>{vi.unstubAllGlobals();localStorage.clear();});
+describe('Given a completed-task goal requiring review',()=>{
+ it.each(['needs_review','paused','stopped','failed'])('When authoritative %s arrives Then clear stale phase without changing task counts',status=>{const s=storeFor();s.commit('goals/UPDATE_GOAL',{id:'g',status,loop_status:'stopped'});expect(s.state.goals.liveIteration.g).toBeUndefined();expect(s.state.goals.goalTaskProgress.g.completed).toBe(4);});
+ it('When refreshed list includes needs_review Then clear stale live phase',()=>{const s=storeFor();s.commit('goals/SET_GOALS',[{id:'g',status:'needs_review'}]);expect(s.state.goals.liveIteration.g).toBeUndefined();});
+ it('When task-status hydration returns needs_review without tasks Then still hydrate goal status',async()=>{localStorage.setItem('token','fixture');vi.stubGlobal('fetch',vi.fn(async()=>({ok:true,json:async()=>({status:'needs_review',allTasks:[]})})));const s=storeFor(null);await s.dispatch('goals/fetchGoalTaskProgress','g');expect(s.getters['goals/getGoalById']('g').status).toBe('needs_review');expect(s.state.goals.liveIteration.g).toBeUndefined();});
+ it('When widget mounts with review state and stale evaluation Then NEEDS REVIEW overrides running and passed',async()=>{const s=storeFor('needs_review');const w=mount(Widget,{props:{goalId:'g'},global:{plugins:[s]}});await flushPromises();expect(w.find('.gpw-status-badge').text()).toBe('NEEDS REVIEW');expect(w.text()).not.toContain('Evaluating');expect(w.text()).not.toContain('PASSED');expect(w.find('.gpw-task-count').text()).toBe('4/4 tasks');w.unmount();});
+ it('When page reloads and status is fetched Then widget displays review without mutation requests',async()=>{localStorage.setItem('token','fixture');const fetch=vi.fn(async()=>({ok:true,json:async()=>({status:'needs_review',allTasks:[{id:'t',status:'completed',title:'Done'}]})}));vi.stubGlobal('fetch',fetch);const s=storeFor(null);const w=mount(Widget,{props:{goalId:'g'},global:{plugins:[s]}});await flushPromises();expect(w.find('.gpw-status-badge').text()).toBe('NEEDS REVIEW');expect(fetch.mock.calls.every(([url,options])=>url.endsWith('/status')&&!options.method)).toBe(true);w.unmount();});
+ it('When review update arrives during evaluation Then mounted widget stops showing live phase',async()=>{const s=storeFor();const w=mount(Widget,{props:{goalId:'g'},global:{plugins:[s]}});await flushPromises();expect(w.text()).toContain('Evaluating');s.commit('goals/UPDATE_GOAL',{id:'g',status:'needs_review',loop_status:'stopped'});await flushPromises();expect(w.find('.gpw-status-badge').text()).toBe('NEEDS REVIEW');expect(w.text()).not.toContain('Evaluating');expect(s.state.goals.liveIteration.g).toBeUndefined();w.unmount();});
+ it('When goal is executing Then keep legitimate evaluation phase',()=>{const s=storeFor();s.commit('goals/UPDATE_GOAL',{id:'g',status:'executing'});expect(s.state.goals.liveIteration.g.phase).toBe('evaluating');});
+});

--- a/frontend/src/views/Terminal/CenterPanel/screens/Chat/components/GoalProgressWidget.vue
+++ b/frontend/src/views/Terminal/CenterPanel/screens/Chat/components/GoalProgressWidget.vue
@@ -57,7 +57,8 @@
 
     <!-- Completed / Error state -->
     <div class="gpw-footer" v-if="isTerminal">
-      <div v-if="isCompleted" class="gpw-completed">Completed — {{ finalScore }}% score</div>
+      <div v-if="isNeedsReview">Execution stopped for review. Completed tasks do not imply acceptance.</div>
+      <div v-else-if="isCompleted" class="gpw-completed">Completed — {{ finalScore }}% score</div>
       <div v-else-if="isError" class="gpw-error">
         {{ errorMessage }}
       </div>
@@ -97,6 +98,8 @@ export default {
 
     // Get live iteration data from goals store
     const liveData = computed(() => {
+      const status = store.getters['goals/getGoalById']?.(props.goalId)?.status;
+      if (['needs_review','validated','completed','failed','error','stopped','paused','planning','pending'].includes(status)) return null;
       return store.getters['goals/getLiveIteration']?.(props.goalId) || null;
     });
 
@@ -137,6 +140,8 @@ export default {
 
     // Current phase label based on task state
     const currentPhase = computed(() => {
+      if (isNeedsReview.value) return 'Needs review — execution stopped';
+      if (isTerminal.value) return '';
       const tp = taskProgress.value;
       if (tp && tp.running > 0) return `${tp.running} running...`;
       if (tp && tp.failed > 0 && tp.completed < tp.total) return `${tp.failed} failed`;
@@ -166,18 +171,23 @@ export default {
       return finalScore.value > 0;
     });
 
+    const isNeedsReview = computed(() => goal.value?.status === 'needs_review');
+    const isStopped = computed(() => ['stopped','paused'].includes(goal.value?.status));
     const isCompleted = computed(() => {
+      if (isNeedsReview.value || isStopped.value || ['failed','error'].includes(goal.value?.status)) return false;
       const status = goal.value?.status;
       const loopStatus = goal.value?.loop_status;
       return status === 'validated' || status === 'completed' || loopStatus === 'completed';
     });
 
     const isError = computed(() => {
+      if (isNeedsReview.value || isStopped.value) return false;
+      if (['failed','error'].includes(goal.value?.status)) return true;
       const loopStatus = goal.value?.loop_status;
       return loopStatus === 'error' || loopStatus === 'stuck' || loopStatus === 'max_iterations';
     });
 
-    const isTerminal = computed(() => isCompleted.value || isError.value);
+    const isTerminal = computed(() => isNeedsReview.value || isStopped.value || isCompleted.value || isError.value);
 
     const isRunning = computed(() => {
       if (isTerminal.value) return false;
@@ -186,6 +196,7 @@ export default {
     });
 
     const statusClass = computed(() => {
+      if (isNeedsReview.value || isStopped.value) return 'pending';
       if (isCompleted.value) return 'completed';
       if (isError.value) return 'error';
       if (isRunning.value) return 'running';
@@ -193,6 +204,8 @@ export default {
     });
 
     const statusIcon = computed(() => {
+      if (isNeedsReview.value) return '\u26A0';
+      if (isStopped.value) return '\u23F8';
       if (isCompleted.value) return '\u2705';
       if (isError.value) return '\u274C';
       if (isRunning.value) return '\u26A1';
@@ -200,6 +213,8 @@ export default {
     });
 
     const statusLabel = computed(() => {
+      if (isNeedsReview.value) return 'NEEDS REVIEW';
+      if (isStopped.value) return goal.value.status.toUpperCase();
       if (isCompleted.value) return 'PASSED';
       if (isError.value) return goal.value?.loop_status?.toUpperCase() || 'ERROR';
       if (isRunning.value) return 'RUNNING';
@@ -270,6 +285,8 @@ export default {
       bestScore,
       finalScore,
       errorMessage,
+      isNeedsReview,
+      isStopped,
       isCompleted,
       isError,
       isTerminal,


### PR DESCRIPTION
## Problem
A goal with all tasks completed stopped at `needs_review` after evaluation failed, but its embedded chat widget kept showing EVALUATING/RUNNING. Reload cleared transient state and instead showed STARTING. Neither described the authoritative goal state.

## Change
Frontend only, three files:
- GoalProgressWidget explicitly renders NEEDS REVIEW and paused/stopped states. Authoritative review/failure/stopped state overrides stale live data and completion fallback; task counts remain visible without implying acceptance.
- Goals store clears obsolete live-iteration state on inactive/review updates and list hydration. Legitimate executing/evaluating progress remains intact.
- Status hydration updates the goal even if the task list is empty, allowing a reloaded chat widget to recover its authoritative state.

No goal retry, approval, execution, migration, backend restart, or backend behavior changes. No dependency on the open goal/recovery/telemetry PRs. Based on current upstream main 3a21c8e7.

## RED → GREEN
Repository-discovered Given/When/Then tests, mounted Vue component + Vuex:
- Against upstream: **9 failed / 1 passed**.
- Same assertions with patch: **10/10 passed**.
- Includes live evaluating→needs_review transition, reload hydration, empty-task status responses, stale-state precedence, task-count preservation, and a positive executing-state control.
- `npm --prefix frontend test -- --run src/store/features/goals.reviewState.spec.js`
- `npm --prefix frontend run build` passed (bundle-size advisory warnings only).
- `git diff --check` passed.

Tests stub browser storage/API configuration to isolate the suite from Node26 localStorage behavior. Fetch fixtures verify GET-only status hydration, not an acceptance or retry action. Full frontend suite not run locally; CI results pending.

## Scope / rollout
The equivalent patch was applied and built in the local daily checkout under explicit UI-fix authorization before publication; its served bundle was verified. User-visible refreshed screen acceptance has not been claimed. This PR was separately reproduced/tested/built in a clean worktree; unrelated local changes excluded. No backend restart or goal state mutation occurred.

This does NOT fix the separate evaluation-report HTTP500, repeated grading of unchanged tasks, event-generation fencing, or add a Discuss-with-Annie action. It corrects the existing widget/store display path. Build/deploy the frontend and refresh clients to activate. Roll back the frontend revision without modifying goal records.
